### PR TITLE
7902970: Script build.sh will fail if the default shell is dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ used to build jtreg with the `--jdk` command-line option. It must be JDK 8 or la
     % cd jtreg-root-directory
     % sh make/build.sh --jdk JDK-directory
 
+Some shells, such as `dash`, don't support the special variables like `BASH_SOURCE`,
+which are used in `build.sh`. If local default shell `sh` doesn't support these
+special variables, the building with `build.sh` will fail. So the explicit shell,
+such as `bash`, need to be specified to replace the default shell `sh`.
+
+    % bash make/build.sh --jdk JDK-directory
+
 The script will create a build sub-directory, download and build dependencies,
 and finally build jtreg itself. The resulting image will be in
 _build/images/jtreg_.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ used to build jtreg with the `--jdk` command-line option. It must be JDK 8 or la
     % cd jtreg-root-directory
     % sh make/build.sh --jdk JDK-directory
 
-Some shells, such as `dash`, don't support the special variables like `BASH_SOURCE`,
-which are used in `build.sh`. If local default shell `sh` doesn't support these
-special variables, the building with `build.sh` will fail. So the explicit shell,
-such as `bash`, need to be specified to replace the default shell `sh`.
+If your shell is not compatible with `bash`, you may need to invoke `bash` explicitly:
 
     % bash make/build.sh --jdk JDK-directory
 


### PR DESCRIPTION
Hi all,

My local default shell is `dash`.

```
$ ls -al /bin/*sh*
-rwxr-xr-x 1 root root 1113504 Jun 7 2019 /bin/bash
-rwxr-xr-x 1 root root 121432 Jan 25 2018 /bin/dash
lrwxrwxrwx 1 root root 4 Sep 26 2020 /bin/rbash -> bash
lrwxrwxrwx 1 root root 4 Sep 26 2020 /bin/sh -> dash
lrwxrwxrwx 1 root root 4 Sep 26 2020 /bin/sh.distrib -> dash
lrwxrwxrwx 1 root root 7 Sep 18 2020 /bin/static-sh -> busybox
```

When I use the command `sh make/build.sh --help`, the build.sh will fail.
Because the `dash` doesn't support the variables such as `BASH_SOURCE`.

```
$ sh make/build.sh --help
make/build.sh: 252: make/build.sh: Bad substitution
make/build.sh: 253: make/build.sh: Bad substitution
make/build.sh: 254: .: Can't open /build-support/build-common.sh
```

The successful command is `bash make/build.sh --help`, which uses `bash` explicitly
instead of the default shell `sh` implicitly.

This patch clarifies this situation in the README.
Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902970](https://bugs.openjdk.java.net/browse/CODETOOLS-7902970): Script build.sh will fail if the default shell is dash


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.java.net/jtreg pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/12.diff">https://git.openjdk.java.net/jtreg/pull/12.diff</a>

</details>
