### PR TITLE
CODETOOLS-7903024: Improve docs and impl for jtreg -show option

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1995,13 +1995,24 @@ public class Tool {
                     try {
                         // work around bug CODETOOLS-7900214 -- force the sections to be reloaded
                         tr.getProperty("sections");
+                        String section, stream;
+                        int sep = showStream.indexOf("/");
+                        if (sep == -1) {
+                            section = null;
+                            stream = showStream;
+                        } else {
+                            section = showStream.substring(0, sep);
+                            stream = showStream.substring(sep + 1);
+                        }
                         for (int i = 0; i < tr.getSectionCount(); i++) {
                             TestResult.Section s = tr.getSection(i);
-                            String text = s.getOutput(showStream);
-                            // need to handle internal newlines properly
-                            if (text != null) {
-                                out.println("### Section " + s.getTitle());
-                                out.println(text);
+                            if (section == null || section.equals(s.getTitle())) {
+                                String text = s.getOutput(stream);
+                                // need to handle internal newlines properly
+                                if (text != null) {
+                                    out.println("### Section " + s.getTitle());
+                                    out.println(text);
+                                }
                             }
                         }
                         ok = true;

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -242,9 +242,14 @@ help.main.startHttpd.desc=Start the http server to view test results
 help.main.showGroups.desc=Show the expansion (to files and directories) of the \
     groups given on the command line. To see the expansion of all the groups \
     in a test suite, specify the name of the test suite.
-help.main.show.desc=Show information from a section in the results file for a test. \
-    For example, -show:rerun
-help.main.show.arg=<section-name>
+help.main.show.desc=Show the contents of a stream in a specific section or in all \
+    sections of the results file for a test. \
+    The content is shown as originally written to the stream: \
+    that is, without the escape encoding used in the .jtr file. \
+    If no section name is given, the output for the named stream in all sections \
+    is shown.\n\
+    For example, -show:rerun  -show:main/System.out
+help.main.show.arg=[<section-name>/]<stream-name>
 
 help.main.w.desc=Location for .class files, .jtr files, etc. "./JTwork" is default
 help.main.w.arg=<directory>

--- a/src/share/doc/javatest/regtest/README
+++ b/src/share/doc/javatest/regtest/README
@@ -24,7 +24,7 @@ The following sections provide the recommended system requirements for running
 jtreg.
 
 - Java platform
-    A platform equivalent to JDK 1.7.0 or later is required.
+    A platform equivalent to JDK 1.8.0 or later is required.
 
 - Memory
     It is recommended that you run jtreg on a computer having at least 256M of 

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -327,10 +327,10 @@ file called `Hello.jtr`.  These files reside in the
 work directory which contains a directory hierarchy that
 parallels the test source structure.
 
-Blocks of text within a .jtr file use `\` to escape certain characters
+Blocks of text within a .jtr file use `\` to [escape](#jtr-encoding) certain characters
 (including `\` itself). This needs to be taken into account if you
 view the contents of the file directly. If you use the GUI, or use
-the jtreg `-show` option, the escapes are automatically taken into acocunt.
+the jtreg `-show` option, the escapes are automatically taken into account.
 
 ### What's the difference between the "fail" and "error" return status?
 
@@ -838,10 +838,11 @@ You have several alternatives.
 
 1.  Use the `-verbose:all` option, or the related result-sensitive
     options `-verbose:pass`, `-verbose:fail`, `-verbose:error`.
-2.  Use the JavaTest harness GUI.
-3.  View the test's `.jtr` file.
-4.  Use the `-show` option. For example,
-    * `jtreg -show:System.out` _test-name_
+2.  Use the JavaTest (JT Harness) harness GUI.
+3.  View the test's `.jtr` file. 
+    _Note: some characters in the file may be [encoded](#jtr-encoding)._
+4.  Use the `-show` option to display the unencoded content of a stream. For example,
+    * `jtreg -w` _work-dir_ `-show:System.out` _test-name_
 
 ### How do I see what groups are defined in my test suite?
 
@@ -856,6 +857,47 @@ to see the details for a specific group, specify the test suite and group.
 Use the `-listtests` option.
 
     $ jtreg -listtests test/langtools/jdk/javadoc/doclet
+
+### Why are there extra `\` characters in the output from a test in a .jtr file? {#jtr-encoding}
+
+By design, the contents of a `.jtr` file, including any output from tests, is represented in a way
+that can be read back in again by `jtreg` and related tools. To that end, characters that are not
+standard ASCII characters (printable characters, and `CR`, `LF`, `SP`, `HT`) are encoded with escape sequences..
+Characters outside that set are represented by `\uXXXX`, and `\` itself as written as `\\`.
+Anyone viewing the contents of a `.jtr` directly, such as in a plain-text editor, or using
+command-line tools like `grep` need to be aware of that encoding and take it into account.
+
+To view the unencoded output from a test that has been recorded in a `.jtr` file, 
+use the `jtreg` `-show:name` option.
+
+    $ jtreg -w:/path/to/work-dir -show:System.out /path/to/test
+
+The `-show` option can also be used to see the `rerun` script that is provided in the `.jtr` file,
+and which may also contain escape sequences. This script allows you to [rerun the test stand-alone](#rerun),
+without the use of the `jtreg` infrastructure.
+
+### What names can I use with the `-show` option
+
+All recent versions of `jtreg` accept the name of an output stream as the name. 
+
+    $ jtreg ...  -show:stream-name ...
+
+The name of each output stream appears after a series of dashes and before a colon `:`
+in the `.jtr` file.  For example, here is a heading for a stream named `System.out`:
+
+    ----------System.out:(1/501)----------
+
+More recent versions (6.2 onwards) support an optional section name as well. 
+See the command-line help for specific details in the version you are using.
+
+    $ jtreg ... -show:section-name/stream-name
+
+The name of all the sections appear in the `testresult` part of the `.jtr` file,
+and individually after `#section:` at the beginning of each section. For example,
+
+    sections=script_messages build compile build main
+
+    #section:compile
 
 ### Can I verify the correctness of test descriptions without actually running the tests?
 
@@ -874,7 +916,7 @@ The following sample output illustrates use of this option.
     Results written to /u/iag/jtw/JTwork
     Error: some tests failed or other problems occurred
 
-### I'd like to run my test standalone, without using jtreg: how do I do that?
+### I'd like to run my test standalone, without using jtreg: how do I do that? {#rerun}
 
 All tests are generally designed so that they can be run without using jtreg.
 Tests either have a `main` method, or can be run using a framework like TestNG or JUnit.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [CODETOOLS-7903024](https://bugs.openjdk.java.net/browse/CODETOOLS-7903024): Improve docs and impl for jtreg -show option ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/jtreg pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/36.diff">https://git.openjdk.java.net/jtreg/pull/36.diff</a>

</details>
