### PR TITLE
7902831: Provide way to isolate tests from general concurrency

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -338,8 +338,7 @@ public class MainAction extends Action
         if (script.isCheck()) {
             status = passed(CHECK_PASS);
         } else {
-            Lock lock = script.getLockIfRequired();
-            if (lock != null) lock.lock();
+            Lock lock = script.acquireLock();
             try {
                 switch (!othervmOverrideReasons.isEmpty() ? ExecMode.OTHERVM : script.getExecMode()) {
                     case AGENTVM:

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -1064,15 +1064,15 @@ public class RegressionScript extends Script {
         return TestNGReporter.instance(workDir);
     }
 
-    Lock getLockIfRequired() throws TestRunException {
+    Lock acquireLock() throws TestRunException{
+        boolean exclusive;
         try {
-            if (!testSuite.needsExclusiveAccess(td))
-                return null;
+            exclusive = testSuite.needsExclusiveAccess(td);
         } catch (TestSuite.Fault e) {
             throw new TestRunException("Can't determine if lock required", e);
         }
 
-        return Lock.get(params);
+        return Lock.get(params).lock(exclusive);
     }
 
     int getNextSerial() {

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -278,8 +278,7 @@ public class ShellAction extends Action
             // PASS TO PROCESSCOMMAND
             PrintWriter sysOut = section.createOutput("System.out");
             PrintWriter sysErr = section.createOutput("System.err");
-            Lock lock = script.getLockIfRequired();
-            if (lock != null) lock.lock();
+            Lock lock = script.acquireLock();
             try {
                 if (showCmd)
                     showCmd("shell", command, section);


### PR DESCRIPTION
a prototype solution of [CODETOOLS-7902831](https://bugs.openjdk.java.net/browse/CODETOOLS-7902831) which changes `exclusiveAccess` tests to behave like "nonconcurrent" tests, i.e. to be isolated from concurrent execution with any other tests. the prototype uses a read-write lock to achive that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [CODETOOLS-7902831](https://bugs.openjdk.org/browse/CODETOOLS-7902831): Provide way to isolate tests from general concurrency (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/jtreg.git pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/4.diff">https://git.openjdk.org/jtreg/pull/4.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/4#issuecomment-797812604)