### PR TITLE
7903045: Fix and enable test workflow using GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,38 +2,49 @@ name: Build and Test JTReg
 
 on:
   push:
-    branches-ignore:
-        - master
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
 
   linux-x64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout the source
-        uses: actions/checkout@v2
-        with:
-          path: jtreg
-          fetch-depth: 0
+    - name: 'Check out repository'
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
 
-      - name: build
-        working-directory: jtreg
-        shell: bash
-        run: bash make/build.sh --jdk ${JAVA_HOME_8_X64}
+    - name: 'Build JTReg'
+      shell: bash
+      run: |
+        java --version
+        bash make/build.sh --jdk ${JAVA_HOME_11_X64}
 
-      - name: upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: jtreg
-          path: jtreg/build/images/jtreg
+    - name: 'Run initial tests (goal: quick-test)'
+      shell: bash
+      env:
+        MAKE_ARGS: quick-test
+        HEADLESS: 1
+      run: |
+        bash make/build.sh --jdk ${JAVA_HOME_11_X64} --skip-download
 
-      - name: test
-        working-directory: jtreg
-        shell: bash
-        run:
-             MAKE_ARGS=test
-             HEADLESS=1
-             JDK8HOME=${JAVA_HOME_8_X64}
-             bash make/build.sh --jdk ${JAVA_HOME_8_X64} --skip-download
+    - name: 'Run all tests (goal: test)'
+      shell: bash
+      env:
+        MAKE_ARGS: test
+        HEADLESS: 1
+      run: |
+        bash make/build.sh --jdk ${JAVA_HOME_11_X64} --skip-download
 
+    - name: 'Upload artifact ${{ github.event.repository.name }}-build-${{ github.sha }}'
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}-build-${{ github.sha }}
+        path: |
+          build/images/jtreg


### PR DESCRIPTION
Resolves https://bugs.openjdk.java.net/browse/CODETOOLS-7903045

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903045](https://bugs.openjdk.java.net/browse/CODETOOLS-7903045): Fix and enable test workflow using GitHub Actions


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.java.net/jtreg pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/32.diff">https://git.openjdk.java.net/jtreg/pull/32.diff</a>

</details>
