### PR TITLE
7903058: Add link to pre-built jtreg binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The fundamental way to build jtreg is with GNU make, specifying where to find
 those external components, but a script is also available that will download
 appropriate copies of those components before building jtreg.
 
+Note: You may [download pre-built versions of jtreg](https://ci.adoptopenjdk.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/) from [here](https://ci.adoptopenjdk.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/).
+
 ## Building jtreg with the build.sh script
 
 This is the recommended way to build jtreg, for those that want a simple,


### PR DESCRIPTION
Preview here:
https://github.com/jerboaa/jtreg/tree/add-links-to-builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [CODETOOLS-7903058](https://bugs.openjdk.org/browse/CODETOOLS-7903058): Add link to pre-built jtreg binaries ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/jtreg pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/41.diff">https://git.openjdk.org/jtreg/pull/41.diff</a>

</details>
