### PR TITLE
CODETOOLS-7903050: Add an FAQ entry for `javatest.maxOutputSize`

### DIFF
--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -1295,6 +1295,17 @@ The discarded output will be replaced with a message like the following:
         set the system property javatest.maxOutputSize to a higher
         value. The current value is 100000.
 
+
+### How do I set `javatest.maxOutputSize`? {#how-to-set-javatest.maxOutputSize}
+
+See the [previous entry](#how-much-output).
+
+TL;DR:  If you're trying to set `javatest.maxOutputSize`, it may be because you have seen a
+message in the middle of some very long output in a `.jtr` file.  You can either
+set the default value with a system property for the JVM running jtreg (_not_ the JVM(s)
+used to run tests), or you can override the default value for some or all tests with the 
+`maxOutputSize` property in the `TEST.ROOT` or `TEST.properties` configuration files.
+
 ### How much time can a test take? {#how-much-time}
 
 jtreg limits the amount of time that may be used to execute each action  of the


### PR DESCRIPTION
There continues to be confusion about setting javatest.maxOutputSize. 

This changes adds an FAQ entry specific to this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903050](https://bugs.openjdk.java.net/browse/CODETOOLS-7903050): Add an FAQ entry for `javatest.maxOutputSize`


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.java.net/jtreg pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/37.diff">https://git.openjdk.java.net/jtreg/pull/37.diff</a>

</details>
