### PR TITLE
CODETOOLS-7903077: Remove @SuppressWarnings for --source 1.2 code

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
@@ -65,7 +65,7 @@ import java.util.Hashtable;
   *
   * @author Iris A Garcia
   */
-@SuppressWarnings("removal") // Applet and related APIs
+// @SuppressWarnings("removal") // Applet and related APIs
 public class AppletWrapper
 {
     public static void main(String [] args) {
@@ -531,7 +531,7 @@ class CheckboxPanel extends Panel
 /**
  * This is the panel which contains the test applet.
  */
-@SuppressWarnings("removal") // Applet and related APIs
+// @SuppressWarnings("removal") // Applet and related APIs
 class AppletPanel extends Panel
 {
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Please review a trivial update to remove `@SuppressWarnings` annotations from `AppletWrapper`, which is still compiled with `--source 1.2` in the recommended build for `jtreg 6`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903077](https://bugs.openjdk.java.net/browse/CODETOOLS-7903077): Remove @SuppressWarnings for --source 1.2 code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/jtreg pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/46.diff">https://git.openjdk.java.net/jtreg/pull/46.diff</a>

</details>
