### PR TITLE
7902942: Elapsed time of MainAction is including serialization wait time

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -336,6 +336,7 @@ public class MainAction extends Action
         if (script.isCheck()) {
             startAction(true);
             status = passed(CHECK_PASS);
+            endAction(status);
         } else {
             Lock lock = script.getLockIfRequired();
             if (lock != null) lock.lock();
@@ -357,11 +358,12 @@ public class MainAction extends Action
                         throw new AssertionError();
                 }
             } finally {
+                // End action before releasing the lock.
+                endAction(status);
                 if (lock != null) lock.unlock();
             }
         }
 
-        endAction(status);
         return status;
     } // run()
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -333,13 +333,16 @@ public class MainAction extends Action
         if (nativeCode && script.getNativeDir() == null)
             return error(MAIN_NO_NATIVES);
 
-        startAction(true);
-
         if (script.isCheck()) {
+            startAction(true);
             status = passed(CHECK_PASS);
         } else {
             Lock lock = script.getLockIfRequired();
             if (lock != null) lock.lock();
+
+            // Start action after the lock is taken to ensure correct "elapsed time".
+            startAction(true);
+
             try {
                 switch (!othervmOverrideReasons.isEmpty() ? ExecMode.OTHERVM : script.getExecMode()) {
                     case AGENTVM:


### PR DESCRIPTION
If you run othervm tests with a concurrency > 1, then the reported test times get inflated. You can see this by running:
make -C ../build/fastdebug test TEST=test/hotspot/jtreg/vmTestbase/vm/gc/compact JTREG="VERBOSE=all"

and looking at the elapsed time for the main action:
```
$ grep -r "othervm specified" -A1 jtreg_open_test_hotspot_jtreg_vmTestbase_vm_gc_compact/jtreg.log | grep elapsed
elapsed time (seconds): 121.194
elapsed time (seconds): 240.631
elapsed time (seconds): 359.092
elapsed time (seconds): 478.718
elapsed time (seconds): 597.433
elapsed time (seconds): 716.628
elapsed time (seconds): 836.638
elapsed time (seconds): 955.156
elapsed time (seconds): 1074.476
elapsed time (seconds): 1193.712
elapsed time (seconds): 1314.116
elapsed time (seconds): 1433.632
elapsed time (seconds): 1553.563
elapsed time (seconds): 1672.996
elapsed time (seconds): 1792.846
elapsed time (seconds): 1913.112
elapsed time (seconds): 1926.819
elapsed time (seconds): 1926.809
elapsed time (seconds): 1926.921
elapsed time (seconds): 1927.093
elapsed time (seconds): 1927.192
elapsed time (seconds): 1927.07
elapsed time (seconds): 1926.896
elapsed time (seconds): 1927.31
elapsed time (seconds): 1927.244
elapsed time (seconds): 1927.33
elapsed time (seconds): 1927.221
elapsed time (seconds): 1927.42
elapsed time (seconds): 1927.158
elapsed time (seconds): 1927.315
elapsed time (seconds): 1927.316
elapsed time (seconds): 1927.311
elapsed time (seconds): 1927.532
elapsed time (seconds): 1927.379
```
Each test is supposed to be run for 120 seconds, but the reported time ramps up in ~120s increments until it reaches the number that matches the "jtreg concurrency" number, which in my run is 16.

I think this happens because we start "concurrent" tests. Each test starts by taking a timestamp, then looks if we need "exclusiveAccess" and if we do, then a lock is taken before the othervm test process is forked. This serializes the tests and inflates the times.

The proposed fix moves the start of the action to after the lock has been acquired, and end of the action before releasing the lock.

The patch has only been tested by running the following:
```
make -C ../build/fastdebug test TEST=test/hotspot/jtreg/vmTestbase/vm/gc/compact JTREG="TIMEOUT_FACTOR=0.1"
```
and manually verifying that the elapsed time stops increasing. Any guidance on how to further test this would be appreciated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902942](https://bugs.openjdk.java.net/browse/CODETOOLS-7902942): Elapsed time of MainAction is including serialization wait time


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jtreg pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/11.diff">https://git.openjdk.java.net/jtreg/pull/11.diff</a>

</details>
