### PR TITLE
7903044: Report `os.*` system properties in .jtr file

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
@@ -1348,7 +1348,7 @@ public class RegressionParameters
 
     //---------------------------------------------------------------------
 
-    private OS getTestOS() {
+    public OS getTestOS() {
         // In general, and particularly when running tests, the testJDK should always be set.
         // But in some testing and reporting situations, it may not be. In these cases,
         // we default to the current platform.

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -135,7 +135,7 @@ public class RegressionScript extends Script {
             hostname = "127.0.0.1";
         }
         testResult.putProperty("hostname", hostname);
-        String[] props = { "user.name" };
+        String[] props = { "user.name", "os.name", "os.arch", "os.version" };
         for (String p: props) {
             testResult.putProperty(p, System.getProperty(p));
         }

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -136,7 +136,7 @@ public class RegressionScript extends Script {
             hostname = "127.0.0.1";
         }
         testResult.putProperty("hostname", hostname);
-        String[] props = { "user.name", "os.name", "os.arch", "os.version" };
+        String[] props = { "user.name" };
         for (String p: props) {
             testResult.putProperty(p, System.getProperty(p));
         }

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -70,6 +70,7 @@ import com.sun.javatest.regtest.config.JDKOpts;
 import com.sun.javatest.regtest.config.Locations;
 import com.sun.javatest.regtest.config.Locations.LibLocn;
 import com.sun.javatest.regtest.config.Modules;
+import com.sun.javatest.regtest.config.OS;
 import com.sun.javatest.regtest.config.ParseException;
 import com.sun.javatest.regtest.config.RegressionEnvironment;
 import com.sun.javatest.regtest.config.RegressionParameters;
@@ -141,6 +142,11 @@ public class RegressionScript extends Script {
         }
         testResult.putProperty("jtregVersion", getVersion());
         testResult.putProperty("testJDK", getTestJDK().getAbsolutePath());
+        OS testOs = params.getTestOS();
+        testResult.putProperty("testJDK_OS", testOs.toString());
+        testResult.putProperty("testJDK_os.name", testOs.name);
+        testResult.putProperty("testJDK_os.version", testOs.version);
+        testResult.putProperty("testJDK_os.arch", testOs.arch);
         if (!getCompileJDK().equals(getTestJDK())) {
             testResult.putProperty("compileJDK", getCompileJDK().getAbsolutePath());
         }


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/CODETOOLS-7903044

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903044](https://bugs.openjdk.java.net/browse/CODETOOLS-7903044): Report `os.*` system properties in .jtr file


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to bd5a1ba9be99c1070130e69c74538aefbdd2852d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jtreg pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/35.diff">https://git.openjdk.java.net/jtreg/pull/35.diff</a>

</details>
