### PR TITLE
7903192: fix typo in 7903030: missed 2nd " in join

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/JDK.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/JDK.java
@@ -631,7 +631,7 @@ public class JDK {
                     logger.accept(line);
                 }
                 String msg = String.format("failed to get JDK properties:%ncmd: \"%s\"%ncwd: \"%s\"%nexit code: %d",
-                        StringUtils.join(cmdArgs, "\" "), scratchDir, rc);
+                        StringUtils.join(cmdArgs, "\" \""), scratchDir, rc);
                 logger.accept(msg);
                 throw new Fault(msg);
             }


### PR DESCRIPTION
Hi all,

could you please review this small follow-up fix for CODETOOLS-7903030 / 97131e841f2e4741bb5ff51e55a794fc83f63749? 

before the fix:
```
cmd: "/Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home/bin/java" -classpath" /Users/iignatye/ws/jtreg/build/images/jtreg/lib/javatest.jar:/Users/iignatye/ws/jtreg/build/images/jtreg/lib/jtreg.jar" -Dtest.vm.opts=-Xms10G -Xmx2G" -Dtest.tool.vm.opts=-J-Xms10G -J-Xmx2G" -Dtest.compiler.opts=" -Dtest.java.opts=" -Dtest.jdk=/Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home" -Dcompile.jdk=/Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home" -Dtest.timeout.factor=1.0" -Dtest.root=/private/tmp/t" -Xms10G" -Xmx2G" com.sun.javatest.regtest.agent.GetJDKProperties" --system-properties" --modules=boot-layer"
```
after the fix:
```
cmd: "/Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home/bin/java" "-classpath" "/Users/iignatye/ws/jtreg/build/images/jtreg/lib/javatest.jar:/Users/iignatye/ws/jtreg/build/images/jtreg/lib/jtreg.jar" "-Dtest.vm.opts=-Xms10G -Xmx2G" "-Dtest.tool.vm.opts=-J-Xms10G -J-Xmx2G" "-Dtest.compiler.opts=" "-Dtest.java.opts=" "-Dtest.jdk=/Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home" "-Dcompile.jdk=/Library/Java/JavaVirtualMachines/jdk-14.jdk/Contents/Home" "-Dtest.timeout.factor=1.0" "-Dtest.root=/private/tmp/t" "-Xms10G" "-Xmx2G" "com.sun.javatest.regtest.agent.GetJDKProperties" "--system-properties" "--modules=boot-layer"
```

Thanks,
-- Igor

attn: @stefank

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [CODETOOLS-7903192](https://bugs.openjdk.java.net/browse/CODETOOLS-7903192): fix typo in 7903030: missed 2nd " in join


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.java.net/jtreg pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/29.diff">https://git.openjdk.java.net/jtreg/pull/29.diff</a>

</details>
