### PR TITLE
CODETOOLS-7902994: clean up `make sanity` target

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -60,22 +60,31 @@ clean:
 .NO_PARALLEL: clean
 
 sanity:
-ifdef JDK15HOME
-	@echo "JDK15HOME           = $(JDK15HOME)"
+ifdef JDK1_1HOME
+	@echo "JDK1_1HOME          = $(JDK1_1HOME)"
 endif
-ifdef JDK16HOME
-	@echo "JDK16HOME           = $(JDK16HOME)"
+ifdef JDK5HOME
+	@echo "JDK5HOME            = $(JDK5HOME)"
 endif
-ifdef JDK17HOME
-	@echo "JDK17HOME           = $(JDK17HOME)"
+ifdef JDK6HOME
+	@echo "JDK6HOME            = $(JDK6HOME)"
+endif
+ifdef JDK7HOME
+	@echo "JDK7HOME            = $(JDK7HOME)"
+endif
+ifdef JDK8HOME
+	@echo "JDK8HOME            = $(JDK8HOME)"
+endif
+ifdef JDK9HOME
+	@echo "JDK9HOME            = $(JDK9HOME)"
+endif
+ifdef JDK14HOME
+	@echo "JDK14HOME           = $(JDK14HOME)"
 endif
 ifdef JDK18HOME
 	@echo "JDK18HOME           = $(JDK18HOME)"
 endif
 	@echo "JDKHOME             = $(JDKHOME)"
-ifdef JAVAHELP_HOME
-	@echo "JAVAHELP_HOME       = $(JAVAHELP_HOME)"
-endif
 	@echo "JAVATEST_HOME       = $(JAVATEST_HOME)"
 ifneq ($(JTHARNESS_HOME), $(JAVATEST_HOME))
 	@echo "JTHARNESS_HOME      = $(JTHARNESS_HOME)"

--- a/test/sanityTest/SanityTest.gmk
+++ b/test/sanityTest/SanityTest.gmk
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+$(BUILDDIR)/TestSanityTest.ok:
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) -p $(@:%.ok=%)
+	$(FIND) $(TOPDIR)/make $(TOPDIR)/test -name \*.gmk | \
+		xargs $(GREP) -o 'JDK[1-9][0-9_]*HOME' | $(SED) -e 's/.*://' | $(SORT) -u \
+		> $(@:%.ok=%/refs.txt)
+	$(GREP) -o 'JDK[1-9][0-9_]*HOME' $(TOPDIR)/make/Makefile | $(SED) -e 's/.*://' | $(SORT) -u \
+		> $(@:%.ok=%/sanity.txt)
+	if $(DIFF) $(@:%.ok=%/refs.txt) $(@:%.ok=%/sanity.txt) ; then \
+	    echo "expected defs found" ; \
+	else \
+	    echo "differences found" ; exit 1 ; \
+	fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += $(BUILDDIR)/TestSanityTest.ok


### PR DESCRIPTION
A change to cleanup the use of the `JDK`_N_`HOME` variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902994](https://bugs.openjdk.java.net/browse/CODETOOLS-7902994): clean up `make sanity` target


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.java.net/jtreg pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/17.diff">https://git.openjdk.java.net/jtreg/pull/17.diff</a>

</details>
