### PR TITLE
7902985: Fix typos about the /nodynamiccopyright/

### DIFF
--- a/plugins/idea/src/main/resources/liveTemplates/jtreg.xml
+++ b/plugins/idea/src/main/resources/liveTemplates/jtreg.xml
@@ -8,7 +8,7 @@
         <option name="JAVA_COMMENT" value="true" />
       </context>
     </template>
-    <template name="@test /nodynamiccopyright/" value="@test /nodynamioccopyright/&#10;* @bug $BUG_ID$&#10;* @summary $BUG_SUMMARY$&#10;* $JTREG_ACTION$/fail/ref=$GOLDEN_NAME$ -XDrawDiagnostics $FILE_NAME$" description="jtreg header (negative test)" toReformat="false" toShortenFQNames="true">
+    <template name="@test /nodynamiccopyright/" value="@test /nodynamiccopyright/&#10;* @bug $BUG_ID$&#10;* @summary $BUG_SUMMARY$&#10;* $JTREG_ACTION$/fail/ref=$GOLDEN_NAME$ -XDrawDiagnostics $FILE_NAME$" description="jtreg header (negative test)" toReformat="false" toShortenFQNames="true">
       <variable name="BUG_ID" expression="groovyScript(&quot;_1 ==~ /T\\d{7}/ ? _1.substring(1).take(7) : 'NNNNNNN'&quot;, fileNameWithoutExtension())" defaultValue="NNNNNNN" alwaysStopAt="true" />
       <variable name="BUG_SUMMARY" expression="&quot;Bug summary&quot;" defaultValue="" alwaysStopAt="true" />
       <variable name="JTREG_ACTION" expression="&quot;@compile&quot;" defaultValue="" alwaysStopAt="true" />

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -1073,7 +1073,7 @@ The arguments to the `@test` tag are ignored by the harness.  For
 identification it may be useful to put information such as SCCS ID keywords after the `@test` tag.
 
 While not part of the tag specification, some tests use the
-string "`/nodynamiccopyright`" after `@test`
+string "`/nodynamiccopyright/`" after `@test`
 to indicate that that the file should not be subject to automated
 copyright processing that might affect the operation of the test,
 for example, by affecting the line numbers of the test source code.


### PR DESCRIPTION
Hi all,

When I try the jtreg IDEA's plugin, I press `CTRL + <Space>` to complete the test and select the negative jtreg test. The plugin generates the following comments:

```
/*
 * @test /nodynamioccopyright/
 * @bug NNNNNNN
 * @summary Bug summary
 * @compile/fail/ref=Test.out -XDrawDiagnostics Test.java
```

I find that the `/nodynamioccopyright/` is not right. It should be `/nodynamiccopyright/` with removing a char 'o'.

Then I search the source codes of the plugin to find more similar situations. I find `/nodynamiccopyright` in the file `faq.md` need a char '/' at the end.

It is good to fix them.
Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902985](https://bugs.openjdk.java.net/browse/CODETOOLS-7902985): Fix typos about the /nodynamiccopyright/


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.java.net/jtreg pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/13.diff">https://git.openjdk.java.net/jtreg/pull/13.diff</a>

</details>
