### PR TITLE
CODETOOLS-7903083: Provide system property or option to override timeout

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
@@ -638,7 +638,7 @@ public class AppletAction extends Action
 
     //----------member variables---------------- --------------------------------
 
-    private String  manual   = "unset";
+    private String  manual   = "unset"; // or "novalue", "done", "yesno"
     private boolean reverseStatus = false;
     private boolean othervm  = false;
     private int     timeout  = -1;

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -787,5 +787,5 @@ public class MainAction extends Action
     protected Set<String> othervmOverrideReasons = new LinkedHashSet<>();
     protected boolean nativeCode = false;
     private int     timeout = -1;
-    private String  manual  = "unset";
+    private String  manual  = "unset"; // or "novalue"
 }

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -492,7 +492,7 @@ public class RegressionScript extends Script {
 
     /**
      * Get the timeout to be used for a test.  Since the timeout for regression
-     * tests is on a per action basis rather than on a per test basis, this
+     * tests is on a per-action basis rather than on a per-test basis, this
      * method should always return zero which indicates that there is no
      * timeout.
      *
@@ -504,22 +504,22 @@ public class RegressionScript extends Script {
     }
 
     /**
-     * Get the timeout to be used for an action.  The timeout will be scaled by
-     * the timeoutFactor as necessary.  The default timeout for any action as
-     * per the tag-spec is 120 seconds scaled by a value found in the
-     * environment ("javatestTimeoutFactor").
-     * The timeout factor is available as both an integer (for backward
-     * compatibility) and a floating point number
+     * Returns the timeout to be used for an action.
      *
-     * @param time The initial timeout which may need to be scaled according
-     *             to the provided timeoutFactor.  If the initial timeout is
-     *             less than zero, then the default timeout will be returned.
-     * @return     The timeout in seconds.
+     * If no debug options have been set, the result will be the given value,
+     * or a default value if the given value is negative, scaled by the timeout factor.
+     *
+     * If debug options have been set, the result will be 0, meaning "no timeout".
+     *
+     * @param time the value of the timeout specified in the action,
+     *             or -1 if no value was specified
+     * @return     the timeout, in seconds
      */
     protected int getActionTimeout(int time) {
-        if (time < 0)
-            time = 120;
-        return (int) (time * getTimeoutFactor());
+        final int DEFAULT_ACTION_TIMEOUT = 120; // seconds
+        return isTimeoutsEnabled()
+                ? (int) ((time < 0 ? DEFAULT_ACTION_TIMEOUT : time) * getTimeoutFactor())
+                : 0;
     }
 
     protected float getTimeoutFactor() {
@@ -527,7 +527,9 @@ public class RegressionScript extends Script {
             // not synchronized, so in worst case may be set more than once
             float value = 1; // default
             try {
-                // use [1] to get the floating point timeout factor
+                // The timeout factor is available as both an integer (for backward compatibility)
+                // and a floating point number.
+                // Use [1] to get the floating point timeout factor
                 String f = (regEnv == null ? null : regEnv.lookup("javatestTimeoutFactor")[1]);
                 if (f != null)
                     value = Float.parseFloat(f);
@@ -540,6 +542,16 @@ public class RegressionScript extends Script {
     }
 
     private static float cacheJavaTestTimeoutFactor = -1;
+
+    /**
+     * Returns whether timeouts are (generally) enabled.
+     *
+     * @return {@code true} if timeouts are enabled, and {@code false} otherwise
+     */
+    protected boolean isTimeoutsEnabled() {
+        // for now, timeouts are always enabled, unless debug options have been specified for the test
+        return getTestDebugOptions().isEmpty();
+    }
 
     /**
      * Set an alarm that will interrupt the calling thread after a specified

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -416,5 +416,5 @@ public class ShellAction extends Action
 
     private boolean reverseStatus = false;
     private int     timeout = -1;
-    private String  manual  = "unset";
+    private String  manual  = "unset"; // or "novalue"
 }

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ help.cmd.introHead=For brief details about a topic, use "-help <term> ...". \
     available for the following topics.\n
 help.cmd.fullHead=
 help.cmd.summaryHead=Information is available for the following topics:
-help.copyright.txt=Copyright (c) 1999, 2021, Oracle and/or its affiliates. \
+help.copyright.txt=Copyright (c) 1999, 2022, Oracle and/or its affiliates. \
     All rights reserved.\nUse is subject to license terms.
 help.cmd.noEntriesFound=No entries were found that matched your query.
 
@@ -157,6 +157,7 @@ help.jdk.vmoptions.arg=<option>...
 help.jdk.debug.desc=Use this to specify VM options to attach a debugger \
     to a VM running a test. It is similar to -vmoptions except that it is not used \
     when starting VMs used to query the properties of that VM. \
+    Any timeout for a test is automatically disabled when this option is used. \
     See also -javaoptions and -vmoptions.
 help.jdk.debug.arg=<option>...
 help.jdk.agentlib.desc=Load native agent library

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -818,6 +818,9 @@ using the `-timeoutHandler` and `-timeoutHanderDir` options. The default
 timeout handler will try and call `jstack` to generate stack traces of all
 the Java threads running in the JVM being used for the action.
 
+Test timeouts are automatically disabled when a test is being debugged,
+as indicated by the use of the `-debug` option.
+
 For all timeout-related options, use `jtreg -help timeout`.
 
 ### How do I run only tests which were written for a specific bugid?


### PR DESCRIPTION
This is a PR to disable timeouts when test debug options have been set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903083](https://bugs.openjdk.java.net/browse/CODETOOLS-7903083): Provide system property or option to override timeout


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.java.net/jtreg pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/47.diff">https://git.openjdk.java.net/jtreg/pull/47.diff</a>

</details>
