### PR TITLE
add simple test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: build
         working-directory: jtreg
         shell: bash
-        run: sh make/build.sh --jdk ${JAVA_HOME_8_X64}
+        run: bash make/build.sh --jdk ${JAVA_HOME_8_X64}
 
       - name: upload artifact
         uses: actions/upload-artifact@v2
@@ -35,5 +35,5 @@ jobs:
              MAKE_ARGS=test
              HEADLESS=1
              JDK8HOME=${JAVA_HOME_8_X64}
-             sh make/build.sh --jdk ${JAVA_HOME_8_X64} --skip-download
+             bash make/build.sh --jdk ${JAVA_HOME_8_X64} --skip-download
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: build
         working-directory: jtreg
         shell: bash
-        run: sh make/build-all.sh ${JAVA_HOME_8_X64}
+        run: sh make/build.sh --jdk ${JAVA_HOME_8_X64}
 
       - name: upload artifact
         uses: actions/upload-artifact@v2
@@ -32,9 +32,8 @@ jobs:
         working-directory: jtreg
         shell: bash
         run:
-             SKIP_WGET=true
              MAKE_ARGS=test
              HEADLESS=1
-             JDK8_HOME=${JAVA_HOME_8_X64}
-             sh make/build-all.sh ${JAVA_HOME_8_X64}
+             JDK8HOME=${JAVA_HOME_8_X64}
+             sh make/build.sh --jdk ${JAVA_HOME_8_X64} --skip-download
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Build and Test JTReg
+
+on:
+  push:
+    branches-ignore:
+        - master
+
+jobs:
+
+  linux-x64:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jtreg
+          fetch-depth: 0
+
+      - name: build
+        working-directory: jtreg
+        shell: bash
+        run: sh make/build-all.sh ${JAVA_HOME_8_X64}
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: jtreg
+          path: jtreg/build/images/jtreg
+
+      - name: test
+        working-directory: jtreg
+        shell: bash
+        run:
+             SKIP_WGET=true
+             MAKE_ARGS=test
+             HEADLESS=1
+             JDK8_HOME=${JAVA_HOME_8_X64}
+             sh make/build-all.sh ${JAVA_HOME_8_X64}
+


### PR DESCRIPTION
Hi all,

could you please review this small patch that adds a simple github action workflow to build and test `jtreg` on `linux-x64`?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.java.net/jtreg pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/16.diff">https://git.openjdk.java.net/jtreg/pull/16.diff</a>

</details>
