### PR TITLE
7902991: fix deprecation warnings generated when compiling with JDK 16.

### DIFF
--- a/src/share/classes/com/sun/javatest/diff/SimpleReporter.java
+++ b/src/share/classes/com/sun/javatest/diff/SimpleReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,20 +75,20 @@ public class SimpleReporter extends Reporter {
     private void writeHead() throws IOException {
         for (int i = 0; i < size; i++) {
             int[] c = testCounts.get(i);
-            int p = c[Status.PASSED];
-            int f = c[Status.FAILED];
-            int e = c[Status.ERROR];
-            int nr = c[Status.NOT_RUN];
+            int passed = c[Status.PASSED];
+            int failed = c[Status.FAILED];
+            int error = c[Status.ERROR];
+            int notRun = c[Status.NOT_RUN];
             writeI18N("simple.set", i, table.getColumnName(i));
             print("  ");
             writeI18N("simple.counts",
-                    new Integer(p),
-                    new Integer((p > 0) && (f + e + nr > 0) ? 1 : 0),
-                    new Integer(f),
-                    new Integer((f > 0) && (e + nr > 0) ? 1 : 0),
-                    new Integer(e),
-                    new Integer((e > 0) && (nr > 0) ? 1 : 0),
-                    new Integer(nr));
+                    passed,
+                    (passed > 0) && (failed + error + notRun > 0) ? 1 : 0,
+                    failed,
+                    (failed > 0) && (error + notRun > 0) ? 1 : 0,
+                    error,
+                    (error > 0) && (notRun > 0) ? 1 : 0,
+                    notRun);
             println();
         }
     }

--- a/src/share/classes/java/lang/JTRegModuleHelper.java
+++ b/src/share/classes/java/lang/JTRegModuleHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,12 @@ import java.lang.reflect.Method;
  * <i>This code is temporary, and should eventually be replaced by
  * injecting code into the relevant modules.</i>
  */
-public class JTRegModuleHelper {
+public final class JTRegModuleHelper {
+
+    // Non-instantiable helper
+    private JTRegModuleHelper() {
+    }
+
     /*
      * Use reflection to simulate:
      *      module.implAddExports(packageName, targetModule);


### PR DESCRIPTION
This PR fixes compilation warnings that fail builds during compilation because of -Werror flag.
The issues with compilation appear on JDK 16. Warnings that were fixed:
- warning: [missing-explicit-ctor] class JTRegModuleHelper in exported package java.lang declares no explicit constructors, thereby exposing a default constructor to clients of module java.base
- SimpleReporter.java:*: warning: [removal] Integer(int) in Integer has been deprecated and marked for removal 

After the changes build passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902991](https://bugs.openjdk.java.net/browse/CODETOOLS-7902991): fix deprecation warnings generated when compiling with JDK 16.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jtreg pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/15.diff">https://git.openjdk.java.net/jtreg/pull/15.diff</a>

</details>
