### PR TITLE
7902934: jtreg plugin should be friendly with different packaging layouts

### DIFF
--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
@@ -50,7 +50,11 @@ import com.oracle.plugin.jtreg.runtime.JTRegTestListener;
 import com.oracle.plugin.jtreg.service.JTRegService;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -153,11 +157,12 @@ class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableState<JTR
 
     protected void configureRTClasspath(JavaParameters javaParameters) {
         JTRegService jtregSettings = JTRegService.getInstance(getConfiguration().getProject());
-        javaParameters.getClassPath().add(jtregSettings.getJTRegDir() + "/lib/jtreg.jar");
-        javaParameters.getClassPath().add(jtregSettings.getJTRegDir() + "/lib/javatest.jar");
-        javaParameters.getClassPath().add(jtregSettings.getJTRegDir() + "/lib/testng.jar");
-        javaParameters.getClassPath().add(jtregSettings.getJTRegDir() + "/lib/junit.jar");
-        javaParameters.getClassPath().add(jtregSettings.getJTRegDir() + "/lib/asmtools.jar");
+        Path jtregLibDir = Path.of(jtregSettings.getJTRegDir(), "lib");
+        try (DirectoryStream<Path> libs = Files.newDirectoryStream(jtregLibDir, "*.jar")) {
+            libs.forEach(lib -> javaParameters.getClassPath().add(lib.toString()));
+        } catch (IOException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     protected void configureRTClasspath(JavaParameters javaParameters, Module module) throws CantRunException {


### PR DESCRIPTION
This fix allows the plugin to work better across different versions of jtreg, as well as across different platforms.
Sometimes testng and jcommander are bundled in the same jar, sometimes in separate jars. This patch simply walks through all the files with a `.jar` extension in the jtreg folder and adds them to the classpath of the IDE test configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902934](https://bugs.openjdk.java.net/browse/CODETOOLS-7902934): jtreg plugin should be friendly with different packaging layouts


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.java.net/jtreg pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/10.diff">https://git.openjdk.java.net/jtreg/pull/10.diff</a>

</details>
