### PR TITLE
CODETOOLS-7903009: Set streams when RegressionSecurityManager not used

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/ActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/ActionHelper.java
@@ -257,6 +257,8 @@ public class ActionHelper {
                 ((RegressionSecurityManager) sc).setAllowSetIO(prev);
             } else {
                 //return Status.error(MAIN_SECMGR_BAD);
+                System.setOut(out);
+                System.setErr(err);
             }
         }
         return passed("OK");


### PR DESCRIPTION
In ActionHelper, redirectOutput only works if the SM is RegressionSecurityManager. 

If it is not, it should still set the streams.