### PR TITLE
7903046: Extend computation of test class path in non-installed run mode

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
@@ -28,6 +28,7 @@ package com.sun.javatest.regtest.config;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -967,8 +968,17 @@ public class RegressionParameters
 
             if (jtClsDir.getName().equals("javatest.jar")) {
                 File installDir = jtClsDir.getParentFile();
-                // append jtreg.jar to the path
-                javaTestClassPath.append(new File(installDir, "jtreg.jar"));
+                // append jtreg.jar or exploded directory to the search path
+                File jtreg = new File(installDir, "jtreg.jar");
+                if (jtreg.exists()) {
+                    javaTestClassPath.append(jtreg);
+                } else try {
+                    // use code source location of this class instead
+                    URL location = getClass().getProtectionDomain().getCodeSource().getLocation();
+                    javaTestClassPath.append(new File(location.toURI()));
+                } catch (Exception e) { // including NullPointerException and URISyntaxException
+                    throw new RuntimeException("Computation of Java test class-path failed", e);
+                }
             }
         }
         return javaTestClassPath;


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/CODETOOLS-7903046

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903046](https://bugs.openjdk.java.net/browse/CODETOOLS-7903046): Extend computation of test class path in non-installed run mode


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/jtreg pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/33.diff">https://git.openjdk.java.net/jtreg/pull/33.diff</a>

</details>
