### PR TITLE
CODETOOLS-7903088: Update version to 7; update build JDK to 11

### DIFF
--- a/make/CheckJavaOSVersion.java
+++ b/make/CheckJavaOSVersion.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * Checks the value of System.getProperty("os.version") against an expected value.
+ * For more info, see
+ * JDK-8253702: BigSur version number reported as 10.16, should be 11.nn
+ * https://bugs.openjdk.java.net/browse/JDK-8253702
+ */
+public class CheckJavaOSVersion {
+    public static void main(String... args) {
+        checkJavaOSVersion(args[0]);
+    }
+
+    private static void checkJavaOSVersion(String expectVersion) {
+        String osVersion = System.getProperty("os.version");
+        if (!osVersion.equals(expectVersion)) {
+            System.err.println("The version of JDK you are using does not report the OS version correctly.");
+            System.err.println("    java.home:    " + System.getProperty("java.home"));
+            System.err.println("    java.version: " + System.getProperty("java.version"));
+            System.err.println("    os.version:   " + osVersion + "  (expected: " + expectVersion + ")");
+            System.err.println("Use a more recent update of this version of JDK, or a newer version of JDK.");
+            System.exit(1);
+        }
+    }
+}

--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -141,40 +141,26 @@ JDKJAVA = $(JDKHOME)/bin/java
 JDKJAVAC = $(JDKHOME)/bin/javac
 JAR = $(JDKHOME)/bin/jar
 
-# Only use -source -target, to support legacy platforms, when building with JDK 8
-# Otherwise, use default values for $JDKHOME/bin/javac
-SUPPORT_OLD_SOURCE_TARGET = $(shell $(JDKJAVAC) -version 2>&1 | grep '[8]' > /dev/null && echo true )
-ifneq ($(SUPPORT_OLD_SOURCE_TARGET),)
-    OLD_JAVAC_SOURCE_TARGET = -source 1.2 -target 1.1
-    AGENT_JAVAC_SOURCE_TARGET = -source 5 -target 5
-    TOOL_JAVAC_SOURCE_TARGET = -source 8 -target 8
-    REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS =
-else
-    EXTRA_LINT_OPTS = -rawtypes,-unchecked
-    REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS = --patch-module java.base=$(JAVADIR)
-endif 
+OLD_JAVAC_SOURCE_TARGET = --release 8
+AGENT_JAVAC_SOURCE_TARGET = --release 8
+TOOL_JAVAC_SOURCE_TARGET = --release 11
+EXTRA_LINT_OPTS = -rawtypes,-unchecked
+REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS = --patch-module java.base=$(JAVADIR)
 
-ifdef JDK5HOME
-    JDK5_BOOTCLASSPATH = -bootclasspath $(JDK5HOME)/jre/lib/rt.jar
-endif
-ifdef JDK8HOME
-    JDK8_BOOTCLASSPATH = -bootclasspath $(JDK8HOME)/jre/lib/rt.jar
-endif
-
-# for files needed to run othervm tests on oldest supported platforms
+# for files needed to run othervm tests (on platforms back to JDK 8)
 REGTEST_OLD_JAVAC = $(JDKHOME)/bin/javac
 REGTEST_OLD_JAVAC_OPTIONS = \
-	$(OLD_JAVAC_SOURCE_TARGET) $(JDK5_BOOTCLASSPATH) -Xlint:all,-options,-deprecation,$(EXTRA_LINT_OPTS) -Werror
+	$(OLD_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation,$(EXTRA_LINT_OPTS) -Werror
 
-# for files needed to run agentvm tests (on platforms back to JDK 1.5)
+# for files needed to run agentvm tests (on platforms back to JDK 8)
 REGTEST_AGENT_JAVAC = $(JDKHOME)/bin/javac
 REGTEST_AGENT_JAVAC_OPTIONS = \
-	$(AGENT_JAVAC_SOURCE_TARGET) $(JDK5_BOOTCLASSPATH) -Xlint:all,-options,-deprecation,$(EXTRA_LINT_OPTS) -Werror
+	$(AGENT_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation,$(EXTRA_LINT_OPTS) -Werror
 
 # for files needed for jtreg tool
 REGTEST_TOOL_JAVAC = $(JDKHOME)/bin/javac
 REGTEST_TOOL_JAVAC_OPTIONS = \
-	$(TOOL_JAVAC_SOURCE_TARGET) $(JDK8_BOOTCLASSPATH) -Xlint:all,-options,-deprecation -Werror
+	$(TOOL_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation -Werror
 
 #----- JavaTest: https://wiki.openjdk.java.net/display/CodeTools/JT+Harness
 #

--- a/make/Makefile
+++ b/make/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,11 +42,11 @@ include Rules.gmk
 
 build: $(BUILDFILES)
 
-test: $(INITIAL_TESTS) $(TESTS) $(FINAL_TESTS)
+test: checkJavaOSVersion $(INITIAL_TESTS) $(TESTS) $(FINAL_TESTS)
 	count=`echo $+ | wc -w` ; \
 	echo "All ($${count}) selected tests completed successfully"
 
-quick-test: $(INITIAL_TESTS)
+quick-test: checkJavaOSVersion $(INITIAL_TESTS)
 	count=`echo $+ | wc -w` ; \
 	echo "All ($${count}) selected tests completed successfully"
 
@@ -108,6 +108,13 @@ endif
 	@echo "BUILD_VERSION       = $(BUILD_VERSION)"
 	@echo "BUILD_MILESTONE     = $(BUILD_MILESTONE)"
 	@echo "BUILD_NUMBER        = $(BUILD_NUMBER)"
+
+#----------------------------------------------------------------------
+
+checkJavaOSVersion:
+ifeq ($(OS_NAME), macosx)
+	$(JDKJAVA) CheckJavaOSVersion.java $(OS_VERSION)
+endif
 
 #----------------------------------------------------------------------
 

--- a/make/build-support/version-numbers
+++ b/make/build-support/version-numbers
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 # questions.
 #
 
-JTREG_VERSION=6.2
+JTREG_VERSION=7
 
 DEFAULT_ANT_VERSION=1.10.8
 DEFAULT_ANT_ARCHIVE_CHECKSUM=dbe187ce2963f9df8a67de8aaff3b0a437d06978

--- a/make/build.sh
+++ b/make/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -258,7 +258,7 @@ usage() {
     echo "--help"
     echo "      Show this message"
     echo "--jdk /path/to/jdk"
-    echo "      Path to JDK; must be JDK 8 or higher"
+    echo "      Path to JDK; must be JDK 11 or higher"
     echo "--quiet | -q"
     echo "      Reduce the logging output."
     echo "--show-default-versions"
@@ -441,13 +441,27 @@ sanity_check_java_home() {
         grep -e ^java -e ^openjdk |
         head -n 1 | \
         sed -e 's/^[^0-9]*\(1\.\)*\([1-9][0-9]*\).*/\2/' )
-    if [ "${vnum:-0}" -lt "8" ]; then
-        error "JDK 8 or newer is required to build jtreg"
+    if [ "${vnum:-0}" -lt "11" ]; then
+        error "JDK 11 or newer is required to build jtreg"
         exit 1
     fi
 }
+
+checkJavaOSVersion() {
+  # This checks that the value in the Java "os.version" system property
+  # is as expected.  While it is OK to *build* jtreg with a JDK with this bug,
+  # some of the `jtreg` self-tests will fail: notably, test/problemList.
+  # See https://bugs.openjdk.java.net/browse/JDK-8253702
+  case `uname` in
+    Darwin )
+      OS_VERSION=`defaults read loginwindow SystemVersionStampAsString`
+      ${JAVA_HOME}/bin/java ${mydir}/CheckJavaOSVersion.java ${OS_VERSION}
+  esac
+}
+
 setup_java_home
 sanity_check_java_home
+#checkJavaOSVersion   #temp: check for presence of the JDK os.version bug (JDK-8253702)
 export JAVA_HOME
 info "JAVA_HOME: ${JAVA_HOME}"
 

--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ JAVAFILES.java.lang := \
 $(BUILDDIR)/classes.java.lang.ok: \
 		$(JAVAFILES.java.lang)
 	CLASSPATH= \
-	    $(REGTEST_TOOL_JAVAC) $(REGTEST_TOOL_JAVAC_OPTIONS) $(REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS) \
+	    $(REGTEST_TOOL_JAVAC) $(REGTEST_TOOL_JAVAC_OPTIONS) --release 9 $(REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS) \
 		-d $(CLASSDIR) \
 		-encoding ISO8859-1 \
 		$(JAVAFILES.java.lang)

--- a/src/share/bin/jtreg.sh
+++ b/src/share/bin/jtreg.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -138,15 +138,15 @@ elif [ -n "$wsl" -a -x "$JTREG_JAVA".exe ]; then
     driveDir=mnt
 fi
 
-# Verify java version (1.)8 or newer used to run jtreg
+# Verify java version 11 or newer used to run jtreg
 version=`"$JTREG_JAVA" -classpath "${JTREG_HOME}/lib/jtreg.jar" com.sun.javatest.regtest.agent.GetSystemProperty java.version 2>&1 |
         grep 'java.version=' | sed -e 's/^.*=//' -e 's/^1\.//' -e 's/\([1-9][0-9]*\).*/\1/'`
 
 if [ -z "$version" ]; then
     echo "Cannot determine version of java to run jtreg"
     exit 1;
-elif [ "$version" -lt 8 ]; then
-    echo "java version 8 or later is required to run jtreg"
+elif [ "$version" -lt 11 ]; then
+    echo "java version 11 or later is required to run jtreg"
     exit 1;
 fi
 

--- a/test/SecurityManager/SecurityManagerTests.gmk
+++ b/test/SecurityManager/SecurityManagerTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ $(BUILDDIR)/SecurityManagerTest_14.ok \
 $(BUILDDIR)/SecurityManagerTest_18.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK$(@:$(BUILDDIR)/SecurityManagerTest_%.ok=%)HOME) \
 		-agentvm \

--- a/test/addmods/AddModulesTest.gmk
+++ b/test/addmods/AddModulesTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ $(BUILDDIR)/AddModulesTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \
 		$(TESTDIR)/addmods \

--- a/test/bootclasspath/BootClassPathTest.gmk
+++ b/test/bootclasspath/BootClassPathTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ $(BUILDDIR)/BootClassPathTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/testng.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		$(TESTDIR)/bootclasspath \

--- a/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
+++ b/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -32,11 +32,12 @@ $(BUILDDIR)/ignoresymbolfile.agentvm.ok: \
 	    	$(JTREG_IMAGE_JAVAHELP_JAR) 
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JDK8HOME)/bin/java \
+	$(JDKHOME)/bin/java \
 		-Djavatest.regtest.showCmd=true \
 		-Djavatest.regtest.debugChild=true \
 		-Djavatest.regtest.traceAgent=true \
 		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		$(@:$(BUILDDIR)/ignoresymbolfile.%.ok=-%) \

--- a/test/javac/JavacTests.gmk
+++ b/test/javac/JavacTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ $(BUILDDIR)/javac/agentvm.ok: \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	JTREG_SHOWAGENT=true JTREG_SHOWCMD=true \
 	JTREG_USE_AGENTVM_FOR_SAMEVM=false \
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		$(@:$(BUILDDIR)/javac/%.ok=-%) \

--- a/test/jdkModulesTest/JDKModulesTest.gmk
+++ b/test/jdkModulesTest/JDKModulesTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 #----------------------------------------------------------------------
 
-ifdef JDK9HOME
-
 $(BUILDDIR)/JDKModulesTest.ok: \
 	    $(TESTDIR)/jdkModulesTest/JDKModulesTest.java \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
@@ -38,12 +36,14 @@ $(BUILDDIR)/JDKModulesTest.ok: \
 		-cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-Xlint -Werror \
 		-encoding ISO8859-1 $(TESTDIR)/jdkModulesTest/JDKModulesTest.java
-	$(JDK9HOME)/bin/java -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" \
+	$(JDKHOME)/bin/java -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" \
+		-Djava.io.tmpdir=$(@:%.ok=%) \
+		JDKModulesTest -Ddummy.vm.option
+	$(JDKHOME)/bin/java -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" \
 		-Djava.io.tmpdir=$(@:%.ok=%) \
 		JDKModulesTest 
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += $(BUILDDIR)/JDKModulesTest.ok
 
-endif
 

--- a/test/jdkModulesTest/JDKModulesTest.java
+++ b/test/jdkModulesTest/JDKModulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,9 @@ public class JDKModulesTest {
         Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
         Path testSuiteDir = tmpDir.resolve("dummyTestSuite");
         Files.createDirectories(testSuiteDir);
-        Files.createFile(testSuiteDir.resolve("TEST.ROOT"));
+        if (!Files.exists(testSuiteDir.resolve("TEST.ROOT"))) {
+            Files.createFile(testSuiteDir.resolve("TEST.ROOT"));
+        }
         dummyTestSuite = RegressionTestSuite.open(testSuiteDir.toFile(), null);
 
         Path dwd = tmpDir.resolve("dummyWorkDir");
@@ -75,22 +77,22 @@ public class JDKModulesTest {
     @Test
     void testNoVMOpts() throws TestSuite.Fault {
         test(Collections.<String>emptyList(),
-                Arrays.asList("java.desktop", "jdk.compiler", "java.corba"),
-                Arrays.asList("java.corba"));
+                Arrays.asList("java.desktop", "jdk.compiler", "java.se"),
+                Arrays.asList("java.se"));
     }
 
     @Test
     void testAddAllSystem() throws TestSuite.Fault {
         test(Arrays.asList("--add-modules", "ALL-SYSTEM"),
-                Arrays.asList("java.desktop", "jdk.compiler", "java.corba"),
+                Arrays.asList("java.desktop", "jdk.compiler", "java.se"),
                 Collections.<String>emptyList());
     }
 
     @Test
     void testLimitJDKCompiler() throws TestSuite.Fault {
         test(Arrays.asList("--limit-modules", "jdk.compiler"),
-                Arrays.asList("java.desktop", "jdk.compiler", "java.corba"),
-                Arrays.asList("java.desktop", "java.corba"));
+                Arrays.asList("java.desktop", "jdk.compiler", "java.se"),
+                Arrays.asList("java.desktop", "java.se"));
     }
 
 

--- a/test/keywords/testKeywords.gmk
+++ b/test/keywords/testKeywords.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ $(BUILDDIR)/TestKeywords.good.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
@@ -43,7 +43,7 @@ $(BUILDDIR)/TestKeywords.badProps.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
@@ -57,7 +57,7 @@ $(BUILDDIR)/TestKeywords.badTest.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \

--- a/test/modlibs/ModLibsTest.gmk
+++ b/test/modlibs/ModLibsTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ $(BUILDDIR)/ModLibsTest.agentvm.ok: \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
             $(MODLIBS_TEST_FILES)
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-J-Djavatest.regtest.allowTrailingBuild=true \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \

--- a/test/modules/ModulesTest.gmk
+++ b/test/modules/ModulesTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ $(BUILDDIR)/ModulesTest_NoLimitMods.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/classes
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \
 		$(TESTDIR)/modules \
@@ -52,7 +52,7 @@ $(BUILDDIR)/ModulesTest_LimitMods_java.se.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/classes
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \
 		-javaoptions:"--limit-modules $(@:$(BUILDDIR)/ModulesTest_LimitMods_%.ok=%)" \
@@ -65,7 +65,7 @@ $(BUILDDIR)/ModulesTest_IgnoreAtModules.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/classes
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		$(TESTDIR)/modules \

--- a/test/preview/PreviewTest.gmk
+++ b/test/preview/PreviewTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ $(BUILDDIR)/PreviewTest_good.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK14HOME) \
 		'-k:!bad' \
@@ -44,7 +44,7 @@ $(BUILDDIR)/PreviewTest_bad.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK14HOME) \
 		'-k:bad' \

--- a/test/refIgnoreLines/RefIgnoreLines.gmk
+++ b/test/refIgnoreLines/RefIgnoreLines.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ $(BUILDDIR)/RefIgnoreLines_std.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		$(TESTDIR)/refIgnoreLines \
@@ -52,7 +52,7 @@ $(BUILDDIR)/RefIgnoreLines_Xmx.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-Xmx100m \
@@ -76,7 +76,7 @@ $(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(@:$(BUILDDIR)/RefIgnoreLines_%_1.ok=%)=-Xmx100m \
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-e:$(@:$(BUILDDIR)/RefIgnoreLines_%_1.ok=%) \
@@ -104,7 +104,7 @@ $(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-e:$(@:$(BUILDDIR)/RefIgnoreLines_%_2.ok=%)=-Xmx100m \

--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ $(BUILDDIR)/RerunTest.othervm.ok: \
 	unset GNOME_DESKTOP_SESSION_ID ; \
 	unset XMODIFIERS ; \
 	LANG=en_US.UTF-8 TZ=GMT+0.00 \
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-J-Djavatest.regtest.allowTrailingBuild=true \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
@@ -51,7 +51,7 @@ $(BUILDDIR)/RerunTest.othervm.ok: \
 	for i in `cd $(TESTDIR)/rerun ; ls */*.sh */*.java` ; do \
 	    echo Checking $(@:$(BUILDDIR)/RerunTest.%.ok=%) $$i ; \
 	    mkdir -p `dirname $(@:%.ok=%)/out/$$i` ; \
-	    $(JTREG_IMAGEDIR)/bin/jtreg \
+	    JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%)/work \
 		-dir:$(TESTDIR)/rerun \
@@ -60,6 +60,7 @@ $(BUILDDIR)/RerunTest.othervm.ok: \
 		    -e 's|^DISPLAY=.* \\|DISPLAY=%DISPLAY% \\|' \
 		    -e 's|$(JDK8HOME)|%JDKHOME%|g' \
 		    -e "s|`cd $(JDK8HOME); pwd -P`|%JDKHOME%|g" \
+		    -e '/JTREG_JAVA=/d' \
 		    -e 's|$(BUILDDIR)|%BUILD%|g' \
 		    -e 's|$(ABSTOPDIR)|%WS%|g' \
 		    -e 's|%BUILD%.images.jtreg.lib.guice\.jar.||g' \

--- a/test/rerun2/RerunTest2.gmk
+++ b/test/rerun2/RerunTest2.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -33,14 +33,15 @@ $(BUILDDIR)/RerunTest2.ok: \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(MKDIR) $(@:%.ok=%)/classes
-	$(JDK8HOME)/bin/javac \
+	$(JDKHOME)/bin/javac \
 		-d $(@:%.ok=%)/classes \
 		-cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-Xlint -Werror \
 		$(TESTDIR)/rerun2/RerunTest2.java
-	cd $(@:%.ok=%) && $(JDK8HOME)/bin/java \
+	cd $(@:%.ok=%) && $(JDKJAVA) \
 		-classpath classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		RerunTest2 \
+		$(JDK8HOME) \
 		../$(TESTDIR)/rerun2/test
 	echo "test passed at `date`" > $@
 

--- a/test/rerun2/RerunTest2.java
+++ b/test/rerun2/RerunTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,20 +35,21 @@ public class RerunTest2 {
     }
 
     void run(String... args) throws Exception {
-        File testSuite = new File(args[0]);
+        File jdk = new File(args[0]);
+        File testSuite = new File(args[1]);
         for (String mode: new String[] { "othervm", "agentvm" }) {
-            test(testSuite, mode);
+            test(jdk, testSuite, mode);
         }
         if (errors > 0)
             throw new Exception(errors + " errors found");
     }
 
-    void test(File testSuite, String mode) throws Exception {
+    void test(File jdk, File testSuite, String mode) throws Exception {
         System.out.println("test " + mode);
 
         File initialWorkDir = new File(mode, "work");
         File initialReportDir = new File(mode, "report");
-        runTests(testSuite, initialWorkDir, initialReportDir, mode);
+        runTests(jdk, testSuite, initialWorkDir, initialReportDir, mode);
 
         for (String test: getTests(initialReportDir)) {
             File testWorkDir = new File(mode,
@@ -59,8 +60,9 @@ public class RerunTest2 {
         System.out.println();
     }
 
-    void runTests(File ts, File wd, File rd, String mode) throws Exception {
+    void runTests(File jdk, File ts, File wd, File rd, String mode) throws Exception {
         String[] args = {
+            "-jdk:" + jdk,
             "-w", wd.getPath(),
             "-r", rd.getPath(),
             "-" + mode,

--- a/test/shell/testShell.gmk
+++ b/test/shell/testShell.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ $(BUILDDIR)/TestShell.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \

--- a/test/testng-junit/TestNGJUnitTest.gmk
+++ b/test/testng-junit/TestNGJUnitTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ $(BUILDDIR)/TestNGJUnitTest.othervm.ok: \
 		$(JTREG_IMAGEDIR)/lib/testng.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \

--- a/test/timeouthandlers/TimeoutHandlerTest.gmk
+++ b/test/timeouthandlers/TimeoutHandlerTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ $(BUILDDIR)/TimeoutHandlerTestDefault.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-va \
@@ -50,7 +50,7 @@ $(BUILDDIR)/TimeoutHandlerTestDefault.shell.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-va \
@@ -76,10 +76,10 @@ $(BUILDDIR)/TimeoutHandlerTestExternal.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JDK8HOME)/bin/javac -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	$(JDKHOME)/bin/javac -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-d $(@:%.ok=%) \
 		$(TESTDIR)/timeouthandlers/MyHandler.java
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-va \
@@ -97,10 +97,10 @@ $(BUILDDIR)/TimeoutHandlerTestExternal.shell.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(JDK8HOME)/bin/javac -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	$(JDKHOME)/bin/javac -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-d $(@:%.ok=%) \
 		$(TESTDIR)/timeouthandlers/MyHandler.java
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-va \

--- a/test/vmopts/TestVMOpts.gmk
+++ b/test/vmopts/TestVMOpts.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,14 +31,14 @@
 $(BUILDDIR)/TestVMOpts.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
-	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDK8HOME) -Dfoo=bar -Xbootclasspath/p:baz \
 		-w:$(BUILDDIR)/jtreg/cmd.othervm/work \
 		-r:$(BUILDDIR)/jtreg/cmd.othervm/report \
 		-verbose:fail \
 		$(TESTDIR)/vmopts
 ifdef ANT
-	JAVA_HOME=$(JDK8HOME) $(ANT) -f $(TESTDIR)/vmopts/build.xml \
+	JAVA_HOME=$(JDKHOME) $(ANT) -f $(TESTDIR)/vmopts/build.xml \
 		-Dbuild.jtreg=$(BUILDDIR)/jtreg \
 		-Djtreg.jar=$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-Dtestjdk=$(JDK8HOME)


### PR DESCRIPTION
Please review a change to increase the `jtreg` version to 7 (simple) and the JDK required to build `jtreg` to JDK 11 or newer. (not so simple).

A consequence of using a more recent version of JDK to build `jtreg` is that we can (going forward) start to modernize the code, but it does mean that starting in this version (7), we can no longer run tests on JDK older than JDK 8.   To run tests on older versions of JDK, you will have to use an older version of `jtreg`.

There was one gotcha in moving to a newer JDK.  Some older versions/updates of JDK do not set the correct value of the system property `os.version` on a Mac.  This is fixed in JDK 17, and the fix has been back ported to most versions from 11 to 16.   For now, there are various checks in the `build.sh` script, the `Makefile`, and in `jtreg` itself, to make sure it does not detect the bug in the JDK used to build or run `jtreg`.   This code can be removed when we move forward (again, later) to using JDK 17 to build `jtreg`, but for now, "baby steps".

A number of tests needed to be updated, typically to specify a newer version of JDK to run `jtreg`, while leaving unchanged the version of JDK used in the tests themselves.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903088](https://bugs.openjdk.java.net/browse/CODETOOLS-7903088): Update version to 7; update build JDK to 11


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.java.net/jtreg pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/48.diff">https://git.openjdk.java.net/jtreg/pull/48.diff</a>

</details>
