### PR TITLE
7903061: Don't upload build artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,3 @@ jobs:
         HEADLESS: 1
       run: |
         bash make/build.sh --jdk ${JAVA_HOME_11_X64} --skip-download
-
-    - name: 'Upload artifact ${{ github.event.repository.name }}-build-${{ github.sha }}'
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}-build-${{ github.sha }}
-        path: |
-          build/images/jtreg


### PR DESCRIPTION
This commit removes the step that uploads a build artifact as part of the test workflow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903061](https://bugs.openjdk.java.net/browse/CODETOOLS-7903061): Don't upload build artifact


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.java.net/jtreg pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/42.diff">https://git.openjdk.java.net/jtreg/pull/42.diff</a>

</details>
