### PR TITLE
7902855: make/build.sh fails when OpenJDK is specified for --jdk option

### DIFF
--- a/make/build.sh
+++ b/make/build.sh
@@ -438,7 +438,7 @@ sanity_check_java_home() {
 
     local version=$(${JAVA_HOME}/bin/java -version 2>&1)
     local vnum=$(echo "${version}" | \
-        grep ^java |
+        grep -e ^java -e ^openjdk |
         head -n 1 | \
         sed -e 's/^[^0-9]*\(1\.\)*\([1-9][0-9]*\).*/\2/' )
     if [ "${vnum:-0}" -lt "8" ]; then


### PR DESCRIPTION
When we specify not Oracle JDK but OpenJDK for --jdk option, make/build.sh fails.
```
$ ~/jdk8u282-b08/bin/java -version
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.282-b08, mixed mode)

$ bash make/build.sh --jdk ~/jdk8u282-b08
[build.sh][ERROR] JDK 8 or newer is required to build jtreg
```
This is caused by a difference in the output of `java -version` command between OpenJDK and Oracle JDK.

```
$ ~/jdk1.8.0_281/bin/java -version
java version "1.8.0_281"
Java(TM) SE Runtime Environment (build 1.8.0_281-b09)
Java HotSpot(TM) Server VM (build 25.281-b09, mixed mode)

 $ bash make/build.sh --jdk ~/jdk1.8.0_281
[build.sh][INFO] JAVA_HOME: /home/jyukutyo/jdk1.8.0_281
...
cd /home/jyukutyo/jtreg/build/images; /usr/bin/zip -rq /home/jyukutyo/jtreg/build/images/jtreg.zip jtreg
```

So this pull request enables to build jtreg with OpenJDK based distributions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902855](https://bugs.openjdk.java.net/browse/CODETOOLS-7902855): make/build.sh fails when OpenJDK is specified for --jdk option


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.java.net/jtreg pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/7.diff">https://git.openjdk.java.net/jtreg/pull/7.diff</a>

</details>
