### PR TITLE
7902870: Infinite loop in AgentServer

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -440,7 +441,11 @@ public class AgentServer implements ActionHelper.OutputHandler {
             private static final int BUFSIZE = 1024;
             private ByteBuffer byteBuffer = ByteBuffer.allocate(BUFSIZE);
             private CharBuffer charBuffer = CharBuffer.allocate(BUFSIZE);
-            private CharsetDecoder decoder = Charset.defaultCharset().newDecoder();
+            private CharsetDecoder decoder = Charset.forName(System.getProperty("sun.stdout.encoding",
+                                                                                System.getProperty("sun.jnu.encoding")))
+                    .newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPLACE)
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
 
             @Override
             public void write(byte[] bytes, int off, int len) throws IOException {

--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -441,11 +441,12 @@ public class AgentServer implements ActionHelper.OutputHandler {
             private static final int BUFSIZE = 1024;
             private ByteBuffer byteBuffer = ByteBuffer.allocate(BUFSIZE);
             private CharBuffer charBuffer = CharBuffer.allocate(BUFSIZE);
-            private CharsetDecoder decoder = Charset.forName(System.getProperty("sun.stdout.encoding",
-                                                                                System.getProperty("sun.jnu.encoding")))
-                    .newDecoder()
-                    .onMalformedInput(CodingErrorAction.REPLACE)
-                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
+            private CharsetDecoder decoder = Charset.forName(
+                    System.getProperty("sun.stdout.encoding", System.getProperty("sun.jnu.encoding",
+                        Charset.defaultCharset().name())))
+                .newDecoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE);
 
             @Override
             public void write(byte[] bytes, int off, int len) throws IOException {


### PR DESCRIPTION
In AgentServer.java, there is this piece of code:

---
             private void decode() throws IOException {
                 byteBuffer.flip();
                 CoderResult cr;
                 while ((cr = decoder.decode(byteBuffer, charBuffer, false)) != CoderResult.UNDERFLOW) {
                     writeCharBuffer();
                 }
                 byteBuffer.compact();
             }
---

The while loop only exits if the decode() returns UNDERFLOW, which may not be true in some occasions, because the encoding used here and the output from the agent VM may differ, decode() may return malformed/unmapped error. Then it will become an infinite loop here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902870](https://bugs.openjdk.java.net/browse/CODETOOLS-7902870): Infinite loop in AgentServer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jtreg pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/6.diff">https://git.openjdk.java.net/jtreg/pull/6.diff</a>

</details>
