### PR TITLE
7903030: jtreg should print stdout if JVM gathering properties fails

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/JDK.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/JDK.java
@@ -627,6 +627,9 @@ public class JDK {
 
             int rc = p.waitFor();
             if (rc != 0) {
+                for (String line : lines) {
+                    logger.accept(line);
+                }
                 String msg = "failed to get JDK properties for "
                         + getJavaProg() + " " + StringUtils.join(vmOpts, " ") + "; exit code " + rc;
                 logger.accept(msg);

--- a/src/share/classes/com/sun/javatest/regtest/config/JDK.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/JDK.java
@@ -630,8 +630,8 @@ public class JDK {
                 for (String line : lines) {
                     logger.accept(line);
                 }
-                String msg = "failed to get JDK properties for "
-                        + getJavaProg() + " " + StringUtils.join(vmOpts, " ") + "; exit code " + rc;
+                String msg = String.format("failed to get JDK properties:%ncmd: \"%s\"%ncwd: \"%s\"%nexit code: %d",
+                        StringUtils.join(cmdArgs, "\" "), scratchDir, rc);
                 logger.accept(msg);
                 throw new Fault(msg);
             }


### PR DESCRIPTION
Hi all,

could you please review this patch?
from JBS:
> currently, if the JVM, which was created to gather (at-requires) properties, fails for any reason, jtreg prints out "failed to get JDK properties for" message together w/ the exit code. and although jtreg always prints out stderr of this JVM, it might not contain enough information to understand the failure and has caused confusion in past.

testing: run `jtreg -vmoptions:"-Xmx1g -Xms2g"`:
```
Error occurred during initialization of VM
Initial heap size set to a larger value than the maximum heap size
failed to get JDK properties for /Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home/bin/java -Xmx1g -Xms2g; exit code 1
Error: failed to get JDK properties for /Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home/bin/java -Xmx1g -Xms2g; exit code 1
```
vs old behavior:
```
failed to get JDK properties for /Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home/bin/java -Xmx1g -Xms2g; exit code 1
Error: failed to get JDK properties for /Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home/bin/java -Xmx1g -Xms2g; exit code 1
```

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903030](https://bugs.openjdk.java.net/browse/CODETOOLS-7903030): jtreg should print stdout if JVM gathering properties fails


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/jtreg pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/28.diff">https://git.openjdk.java.net/jtreg/pull/28.diff</a>

</details>
