### PR TITLE
7902859: IntelliJ 2020.2: constructor must not have parameters: JTRegServiceConfigurable

### DIFF
--- a/plugins/idea/resources/META-INF/plugin.xml
+++ b/plugins/idea/resources/META-INF/plugin.xml
@@ -26,14 +26,14 @@
 <idea-plugin>
     <id>jtreg</id>
     <name>jtreg Test Support</name>
-    <version>1.11</version>
+    <version>1.12</version>
     <description><![CDATA[
       Allows execution of tests developed using the <a href="http://openjdk.java.net/jtreg/">jtreg</a> framework.
     ]]></description>
 
     <change-notes><![CDATA[
     <ul>
-      <li>Fix crash in IntelliJ IDE2020.1</li>
+      <li>Fix compatibility with 2020.2</li>
     </ul>
     ]]>
     </change-notes>

--- a/plugins/idea/src/com/oracle/plugin/jtreg/service/ui/JTRegServiceConfigurable.java
+++ b/plugins/idea/src/com/oracle/plugin/jtreg/service/ui/JTRegServiceConfigurable.java
@@ -73,15 +73,18 @@ public class JTRegServiceConfigurable implements SearchableConfigurable {
     private JPanel myListPane;
     private CollectionListModel<AntBuildTarget> myModel;
 
-
     Project project;
-    JTRegService service;
-    AntConfigurationBase antConfiguration;
 
-    public JTRegServiceConfigurable(Project project, JTRegService service, AntConfiguration antConfiguration) {
+    public JTRegServiceConfigurable(Project project) {
         this.project = project;
-        this.service = service;
-        this.antConfiguration = (AntConfigurationBase)antConfiguration;
+    }
+
+    private JTRegService getJTRegService() {
+        return JTRegService.getInstance(project);
+    }
+
+    private AntConfigurationBase getAntConfigurationBase() {
+        return AntConfigurationBase.getInstance(project);
     }
 
     @Nullable
@@ -116,6 +119,8 @@ public class JTRegServiceConfigurable implements SearchableConfigurable {
 
     @Override
     public boolean isModified() {
+        JTRegService service = getJTRegService();
+        AntConfigurationBase antConfiguration = getAntConfigurationBase();
         return !jtregOptions.getText().trim().equals(service.getJTregOptions()) ||
                 jrePathEditor.isAlternativeJreSelected() != service.isAlternativeJrePathEnabled() ||
                 !jtregDir.getText().trim().equals(service.getJTRegDir()) ||
@@ -127,6 +132,7 @@ public class JTRegServiceConfigurable implements SearchableConfigurable {
 
     @Override
     public void apply() throws ConfigurationException {
+        JTRegService service = getJTRegService();
         service.setJTRegOptions(jtregOptions.getText().trim());
         service.setAlternativePathEnabled(jrePathEditor.isAlternativeJreSelected());
         service.setAlternativeJrePath(jrePathEditor.getJrePathOrName());
@@ -137,6 +143,8 @@ public class JTRegServiceConfigurable implements SearchableConfigurable {
 
     @Override
     public void reset() {
+        JTRegService service = getJTRegService();
+        AntConfigurationBase antConfiguration = getAntConfigurationBase();
         jtregOptions.setText(service.getJTregOptions());
         jrePathEditor.setPathOrName(service.getAlternativeJrePath(), service.isAlternativeJrePathEnabled());
         jtregDir.setText(FileUtil.toSystemDependentName(service.getJTRegDir()));
@@ -170,6 +178,7 @@ public class JTRegServiceConfigurable implements SearchableConfigurable {
         }
 
 
+        AntConfigurationBase antConfiguration = getAntConfigurationBase();
         antConfiguration.ensureInitialized();
         boolean antConfigEnabled = JTRegUtils.getAntBuildFiles(antConfiguration).length != 0;
 


### PR DESCRIPTION
```
com.intellij.diagnostic.PluginException: Class constructor must not have parameters: com.oracle.plugin.jtreg.service.ui.JTRegServiceConfigurable [Plugin: jtreg]
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateExtensionWithPicoContainerOnlyIfNeeded(ComponentManagerImpl.kt:696)
	at com.intellij.openapi.options.ConfigurableEP$ClassProducer.createElement(ConfigurableEP.java:422)
	at com.intellij.openapi.options.ConfigurableEP.createConfigurable(ConfigurableEP.java:329)
	at com.intellij.openapi.options.ex.ConfigurableWrapper.createConfigurable(ConfigurableWrapper.java:45)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902859](https://bugs.openjdk.java.net/browse/CODETOOLS-7902859): IntelliJ 2020.2: constructor must not have parameters: JTRegServiceConfigurable


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to 1c58dbf6bd0032803e8083bb828e18fb486f1208


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jtreg pull/5/head:pull/5`
`$ git checkout pull/5`

To update a local copy of the PR:
`$ git checkout pull/5`
`$ git pull https://git.openjdk.java.net/jtreg pull/5/head`
