### PR TITLE
CODETOOLS-7903006: Upgrade jtreg plugin to IntelliJ 2021.2

### DIFF
--- a/plugins/idea/README.md
+++ b/plugins/idea/README.md
@@ -38,7 +38,7 @@ This will download gradle and the required IntelliJ dependencies, will build the
 
 > Note: to build the plugin, the build script must point to a valid jtreg installation; see the property `jtregHome` in the `gradle.properties` file, and tweak accordingly.
 
-> Note: the property `intellijVersion` can be used to specify which IDE version should the plugin depend on (defaults to `2021.1`).
+> Note: the property `intellijVersion` can be used to specify which IDE version should the plugin depend on (defaults to `2021.2`).
 
 Once the build is configured correctly, the plugin can even be tested in a sandbox environment, as follows:
 

--- a/plugins/idea/gradle.properties
+++ b/plugins/idea/gradle.properties
@@ -1,5 +1,5 @@
 jtregHome = /path/to/jtreg
-intellijVersion = 2021.1.1
+intellijVersion = 2021.2
 pluginVersion = 1.12
 javaLevel = 11
 notes = <ul>\


### PR DESCRIPTION
Hi,

could we update target platform version to 21.2?

There were no issues with the build, plugin works fine (IntelliJ 2021.2 on Ubuntu x64).

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903006](https://bugs.openjdk.java.net/browse/CODETOOLS-7903006): Upgrade jtreg plugin to IntelliJ 2021.2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/jtreg pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/20.diff">https://git.openjdk.java.net/jtreg/pull/20.diff</a>

</details>
