### PR TITLE
CODETOOLS-7903090: Merge othervm and agentvm classes; eliminate raw types

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -141,21 +141,14 @@ JDKJAVA = $(JDKHOME)/bin/java
 JDKJAVAC = $(JDKHOME)/bin/javac
 JAR = $(JDKHOME)/bin/jar
 
-OLD_JAVAC_SOURCE_TARGET = --release 8
 AGENT_JAVAC_SOURCE_TARGET = --release 8
 TOOL_JAVAC_SOURCE_TARGET = --release 11
-EXTRA_LINT_OPTS = -rawtypes,-unchecked
 REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS = --patch-module java.base=$(JAVADIR)
 
-# for files needed to run othervm tests (on platforms back to JDK 8)
-REGTEST_OLD_JAVAC = $(JDKHOME)/bin/javac
-REGTEST_OLD_JAVAC_OPTIONS = \
-	$(OLD_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation,$(EXTRA_LINT_OPTS) -Werror
-
-# for files needed to run agentvm tests (on platforms back to JDK 8)
+# for files needed to run agentvm and othervm tests (on platforms back to JDK 8)
 REGTEST_AGENT_JAVAC = $(JDKHOME)/bin/javac
 REGTEST_AGENT_JAVAC_OPTIONS = \
-	$(AGENT_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation,$(EXTRA_LINT_OPTS) -Werror
+	$(AGENT_JAVAC_SOURCE_TARGET) -Xlint:all,-options,-deprecation -Werror
 
 # for files needed for jtreg tool
 REGTEST_TOOL_JAVAC = $(JDKHOME)/bin/javac

--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -27,32 +27,13 @@
 #
 # compile com.sun.javatest.regtest
 
-### The following files are required to run othervm tests
-
-REGTEST-OTHERVM-CLASSES = AppletWrapper GetSystemProperty MainWrapper AStatus StringArray
-JAVAFILES.com.sun.javatest.regtest-othervm = \
-	$(REGTEST-OTHERVM-CLASSES:%=$(JAVADIR)/com/sun/javatest/regtest/agent/%.java)
-
-# TODO: set -bootclasspath to JDK 1.1 classes?
-$(BUILDDIR)/classes.com.sun.javatest.regtest-othervm.ok: \
-		$(JAVAFILES.com.sun.javatest.regtest-othervm) \
-		$(call PosixPath,$(JAVATEST_JAR))
-	$(MKDIR) -p $(CLASSDIR)
-	CLASSPATH="$(CLASSDIR)$(PS)$(JAVATEST_JAR)" \
-	    $(REGTEST_OLD_JAVAC) $(REGTEST_OLD_JAVAC_OPTIONS) \
-		-d $(CLASSDIR) \
-		-encoding ISO8859-1 \
-		$(JAVAFILES.com.sun.javatest.regtest-othervm)
-	echo "classes built at `date`" > $@
-
-### The following files are required to run agentvm tests, as far back as JDK 1.5
+### The following files are required to run agentvm and othervm tests, as far back as JDK 8
 
 JAVAFILES.com.sun.javatest.regtest-agentvm := \
-	$(filter-out $(JAVAFILES.com.sun.javatest.regtest-othervm), $(shell $(FIND) $(JAVADIR)/com/sun/javatest/regtest/agent -name \*.java ))
+	$(shell $(FIND) $(JAVADIR)/com/sun/javatest/regtest/agent -name \*.java )
 
 $(BUILDDIR)/classes.com.sun.javatest.regtest.agent.ok: \
-		$(JAVAFILES.com.sun.javatest.regtest-agentvm) \
-		$(BUILDDIR)/classes.com.sun.javatest.regtest-othervm.ok
+		$(JAVAFILES.com.sun.javatest.regtest-agentvm)
 	CLASSPATH="$(CLASSDIR)$(PS)$(JAVATEST_JAR)$(PS)$(JUNIT_JAR)$(PS)$(TESTNG_JAR)" \
 	    $(REGTEST_AGENT_JAVAC) $(REGTEST_AGENT_JAVAC_OPTIONS) \
 		-d $(CLASSDIR) \
@@ -81,6 +62,7 @@ TARGETS.com.sun.javatest.regtest += $(BUILDDIR)/classes.com.sun.javatest.regtest
 JAVAFILES.java.lang := \
 	$(JAVADIR)/java/lang/JTRegModuleHelper.java
 
+# The hardcoded use of --release 9 reflects the introduction of the Java Platform Module System
 $(BUILDDIR)/classes.java.lang.ok: \
 		$(JAVAFILES.java.lang)
 	CLASSPATH= \

--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -34,6 +34,7 @@ JAVAFILES.com.sun.javatest.regtest-agentvm := \
 
 $(BUILDDIR)/classes.com.sun.javatest.regtest.agent.ok: \
 		$(JAVAFILES.com.sun.javatest.regtest-agentvm)
+	$(MKDIR) -p $(CLASSDIR)
 	CLASSPATH="$(CLASSDIR)$(PS)$(JAVATEST_JAR)$(PS)$(JUNIT_JAR)$(PS)$(TESTNG_JAR)" \
 	    $(REGTEST_AGENT_JAVAC) $(REGTEST_AGENT_JAVAC_OPTIONS) \
 		-d $(CLASSDIR) \

--- a/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
@@ -65,16 +65,16 @@ import java.util.Hashtable;
   *
   * @author Iris A Garcia
   */
-// @SuppressWarnings("removal") // Applet and related APIs
+@SuppressWarnings("removal") // Applet and related APIs
 public class AppletWrapper
 {
-    public static void main(String [] args) {
-        String [] appArgs;
+    public static void main(String[] args) {
+        String[] appArgs;
         try {
             FileReader in = new FileReader(args[0]);
 
             StringWriter out = new StringWriter();
-            char [] buf = new char[1024];
+            char[] buf = new char[1024];
             int howMany;
 
             while ((howMany = in.read(buf)) > 0)
@@ -113,9 +113,9 @@ public class AppletWrapper
         // non-interrupted case
     } // main()
 
-    private static Dictionary stringToDictionary(String s) {
+    private static Dictionary<String,String> stringToDictionary(String s) {
         String[] pairs = StringArray.splitTerminator("\034", s);
-        Dictionary retVal = new Hashtable(3);
+        Dictionary<String,String> retVal = new Hashtable<>(3);
         for (int i = 0; i < pairs.length; i+=2)
             retVal.put(pairs[i], pairs[i+1]);
         return retVal;
@@ -132,8 +132,8 @@ public class AppletWrapper
         public void run() {
             waiter = new AppletWaiter();
 
-            int width  = Integer.parseInt((String) appletAtts.get("width"));
-            int height = Integer.parseInt((String) appletAtts.get("height"));
+            int width  = Integer.parseInt(appletAtts.get("width"));
+            int height = Integer.parseInt(appletAtts.get("height"));
             AppletFrame app = new AppletFrame(className, body, manual, width, height);
             Applet applet = app.getApplet();
             AppletStubImpl stub = new AppletStubImpl();
@@ -189,15 +189,15 @@ public class AppletWrapper
 
         private void validate(final Component c) {
             try {
-                Class eventQueueClass = EventQueue.class;
-                Method isDispatchThread  = eventQueueClass.getMethod("isDispatchThread", new Class[] {});
-                Method invokeAndWait = eventQueueClass.getMethod("invokeAndWait", new Class[] { Runnable.class });
-                if (!((Boolean) (isDispatchThread.invoke(null, new Object[] { }))).booleanValue()) {
-                    invokeAndWait.invoke(null, new Object[] { new Runnable() {
+                Class<?> eventQueueClass = EventQueue.class;
+                Method isDispatchThread  = eventQueueClass.getMethod("isDispatchThread");
+                Method invokeAndWait = eventQueueClass.getMethod("invokeAndWait", Runnable.class );
+                if (!((Boolean) (isDispatchThread.invoke(null))).booleanValue()) {
+                    invokeAndWait.invoke(null, new Runnable() {
                             public void run() {
                                 c.validate();
                             }
-                        }});
+                        });
                     return;
                 }
             }
@@ -228,7 +228,7 @@ public class AppletWrapper
         }
 
         public String getParameter(String name) {
-            return (String) appletParams.get(name);
+            return appletParams.get(name);
         }
 
         public AppletContext getAppletContext() {
@@ -336,7 +336,7 @@ public class AppletWrapper
                     c.gridwidth = 1;
                     c.weightx = 0.0;
                     c.anchor  = GridBagConstraints.WEST;
-                    String [] boxNames = {"fixed", "variable"};
+                    String[] boxNames = {"fixed", "variable"};
                     makeCheckboxPanel(boxNames, gridbag, c);
                 }
 
@@ -413,7 +413,7 @@ public class AppletWrapper
         private void makeApplet(String className, GridBagLayout gridbag, GridBagConstraints c,
                                 int width, int height) {
             try {
-                Class cls = Class.forName(className);
+                Class<?> cls = Class.forName(className);
                 applet = (Applet) cls.newInstance();
             } catch (InstantiationException e) {
                 e.printStackTrace();
@@ -460,7 +460,7 @@ public class AppletWrapper
             add(textArea);
         } // makeTextArea()
 
-        private void makeCheckboxPanel(String [] name, GridBagLayout gridbag, GridBagConstraints c) {
+        private void makeCheckboxPanel(String[] name, GridBagLayout gridbag, GridBagConstraints c) {
             CheckboxPanel p = new CheckboxPanel(appletPanel, name);
             gridbag.setConstraints(p, c);
             add(p);
@@ -484,8 +484,8 @@ public class AppletWrapper
     private static String classpath;
     private static String manual;
     private static String body;
-    private static Dictionary appletParams;
-    private static Dictionary appletAtts;
+    private static Dictionary<String,String> appletParams;
+    private static Dictionary<String,String> appletAtts;
 } // class AppletWrapper
 
 /**
@@ -496,7 +496,7 @@ class CheckboxPanel extends Panel
 {
     private static final long serialVersionUID = 1L;
 
-    public CheckboxPanel(AppletPanel appletPanel, String [] boxNames) {
+    public CheckboxPanel(AppletPanel appletPanel, String[] boxNames) {
         panel = appletPanel;
 
         CheckboxGroup group = new CheckboxGroup();

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
@@ -62,7 +62,7 @@ public class MainWrapper
             className  = (sep == -1) ? moduleClassName : moduleClassName.substring(sep + 1);
             classArgs = StringArray.splitWS(fileArgs[i++]);
         } catch (IOException e) {
-            AStatus.failed(MAIN_CANT_READ_ARGS + e.toString()).exit();
+            AStatus.failed(MAIN_CANT_READ_ARGS + e).exit();
             throw new IllegalStateException(); // implies exit() didn't sucees
         }
 
@@ -88,10 +88,10 @@ public class MainWrapper
 
     private static void handleTestException(Throwable e) {
         if (SKIP_EXCEPTION.equals(e.getClass().getName())) {
-            AStatus.passed(MAIN_SKIPPED + e.toString())
+            AStatus.passed(MAIN_SKIPPED + e)
                    .exit();
         } else {
-            AStatus.failed(MAIN_THREW_EXCEPT + e.toString())
+            AStatus.failed(MAIN_THREW_EXCEPT + e)
                    .exit();
         }
     }
@@ -178,7 +178,7 @@ public class MainWrapper
                 uncaughtThread    = t;
             }
 //          cleanup();
-            AStatus.failed(MAIN_THREW_EXCEPT + e.toString()).exit();
+            AStatus.failed(MAIN_THREW_EXCEPT + e).exit();
         } // uncaughtException()
 
 //      public void cleanup() {

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Method;
   */
 public class MainWrapper
 {
-    public static void main(String [] args) {
+    public static void main(String[] args) {
         String moduleName;
         String className;
         String[] classArgs;
@@ -107,24 +107,24 @@ public class MainWrapper
             try {
                 ClassLoader cl;
                 if (moduleName != null) {
-                    Class layerClass;
+                    Class<?> layerClass;
                     try {
                         layerClass = Class.forName("java.lang.ModuleLayer");
                     } catch (ClassNotFoundException e) {
                         layerClass = Class.forName("java.lang.reflect.Layer");
                     }
-                    Method bootMethod = layerClass.getMethod("boot", new Class[] { });
-                    Object bootLayer = bootMethod.invoke(null, new Object[] { });
-                    Method findLoaderMth = layerClass.getMethod("findLoader", new Class[] { String.class });
-                    cl = (ClassLoader) findLoaderMth.invoke(bootLayer, new Object[] { moduleName });
+                    Method bootMethod = layerClass.getMethod("boot");
+                    Object bootLayer = bootMethod.invoke(null);
+                    Method findLoaderMth = layerClass.getMethod("findLoader", String.class);
+                    cl = (ClassLoader) findLoaderMth.invoke(bootLayer, moduleName);
                 } else {
                     cl = getClass().getClassLoader();
                 }
 
                 // RUN JAVA PROGRAM
-                Class c = Class.forName(className, false, cl);
-                Method mainMethod = c.getMethod("main", new Class[] { String[].class });
-                mainMethod.invoke(null, new Object[] { args });
+                Class<?> c = Class.forName(className, false, cl);
+                Method mainMethod = c.getMethod("main", String[].class);
+                mainMethod.invoke(null, (Object) args);
 
             } catch (InvocationTargetException e) {
                 Throwable throwable = e.getTargetException();
@@ -160,7 +160,7 @@ public class MainWrapper
 
         private final String moduleName;
         private final String className;
-        private final String [] args;
+        private final String[] args;
     }
 
     static class MainThreadGroup extends ThreadGroup

--- a/src/share/classes/com/sun/javatest/regtest/agent/StringArray.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/StringArray.java
@@ -81,7 +81,7 @@ public class StringArray {
      * @see #splitTerminator
      */
     public static String[] splitSeparator(String sep, String s) {
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         int tokenStart = 0;
         int tokenEnd   = 0;
 
@@ -91,7 +91,7 @@ public class StringArray {
         }
         v.addElement(s.substring(tokenStart));
 
-        String [] retVal = new String[v.size()];
+        String[] retVal = new String[v.size()];
         v.copyInto(retVal);
         return retVal;
     } // splitSeparator()
@@ -111,7 +111,7 @@ public class StringArray {
      * @see #splitSeparator
      */
     public static String[] splitTerminator(String sep, String s) {
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         int tokenStart = 0;
         int tokenEnd   = 0;
 
@@ -120,7 +120,7 @@ public class StringArray {
             tokenStart = tokenEnd+1;
         }
 
-        String [] retVal = new String[v.size()];
+        String[] retVal = new String[v.size()];
         v.copyInto(retVal);
         return retVal;
     } // splitTerminator()
@@ -139,7 +139,7 @@ public class StringArray {
         if (s == null)
             return new String[0];
 
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         int tokenStart = 0;
         int tokenEnd   = 0;
 
@@ -159,7 +159,7 @@ public class StringArray {
             tokenStart = tokenEnd;
         }
 
-        String [] retVal = new String[v.size()];
+        String[] retVal = new String[v.size()];
         v.copyInto(retVal);
         return retVal;
     } // splitWS()

--- a/src/share/classes/com/sun/javatest/regtest/agent/StringArray.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/StringArray.java
@@ -25,7 +25,8 @@
 
 package com.sun.javatest.regtest.agent;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Various static methods used to operate on arrays of strings.  This includes
@@ -67,9 +68,9 @@ public class StringArray {
 
     /**
      * Splits a string based on presence of a specified separator. Returns an
-     * array of arbitrary length.  Then end of each element in the array is
+     * array of arbitrary length.  The end of each element in the array is
      * indicated by the separator or the end of the string.  If there is a
-     * separator immeidately before the end of the string, the final element
+     * separator immediately before the end of the string, the final element
      * will be empty.  None of the strings will contain the separator. Useful
      * when separating strings such as "foo/bar/bas" using separator '/'.
      *
@@ -81,19 +82,17 @@ public class StringArray {
      * @see #splitTerminator
      */
     public static String[] splitSeparator(String sep, String s) {
-        Vector<String> v = new Vector<>();
+        List<String> v = new ArrayList<>();
         int tokenStart = 0;
-        int tokenEnd   = 0;
+        int tokenEnd;
 
         while ((tokenEnd = s.indexOf(sep, tokenStart)) != -1) {
-            v.addElement(s.substring(tokenStart, tokenEnd));
+            v.add(s.substring(tokenStart, tokenEnd));
             tokenStart = tokenEnd+1;
         }
-        v.addElement(s.substring(tokenStart));
+        v.add(s.substring(tokenStart));
 
-        String[] retVal = new String[v.size()];
-        v.copyInto(retVal);
-        return retVal;
+        return v.toArray(new String[0]);
     } // splitSeparator()
 
     /**
@@ -111,18 +110,16 @@ public class StringArray {
      * @see #splitSeparator
      */
     public static String[] splitTerminator(String sep, String s) {
-        Vector<String> v = new Vector<>();
+        List<String> v = new ArrayList<>();
         int tokenStart = 0;
-        int tokenEnd   = 0;
+        int tokenEnd;
 
         while ((tokenEnd = s.indexOf(sep, tokenStart)) != -1) {
-            v.addElement(s.substring(tokenStart, tokenEnd));
+            v.add(s.substring(tokenStart, tokenEnd));
             tokenStart = tokenEnd+1;
         }
 
-        String[] retVal = new String[v.size()];
-        v.copyInto(retVal);
-        return retVal;
+        return v.toArray(new String[0]);
     } // splitTerminator()
 
     /**
@@ -139,9 +136,9 @@ public class StringArray {
         if (s == null)
             return new String[0];
 
-        Vector<String> v = new Vector<>();
+        List<String> v = new ArrayList<>();
         int tokenStart = 0;
-        int tokenEnd   = 0;
+        int tokenEnd;
 
         while (true) {
             if (tokenStart == s.length())
@@ -155,12 +152,10 @@ public class StringArray {
             while ((tokenEnd < s.length())
                    && !Character.isWhitespace(s.charAt(tokenEnd)))
                 tokenEnd++;
-            v.addElement(s.substring(tokenStart, tokenEnd));
+            v.add(s.substring(tokenStart, tokenEnd));
             tokenStart = tokenEnd;
         }
 
-        String[] retVal = new String[v.size()];
-        v.copyInto(retVal);
-        return retVal;
+        return v.toArray(new String[0]);
     } // splitWS()
 }


### PR DESCRIPTION
Please review some moderately simple changes to update the code used in test VMs, hitherto constrained to use JDK 1.2 or 1.5.

As well as eliminating raw types, the code is converted to use standard Collection classes instead of the old Dictionary and Vector.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903090](https://bugs.openjdk.java.net/browse/CODETOOLS-7903090): Merge othervm and agentvm classes; eliminate raw types


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to f1b761cd270a04b8fa86f13ce532b7abc94e4b31


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.java.net/jtreg pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/49.diff">https://git.openjdk.java.net/jtreg/pull/49.diff</a>

</details>
