### PR TITLE
CODETOOLS-7903013: Update README reference to plugin/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following dependencies are optional.
 * JDK 18:
   This is used when running some of the tests. Set `JDK18HOME` to run these
   tests. It need not be set if you are just building jtreg.
-  
+
 The recommended versions are also defined in `make/build-support/version-numbers`.
 
 ## Running jtreg Self-Tests
@@ -192,4 +192,4 @@ The jtreg repo also contains a plugin for the IntelliJ IDE.
 This is a convenience plugin which adds jtreg capabilities to the IntelliJ IDE.
 With this plugin, OpenJDK developers can write, run, and debug jtreg tests
 without leaving their IDE environment.  For more details, see the file
-_plugins/idea/README.md_ in this repo.
+[plugins/idea/README.md](plugins/idea/README.md) in this repo.


### PR DESCRIPTION
Please update a minor tweak to the main jtreg README, to update a reference to the plugin README to be a link.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903013](https://bugs.openjdk.java.net/browse/CODETOOLS-7903013): Update README reference to plugin/README


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/jtreg pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/25.diff">https://git.openjdk.java.net/jtreg/pull/25.diff</a>

</details>
