### PR TITLE
7902831: Provide a way to isolate tests from general concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following dependencies are optional.
 * JDK 18:
   This is used when running some of the tests. Set `JDK18HOME` to run these
   tests. It need not be set if you are just building jtreg.
-  
+
 The recommended versions are also defined in `make/build-support/version-numbers`.
 
 ## Running jtreg Self-Tests
@@ -192,4 +192,4 @@ The jtreg repo also contains a plugin for the IntelliJ IDE.
 This is a convenience plugin which adds jtreg capabilities to the IntelliJ IDE.
 With this plugin, OpenJDK developers can write, run, and debug jtreg tests
 without leaving their IDE environment.  For more details, see the file
-_plugins/idea/README.md_ in this repo.
+[plugins/idea/README.md](plugins/idea/README.md) in this repo.

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionTestSuite.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import com.sun.javatest.TestEnvironment;
 import com.sun.javatest.TestFinder;
 import com.sun.javatest.TestSuite;
 import com.sun.javatest.WorkDirectory;
+import com.sun.javatest.regtest.exec.Exclusiveness;
 import com.sun.javatest.regtest.exec.RegressionScript;
 import com.sun.javatest.regtest.tool.Version;
 import com.sun.javatest.util.BackupPolicy;
@@ -215,8 +216,8 @@ public class RegressionTestSuite extends TestSuite
         return properties.useOtherVM(td.getFile());
     }
 
-    public boolean needsExclusiveAccess(TestDescription td) throws TestSuite.Fault {
-        return properties.needsExclusiveAccess(td.getFile());
+    public Exclusiveness exclusiveness(TestDescription td) {
+        return properties.exclusiveness(td.getFile());
     }
 
     public Version getRequiredVersion() {

--- a/src/share/classes/com/sun/javatest/regtest/exec/Exclusiveness.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Exclusiveness.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.regtest.exec;
+
+/**
+ * A scope which a test requires exclusive access to
+ *
+ */
+public enum Exclusiveness {NONE, DIRECTORY, MACHINE}

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1064,15 +1064,8 @@ public class RegressionScript extends Script {
         return TestNGReporter.instance(workDir);
     }
 
-    Lock acquireLock() throws TestRunException{
-        boolean exclusive;
-        try {
-            exclusive = testSuite.needsExclusiveAccess(td);
-        } catch (TestSuite.Fault e) {
-            throw new TestRunException("Can't determine if lock required", e);
-        }
-
-        return Lock.get(params).lock(exclusive);
+    Lock acquireLock() {
+        return Lock.get(params).lock(testSuite.exclusiveness(td));
     }
 
     int getNextSerial() {

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/exclusiveAccessDir/Common.sh
+++ b/test/exclusiveAccessDir/Common.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,5 +23,21 @@
 # questions.
 #
 
-# @test
-# @run shell Test.sh
+# The scratch directory will be either workdir/scratch* or workdir/scratch*/*
+cwd=`pwd`
+case $cwd in
+    */scratch*/* )
+        workdir=`dirname \`dirname $cwd\`` ;;
+    */scratch* )
+        workdir=`dirname $cwd` ;;
+    * )
+        echo "Error, can't find workdir"; exit 1;;
+esac
+
+logfile=`dirname $workdir`/Test.log
+
+# Append slowly to a shared resource available to all tests.
+for i in 1 2 3 4 5 ; do
+    echo "Test: $i" >> $logfile
+    sleep 1
+done

--- a/test/exclusiveAccessDir/ExclusiveAccessDirTest.gmk
+++ b/test/exclusiveAccessDir/ExclusiveAccessDirTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,40 +23,40 @@
 # questions.
 #
 
-$(BUILDDIR)/ExclusiveAccessTest.ref:
-	( for t in 1 2 3 4 ; do for i in 1 2 3 4 5 ; do echo "Test: $$i" ; done ; done ) > $@
+$(BUILDDIR)/ExclusiveAccessDirTest.ref:
+	( for i in 1 2 3 4 5 ; do for t in 1 5 6 ; do echo "Test: $$i" ; done ; done; for t in 2 3 4 ; do for i in 1 2 3 4 5 ; do echo "Test: $$i" ; done ; done) > $@
 
-$(BUILDDIR)/ExclusiveAccessTest.single.ok: \
+$(BUILDDIR)/ExclusiveAccessDirTest.single.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg \
-	$(BUILDDIR)/ExclusiveAccessTest.ref
+	$(BUILDDIR)/ExclusiveAccessDirTest.ref
 	$(RM) $(@:%.ok=%) && $(MKDIR) $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		-conc:4 \
-		$(TESTDIR)/exclusive \
+		-conc:6 \
+		$(TESTDIR)/exclusiveAccessDir \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: 4' $(@:%.ok=%/jt.log)  > /dev/null
-	$(DIFF) $(BUILDDIR)/ExclusiveAccessTest.ref $(@:%.ok=%)/Test.log
+	$(GREP) -s 'Test results: passed: 6' $(@:%.ok=%/jt.log)  > /dev/null
+	$(DIFF) $(BUILDDIR)/ExclusiveAccessDirTest.ref $(@:%.ok=%)/Test.log
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ExclusiveAccessTest.multi.ok: \
+$(BUILDDIR)/ExclusiveAccessDirTest.multi.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg \
-	$(BUILDDIR)/ExclusiveAccessTest.ref
+	$(BUILDDIR)/ExclusiveAccessDirTest.ref
 	$(RM) $(@:%.ok=%) && $(MKDIR) $(@:%.ok=%)
 	for i in 1 2 3 4 ; do \
 	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work.$$i -r:$(@:%.ok=%)/report.$$i \
 		-jdk:$(JDKHOME) \
 		-lock:$(@:%.ok=%)/Test.lck \
-		$(TESTDIR)/exclusive/dir/Test$$i.sh \
+		$(TESTDIR)/exclusiveAccessDir/exclusive/Test$$i.sh \
 			> $(@:%.ok=%/jt.$$i.log) 2>&1 & \
         done ; wait
-	$(DIFF) $(BUILDDIR)/ExclusiveAccessTest.ref $(@:%.ok=%)/Test.log
+	$(DIFF) $(BUILDDIR)/ExclusiveAccessDirTest.ref $(@:%.ok=%)/Test.log
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExclusiveAccessTest.single.ok
+	$(BUILDDIR)/ExclusiveAccessDirTest.single.ok

--- a/test/exclusiveAccessDir/TEST.ROOT
+++ b/test/exclusiveAccessDir/TEST.ROOT
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.dirs = exclusive
+

--- a/test/exclusiveAccessDir/concurrent/Test5.sh
+++ b/test/exclusiveAccessDir/concurrent/Test5.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell ../Common.sh

--- a/test/exclusiveAccessDir/concurrent/Test6.sh
+++ b/test/exclusiveAccessDir/concurrent/Test6.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell ../Common.sh

--- a/test/exclusiveAccessDir/exclusive/Test1.sh
+++ b/test/exclusiveAccessDir/exclusive/Test1.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell ../Common.sh

--- a/test/exclusiveAccessDir/exclusive/Test2.sh
+++ b/test/exclusiveAccessDir/exclusive/Test2.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell ../Common.sh

--- a/test/exclusiveAccessDir/exclusive/Test3.sh
+++ b/test/exclusiveAccessDir/exclusive/Test3.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell ../Common.sh

--- a/test/exclusiveAccessDir/exclusive/Test4.sh
+++ b/test/exclusiveAccessDir/exclusive/Test4.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell ../Common.sh

--- a/test/exclusiveAccessMachine/ExclusiveAccessMachineTest.gmk
+++ b/test/exclusiveAccessMachine/ExclusiveAccessMachineTest.gmk
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+$(BUILDDIR)/ExclusiveAccessMachineTest.ref:
+	( for t in 1 2 3 4 5 6 ; do for i in 1 2 3 4 5 ; do echo "Test: $$i" ; done ; done ) > $@
+
+$(BUILDDIR)/ExclusiveAccessMachineTest.ok: \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	$(JTREG_IMAGEDIR)/bin/jtreg \
+	$(BUILDDIR)/ExclusiveAccessMachineTest.ref
+	$(RM) $(@:%.ok=%) && $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-conc:6 \
+		$(TESTDIR)/exclusiveAccessMachine \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from JavaTest intentionally ignored"
+	$(GREP) -s 'Test results: passed: 8' $(@:%.ok=%/jt.log)  > /dev/null
+	# All exclusives should be uninterrupted
+	cat $(@:%.ok=%)/Test.log | $(GREP) "Exclusive" | $(DIFF) $(TESTDIR)/exclusiveAccessMachine/expect-exclusive.txt -
+	# There should be at least one parallel run (Two consequent 'Test: 1' lines)
+	cat $(@:%.ok=%)/Test.log | \
+		awk 'BEGIN {rc=1} ; /Concurrent: 1/ {if (found==1) { rc=0 } else {found=1}}; !/Concurrent: 1/ {found=0}; END { exit rc} '
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDDIR)/ExclusiveAccessMachineTest.ok

--- a/test/exclusiveAccessMachine/TEST.ROOT
+++ b/test/exclusiveAccessMachine/TEST.ROOT
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+

--- a/test/exclusiveAccessMachine/concurrent/Common.sh
+++ b/test/exclusiveAccessMachine/concurrent/Common.sh
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# The scratch directory will be either workdir/scratch* or workdir/scratch*/*
+cwd=`pwd`
+case $cwd in
+    */scratch*/* )
+        workdir=`dirname \`dirname $cwd\`` ;;
+    */scratch* )
+        workdir=`dirname $cwd` ;;
+    * )
+        echo "Error, can't find workdir"; exit 1;;
+esac
+
+logfile=`dirname $workdir`/Test.log
+
+# Append slowly to a shared resource available to all tests.
+for i in 1 2 3 4 5 ; do
+    echo "Concurrent: $i" >> $logfile
+    sleep 1
+done

--- a/test/exclusiveAccessMachine/concurrent/Test4.sh
+++ b/test/exclusiveAccessMachine/concurrent/Test4.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -24,4 +24,4 @@
 #
 
 # @test
-# @run shell Test.sh
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/concurrent/Test5.sh
+++ b/test/exclusiveAccessMachine/concurrent/Test5.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -24,4 +24,4 @@
 #
 
 # @test
-# @run shell Test.sh
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/concurrent/Test6.sh
+++ b/test/exclusiveAccessMachine/concurrent/Test6.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,21 +23,5 @@
 # questions.
 #
 
-# The scratch directory will be either workdir/scratch* or workdir/scratch*/*
-cwd=`pwd`
-case $cwd in
-    */scratch*/* )
-        workdir=`dirname \`dirname $cwd\`` ;;
-    */scratch* )
-        workdir=`dirname $cwd` ;;
-    * )
-        echo "Error, can't find workdir"; exit 1;;
-esac
-
-logfile=`dirname $workdir`/Test.log
-
-# Append slowly to a shared resource available to all tests.
-for i in 1 2 3 4 5 ; do
-    echo "Test: $i" >> $logfile
-    sleep 1
-done
+# @test
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/concurrent/Test7.sh
+++ b/test/exclusiveAccessMachine/concurrent/Test7.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,5 +23,5 @@
 # questions.
 #
 
-exclusiveAccess.dirs = dir
-
+# @test
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/concurrent/Test8.sh
+++ b/test/exclusiveAccessMachine/concurrent/Test8.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/exclusive/Common.sh
+++ b/test/exclusiveAccessMachine/exclusive/Common.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,5 +23,23 @@
 # questions.
 #
 
-# @test
-# @run shell Test.sh
+# The scratch directory will be either workdir/scratch* or workdir/scratch*/*
+cwd=`pwd`
+case $cwd in
+    */scratch*/* )
+        workdir=`dirname \`dirname $cwd\`` ;;
+    */scratch* )
+        workdir=`dirname $cwd` ;;
+    * )
+        echo "Error, can't find workdir"; exit 1;;
+esac
+
+logfile=`dirname $workdir`/Test.log
+
+# Append slowly to a shared resource available to all tests.
+for i in 1 2 3 4 ; do
+    echo -n "Exclusive: $i " >> $logfile
+    sleep 1
+done
+echo "Exclusive 5" >> $logfile
+sleep 1

--- a/test/exclusiveAccessMachine/exclusive/TEST.properties
+++ b/test/exclusiveAccessMachine/exclusive/TEST.properties
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.machine=true

--- a/test/exclusiveAccessMachine/exclusive/Test1.sh
+++ b/test/exclusiveAccessMachine/exclusive/Test1.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/exclusive/Test2.sh
+++ b/test/exclusiveAccessMachine/exclusive/Test2.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/exclusive/Test3.sh
+++ b/test/exclusiveAccessMachine/exclusive/Test3.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @run shell Common.sh

--- a/test/exclusiveAccessMachine/expect-exclusive.txt
+++ b/test/exclusiveAccessMachine/expect-exclusive.txt
@@ -1,0 +1,3 @@
+Exclusive: 1 Exclusive: 2 Exclusive: 3 Exclusive: 4 Exclusive 5
+Exclusive: 1 Exclusive: 2 Exclusive: 3 Exclusive: 4 Exclusive 5
+Exclusive: 1 Exclusive: 2 Exclusive: 3 Exclusive: 4 Exclusive 5


### PR DESCRIPTION
The PR expands the test isolation possibilities to the whole machine. Possibility to limit exclusiveness to the directory remains.
There are two options now: "exclusiveAccess.dirs" (a directory list), and "exclusiveAccess.machine" (boolean).

The solution is based on the ReentrantReadWriteLock, Write lock is held by machine-exclusive executors while read lock is taken for directory-only and fully-concurrent tests. Directory-scoped isolation is achieved by an additional lock.

Testing: shell-based tests added, run locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Title mismatch between PR and JBS for issue [CODETOOLS-7902831](https://bugs.openjdk.org/browse/CODETOOLS-7902831)
&nbsp;⚠️ Whitespace errors (failed with updated jcheck configuration in pull request)

### Issue
 * [CODETOOLS-7902831](https://bugs.openjdk.org/browse/CODETOOLS-7902831): Provide way to isolate tests from general concurrency (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jtreg.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/43.diff">https://git.openjdk.org/jtreg/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/43#issuecomment-981709455)