### PR TITLE
CODETOOLS-7903051: Fix minor typo in FAQ

### DIFF
--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -1791,7 +1791,7 @@ You can use `@run driver` to run a class that provides more complex logic, if ne
 
 ### My test uses "preview features": how do I specify the necessary options?
 
-Tests that use preview features must use the `--enable-option` to compile
+Tests that use preview features must use the `--enable-preview` to compile
 and run the code.  In addition, to compile the code you must also specify the 
 appropriate source level.
 


### PR DESCRIPTION
`--enable-option` should be `--enable-preview`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903051](https://bugs.openjdk.java.net/browse/CODETOOLS-7903051): Fix minor typo in FAQ


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/jtreg pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/38.diff">https://git.openjdk.java.net/jtreg/pull/38.diff</a>

</details>
