### PR TITLE
CODETOOLS-7903037: Allow Subtest ids with dashes and underscores

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -295,7 +295,7 @@ public class TestManager {
             TestResultTable trt = wd.getTestResultTable();
             if (trt.validatePath(path)) {
                 // bypass check when fragment syntax used
-                if (path.matches("(?i).*#[a-z0-9\\-_]+"))
+                if (path.matches("(?i).*#[a-z0-9-_]+"))
                     return true;
                 File rootDir = wd.getTestSuite().getRootDir();
                 File f = new File(rootDir, path);

--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -295,9 +295,8 @@ public class TestManager {
             TestResultTable trt = wd.getTestResultTable();
             if (trt.validatePath(path)) {
                 // bypass check when fragment syntax used
-                if (path.matches(".*#[A-Za-z0-9-_]+")) {
+                if (path.matches(".*#[A-Za-z0-9-_]+"))
                     return true;
-                }
                 File rootDir = wd.getTestSuite().getRootDir();
                 File f = new File(rootDir, path);
                 if (f.isDirectory())

--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -295,8 +295,9 @@ public class TestManager {
             TestResultTable trt = wd.getTestResultTable();
             if (trt.validatePath(path)) {
                 // bypass check when fragment syntax used
-                if (path.matches("(?i).*#[a-z0-9-_]+"))
+                if (path.matches(".*#[A-Za-z0-9-_]+")) {
                     return true;
+                }
                 File rootDir = wd.getTestSuite().getRootDir();
                 File f = new File(rootDir, path);
                 if (f.isDirectory())

--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -295,7 +295,7 @@ public class TestManager {
             TestResultTable trt = wd.getTestResultTable();
             if (trt.validatePath(path)) {
                 // bypass check when fragment syntax used
-                if (path.matches("(?i).*#[a-z0-9]+"))
+                if (path.matches("(?i).*#[a-z0-9\\-_]+"))
                     return true;
                 File rootDir = wd.getTestSuite().getRootDir();
                 File f = new File(rootDir, path);

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -994,7 +994,7 @@ public class Tool {
                     ? Pattern.compile("(|[^A-Za-z]|.{2,}):[A-Za-z0-9_,]+")
                     : Pattern.compile(".*:[A-Za-z0-9_,]+");
 
-            Pattern fileIdPtn = Pattern.compile("(?i).*#[a-z0-9]+");
+            Pattern fileIdPtn = Pattern.compile("(?i).*#[a-z0-9\\-_]+");
         }
     );
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -994,7 +994,7 @@ public class Tool {
                     ? Pattern.compile("(|[^A-Za-z]|.{2,}):[A-Za-z0-9_,]+")
                     : Pattern.compile(".*:[A-Za-z0-9_,]+");
 
-            Pattern fileIdPtn = Pattern.compile("(?i).*#[a-z0-9\\-_]+");
+            Pattern fileIdPtn = Pattern.compile("(?i).*#[a-z0-9-_]+");
         }
     );
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -994,7 +994,7 @@ public class Tool {
                     ? Pattern.compile("(|[^A-Za-z]|.{2,}):[A-Za-z0-9_,]+")
                     : Pattern.compile(".*:[A-Za-z0-9_,]+");
 
-            Pattern fileIdPtn = Pattern.compile("(?i).*#[a-z0-9-_]+");
+            Pattern fileIdPtn = Pattern.compile(".*#[A-Za-z0-9-_]+");
         }
     );
 


### PR DESCRIPTION
At the moment the jtreg launcher does not accept subtest ids that contain dashes or underscores. For example:

```
thomas@starfish:jtreg ... source/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java#debug-none
Error: Not a test or directory containing tests: runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java#debug-none
```

Patch fixes this:

```
thomas@starfish:jtreg ... source/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java#debug-none
Test results: passed: 1
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903037](https://bugs.openjdk.java.net/browse/CODETOOLS-7903037): Allow Subtest ids with dashes and underscores


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - no project role) ⚠️ Review applies to 5b44aa418d22e5a43fe29628e615321d6e52fab3
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.java.net/jtreg pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/30.diff">https://git.openjdk.java.net/jtreg/pull/30.diff</a>

</details>
