### PR TITLE
CODETOOLS-7902987: Git build should record the actual tag, not the latest one

### DIFF
--- a/make/build-all.sh
+++ b/make/build-all.sh
@@ -84,7 +84,7 @@ get_root() {
 get_tag_info() {
    case $SCM_TYPE in
        HG)  hg tags | grep jtreg | head -1 ;;
-       GIT) git tag | grep jtreg | tail -1 ;;
+       GIT) git describe ;;
        *) echo "Error: unknown SCM" >&2 ; exit 1 ;;
    esac
 }


### PR DESCRIPTION
Use `git describe` to poll the actual tag. Otherwise JTReg build would always report the latest tag (currently `jtreg6`), regardless of the actually built version. See more details in the bug report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902987](https://bugs.openjdk.java.net/browse/CODETOOLS-7902987): Git build should record the actual tag, not the latest one


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/jtreg pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/14.diff">https://git.openjdk.java.net/jtreg/pull/14.diff</a>

</details>
