### PR TITLE
CODETOOLS-7903073: jtreg build fails with JDK 17

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/ActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/ActionHelper.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import static com.sun.javatest.regtest.agent.AStatus.error;
 import static com.sun.javatest.regtest.agent.AStatus.passed;
 
+@SuppressWarnings("removal") // Security Manager and related APIs
 public class ActionHelper {
 
     // <editor-fold defaultstate="collapsed" desc=" Save State ">

--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 
+@SuppressWarnings("removal") // Security Manager and related APIs
 public class AgentServer implements ActionHelper.OutputHandler {
 
     /**

--- a/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
@@ -65,6 +65,7 @@ import java.util.Hashtable;
   *
   * @author Iris A Garcia
   */
+@SuppressWarnings("removal") // Applet and related APIs
 public class AppletWrapper
 {
     public static void main(String [] args) {
@@ -530,6 +531,7 @@ class CheckboxPanel extends Panel
 /**
  * This is the panel which contains the test applet.
  */
+@SuppressWarnings("removal") // Applet and related APIs
 class AppletPanel extends Panel
 {
     private static final long serialVersionUID = 1L;

--- a/src/share/classes/com/sun/javatest/regtest/agent/JavaTestSecurityManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JavaTestSecurityManager.java
@@ -42,6 +42,7 @@ import java.util.PropertyPermission;
  * by JDK1.0.2.
  */
 
+@SuppressWarnings("removal") // Security Manager and related APIs
 public class JavaTestSecurityManager extends SecurityManager
 {
     /**

--- a/src/share/classes/com/sun/javatest/regtest/agent/RegressionSecurityManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/RegressionSecurityManager.java
@@ -28,6 +28,7 @@ package com.sun.javatest.regtest.agent;
 import java.security.Permission;
 import java.util.PropertyPermission;
 
+@SuppressWarnings("removal") // Security Manager and related APIs
 public class RegressionSecurityManager extends JavaTestSecurityManager {
     /**
      * Try to install a copy of this security manager, up to but not including JDK 18.

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -131,6 +131,7 @@ import static com.sun.javatest.regtest.tool.Option.ArgType.*;
 /**
  * Main entry point to be used to access jtreg.
  */
+@SuppressWarnings("removal") // Security Manager and related APIs
 public class Tool {
 
     /**


### PR DESCRIPTION
Please review a trivial change to suppress "removal" warnings when compiling jtreg with JDK 17.

The warnings are for applets and the security manager.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903073](https://bugs.openjdk.java.net/browse/CODETOOLS-7903073): jtreg build fails with JDK 17


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jtreg pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/45.diff">https://git.openjdk.java.net/jtreg/pull/45.diff</a>

</details>
