### PR TITLE
CODETOOLS-7903091: Convert jtreg to use NIO

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/Main.java
+++ b/src/share/classes/com/sun/javatest/regtest/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package com.sun.javatest.regtest;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -282,7 +283,7 @@ public class Main {
                         && tool.testGroupArgs.isEmpty()
                         && dir != null) {
                     DirectoryScanner s = getDirectoryScanner(dir);
-                    addPaths(dir, s.getIncludedFiles());
+                    addPaths(dir.toPath(), s.getIncludedFiles());
                 }
 
                 int rc = tool.run();
@@ -309,10 +310,10 @@ public class Main {
             }
         }
 
-        private void addPaths(File dir, String[] paths) {
+        private void addPaths(Path dir, String[] paths) {
             if (paths != null) {
                 for (String p: paths)
-                    tool.antFileArgs.add(new File(dir, p));
+                    tool.antFileArgs.add(dir.resolve(p));
             }
         }
     }

--- a/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
+++ b/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import com.sun.javatest.regtest.agent.Alarm;
@@ -55,7 +56,7 @@ public abstract class TimeoutHandler {
     /**
      * The JDK being tested.
      */
-    protected final File testJdk;
+    protected final Path testJdk;
 
     private long timeout;
 
@@ -67,6 +68,17 @@ public abstract class TimeoutHandler {
      * @param testJdk the JDK being tested
      */
     public TimeoutHandler(PrintWriter log, File outputDir, File testJdk) {
+        this(log, outputDir, testJdk.toPath());
+    }
+
+    /**
+     * Creates a timeout handler.
+     *
+     * @param log to which messages should be written
+     * @param outputDir a directory in which diagnostic information may be written
+     * @param testJdk the JDK being tested
+     */
+    public TimeoutHandler(PrintWriter log, File outputDir, Path testJdk) {
         this.log = log;
         this.outputDir = outputDir;
         this.testJdk = testJdk;

--- a/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
+++ b/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
@@ -56,7 +56,7 @@ public abstract class TimeoutHandler {
     /**
      * The JDK being tested.
      */
-    protected final Path testJdk;
+    protected final File testJdk;
 
     private long timeout;
 
@@ -81,7 +81,7 @@ public abstract class TimeoutHandler {
     public TimeoutHandler(PrintWriter log, File outputDir, Path testJdk) {
         this.log = log;
         this.outputDir = outputDir;
-        this.testJdk = testJdk;
+        this.testJdk = testJdk.toFile();
     }
 
     /**

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package com.sun.javatest.regtest.agent;
 
-import java.io.File;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
@@ -33,6 +32,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -146,9 +146,9 @@ public class MainActionHelper extends ActionHelper {
             }
             if (classpath != null && !classpath.isEmpty()) {
                 List<URL> urls = new ArrayList<URL>();
-                for (File f : classpath.asList()) {
+                for (Path f : classpath.asList()) {
                     try {
-                        urls.add(f.toURI().toURL());
+                        urls.add(f.toUri().toURL());
                     } catch (MalformedURLException e) {
                     }
                 }

--- a/src/share/classes/com/sun/javatest/regtest/config/JDK.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/JDK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -84,9 +87,11 @@ public class JDK {
      * @param javaHome the "home" directory for the JDK
      *
      * @return the JDK object
+     *
+     * @throws InvalidPathException if the path is invalid
      */
-    public static JDK of(String javaHome) {
-        return of(new File(javaHome));
+    public static JDK of(String javaHome) throws InvalidPathException {
+        return of(Path.of(javaHome));
     }
 
     /**
@@ -96,23 +101,23 @@ public class JDK {
      *
      * @return the JDK object
      */
-    public static synchronized JDK of(File javaHome) {
+    public static synchronized JDK of(Path javaHome) {
         JDK jdk = cache.get(javaHome);
         if (jdk == null)
             cache.put(javaHome, jdk = new JDK(javaHome));
         return jdk;
     }
 
-    private static final Map<File, JDK> cache = new HashMap<>();
+    private static final Map<Path, JDK> cache = new HashMap<>();
 
     /**
      * Creates a JDK object, given its "$JAVA_HOME" path.
      *
      * @param jdk the "home" directory for the JDK
      */
-    private JDK(File jdk) {
+    private JDK(Path jdk) {
         this.jdk = jdk;
-        absJDK = jdk.getAbsoluteFile();
+        absJDK = jdk.toAbsolutePath();
     }
 
     /**
@@ -143,7 +148,7 @@ public class JDK {
      *
      * @return the home directory for the JDK
      */
-    public File getFile() {
+    public Path getFile() {
         return jdk;
     }
 
@@ -152,7 +157,7 @@ public class JDK {
      *
      * @return the absolute path of the home directory for the JDK
      */
-    public File getAbsoluteFile() {
+    public Path getAbsoluteFile() {
         return absJDK;
     }
 
@@ -161,7 +166,7 @@ public class JDK {
      *
      * @return a path for the Java launcher for this JDK
      */
-    public File getJavaProg() {
+    public Path getJavaProg() {
         return getProg("java", false);
     }
 
@@ -170,7 +175,7 @@ public class JDK {
      *
      * @return a path for the Java compiler for this JDK
      */
-    public File getJavacProg() {
+    public Path getJavacProg() {
         return getProg("javac", false);
     }
 
@@ -183,12 +188,12 @@ public class JDK {
      *
      * @return the path
      */
-    public File getProg(String command, boolean checkExe) {
-        File bin = new File(absJDK, "bin");
-        File prog = new File(bin, command);
-        if (!prog.exists() && checkExe) {
-            File prog_exe = new File(bin, command + ".exe");
-            if (prog_exe.exists()) {
+    public Path getProg(String command, boolean checkExe) {
+        Path bin = absJDK.resolve("bin");
+        Path prog = bin.resolve(command);
+        if (!Files.exists(prog) && checkExe) {
+            Path prog_exe = bin.resolve(command + ".exe");
+            if (Files.exists(prog_exe)) {
                 return prog_exe;
             }
         }
@@ -201,7 +206,7 @@ public class JDK {
      * @return whether or not the home directory for this JDK exists
      */
     public boolean exists() {
-        return jdk.exists();
+        return Files.exists(jdk);
     }
 
     /**
@@ -210,7 +215,7 @@ public class JDK {
      * @return the home directory for the JDK
      */
     public String getPath() {
-        return jdk.getPath();
+        return jdk.toString();
     }
 
     /**
@@ -219,7 +224,7 @@ public class JDK {
      * @return the absolute path of the home directory for the JDK
      */
     public String getAbsolutePath() {
-        return absJDK.getPath();
+        return absJDK.toString();
     }
 
     /**
@@ -230,7 +235,7 @@ public class JDK {
      */
     public SearchPath getJDKClassPath() {
         // will return an empty path if tools.jar does not exist
-        return new SearchPath(new File(new File(absJDK, "lib"), "tools.jar"));
+        return new SearchPath(absJDK.resolve("lib").resolve("tools.jar"));
     }
 
     /**
@@ -299,7 +304,7 @@ public class JDK {
         // since we are trying to determine the Java version, we have to assume
         // the worst, and use CLASSPATH.
         pb.environment().put("CLASSPATH", getSysPropClassPath.toString());
-        pb.command(getJavaProg().getPath(), GetSystemProperty.class.getName(), VERSION_PROPERTY);
+        pb.command(getJavaProg().toString(), GetSystemProperty.class.getName(), VERSION_PROPERTY);
         pb.redirectErrorStream(true);
         try {
             Process p = pb.start();
@@ -355,7 +360,7 @@ public class JDK {
         if (fullVersion == null) {
             fullVersion = "";  // default
             List<String> cmdArgs = new ArrayList<>();
-            cmdArgs.add(getJavaProg().getPath());
+            cmdArgs.add(getJavaProg().toString());
             cmdArgs.addAll(vmOpts);
             cmdArgs.add(VERSION_OPTION);
 
@@ -547,9 +552,9 @@ public class JDK {
                     return hasOldSymbolFile;
                 }
             }
-            File ctSym = new File(new File(absJDK, "lib"), "ct.sym");
-            if (ctSym.exists()) {
-                try (JarFile jar = new JarFile(ctSym)) {
+            Path ctSym = absJDK.resolve("lib").resolve("ct.sym");
+            if (Files.exists(ctSym)) {
+                try (JarFile jar = new JarFile(ctSym.toFile())) {
                     JarEntry e = jar.getJarEntry("META-INF/sym/rt.jar/java/lang/Object.class");
                     hasOldSymbolFile = (e != null);
                 } catch (IOException e) {
@@ -607,7 +612,7 @@ public class JDK {
         jdkOpts.addAll(epd.getVMOpts());
 
         List<String> cmdArgs = new ArrayList<>();
-        cmdArgs.add(getJavaProg().getPath());
+        cmdArgs.add(getJavaProg().toString());
         cmdArgs.addAll(jdkOpts.toList());
         cmdArgs.add(GetJDKProperties.class.getName());
 
@@ -708,8 +713,8 @@ public class JDK {
         return info;
     }
 
-    private final File jdk;
-    private final File absJDK;
+    private final Path jdk;
+    private final Path absJDK;
 
     /** Value of java.specification.version for this JDK. Lazily evaluated as needed. */
     private String javaSpecificationVersion;

--- a/src/share/classes/com/sun/javatest/regtest/config/JDK.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/JDK.java
@@ -147,8 +147,19 @@ public class JDK {
      * Returns the home directory for the JDK, as specified when the object was created.
      *
      * @return the home directory for the JDK
+     *
+     * @see #getHomeDirectory()
      */
-    public Path getFile() {
+    public File getFile() {
+        return jdk.toFile();
+    }
+
+    /**
+     * Returns the home directory for the JDK, as specified when the object was created.
+     *
+     * @return the home directory for the JDK
+     */
+    public Path getHomeDirectory() {
         return jdk;
     }
 
@@ -156,8 +167,19 @@ public class JDK {
      * Returns the absolute path of the home directory for the JDK.
      *
      * @return the absolute path of the home directory for the JDK
+     *
+     * @see #getAbsoluteHomeDirectory()
      */
-    public Path getAbsoluteFile() {
+    public File getAbsoluteFile() {
+        return absJDK.toFile();
+    }
+
+    /**
+     * Returns the absolute path of the home directory for the JDK.
+     *
+     * @return the absolute path of the home directory for the JDK
+     */
+    public Path getAbsoluteHomeDirectory() {
         return absJDK;
     }
 
@@ -213,6 +235,8 @@ public class JDK {
      * Returns the home directory for the JDK as a string, as specified when the object was created.
      *
      * @return the home directory for the JDK
+     *
+     * @see #getHomeDirectory()
      */
     public String getPath() {
         return jdk.toString();
@@ -222,6 +246,8 @@ public class JDK {
      * Returns the absolute path of the home directory for the JDK, as a string.
      *
      * @return the absolute path of the home directory for the JDK
+     *
+     * @see #getAbsoluteHomeDirectory()
      */
     public String getAbsolutePath() {
         return absJDK.toString();

--- a/src/share/classes/com/sun/javatest/regtest/config/JDKOpts.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/JDKOpts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
 package com.sun.javatest.regtest.config;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.sun.javatest.regtest.agent.SearchPath;
+import com.sun.javatest.regtest.util.FileUtils;
 import com.sun.javatest.regtest.util.StringUtils;
 
 /**
@@ -174,13 +177,14 @@ public class JDKOpts {
      */
     public void addAllPatchModules(SearchPath patchPath) {
         if (patchPath != null) {
-            for (File dir : patchPath.asList()) {
-                File[] subdirs = dir.listFiles();
+            for (Path dir : patchPath.asList()) {
+                List<Path> subdirs = FileUtils.listFiles(dir);
                 if (subdirs != null) {
-                    Arrays.sort(subdirs); // for repeatability; good enough for now
-                    for (File subdir: subdirs) {
-                        if (subdir.isDirectory()) {
-                            mergeHandler.handleOption(Option.PATCH_MODULE, "--patch-module", subdir.getName() + "=" + subdir);
+                    Collections.sort(subdirs); // for repeatability; good enough for now
+                    for (Path subdir: subdirs) {
+                        if (Files.isDirectory(subdir)) {
+                            String moduleName = subdir.getFileName().toString();
+                            mergeHandler.handleOption(Option.PATCH_MODULE, "--patch-module",  moduleName + "=" + subdir);
                         }
                     }
                 }
@@ -322,7 +326,7 @@ public class JDKOpts {
          * specified separator. If a key is provided, it will be followed by the
          * key separator character in the result.
          * @param key the key, or null if none
-         * @param keySet the separator to follow the key if one is specified
+         * @param keySep the separator to follow the key if one is specified
          * @param values the values
          * @param valSep the separator to use if more than one key
          * @return the composite string

--- a/src/share/classes/com/sun/javatest/regtest/config/Locations.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/Locations.java
@@ -261,7 +261,7 @@ public class Locations {
                 String name = lib.substring(2, end);
                 Path dir = null;
                 if (name.equals("java.home")) {
-                    dir = testJDK.getAbsoluteFile();
+                    dir = testJDK.getAbsoluteHomeDirectory();
                 } else if (name.equals("jtreg.home")) {
                     dir = jtpath.asList().get(0).getParent().getParent();
                 }

--- a/src/share/classes/com/sun/javatest/regtest/config/Locations.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/Locations.java
@@ -757,21 +757,9 @@ public class Locations {
         return (optModule == null) ? absBaseDir : absBaseDir.resolve(optModule);
     }
 
-//    private File getFile(File absBaseDir, String optModule) {
-//        return (optModule == null) ? absBaseDir : new File(absBaseDir, optModule);
-//    }
-
     private Path getFile(Path absBaseDir, String optModule, String relFile) {
         return getFile(absBaseDir, optModule).resolve(relFile);
     }
-
-//    private File getFile(File absBaseDir, String optModule, String relFile) {
-//        return new File(getFile(absBaseDir, optModule), relFile);
-//    }
-
-//    private static File normalize(File f) {
-//        return new File(f.toURI().normalize());
-//    }
 
     private boolean hasExtn(String name, String... extns) {
         for (String e: extns) {

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,6 +41,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -60,7 +64,9 @@ import com.sun.javatest.interview.BasicInterviewParameters;
 import com.sun.javatest.regtest.agent.JDK_Version;
 import com.sun.javatest.regtest.agent.SearchPath;
 import com.sun.javatest.regtest.exec.TimeoutHandlerProvider;
+import com.sun.javatest.regtest.util.FileUtils;
 import com.sun.javatest.regtest.util.StringUtils;
+import com.sun.javatest.util.I18NResourceBundle;
 
 import static com.sun.javatest.regtest.util.StringUtils.join;
 
@@ -137,10 +143,10 @@ public class RegressionParameters
         mtfp.setTimeoutFactor(tfac);
     }
 
-    public void setExcludeLists(File[] files) {
+    public void setExcludeLists(Path[] files) {
         MutableExcludeListParameters mep =
             (MutableExcludeListParameters) getExcludeListParameters();
-        mep.setExcludeFiles(files);
+        mep.setExcludeFiles(FileUtils.toFiles(files));
     }
 
     public void setPriorStatusValues(boolean[] b) {
@@ -463,13 +469,16 @@ public class RegressionParameters
 
     private TestFilter getMatchListFilter() {
         if (matchListFilter == UNSET) {
-            List<File> matchList = getMatchLists();
+            List<Path> matchList = getMatchLists();
             if (matchList.isEmpty()) {
                 matchListFilter = null;
             } else {
                 final ExcludeList el;
                 try {
-                    el = new ExcludeList(matchList.toArray(new File[]{}));
+                    el = new ExcludeList(matchList.stream()
+                            .map(Path::toFile)
+                            .collect(Collectors.toList())
+                            .toArray(new File[0]));
                 } catch (ExcludeList.Fault | IOException e) {
                     throw new Error(e);
                 }
@@ -630,87 +639,95 @@ public class RegressionParameters
     private void load0(Map<String,String> data, boolean checkChecksum) throws Interview.Fault {
         String prefix = getTag();
 
-        String v;
+        try {
+            String v;
 
-        v = data.get(prefix + ENVVARS);
-        if (v != null)
-            setEnvVars(deserializeEnv(v, "\n"));
+            v = data.get(prefix + ENVVARS);
+            if (v != null)
+                setEnvVars(deserializeEnv(v, "\n"));
 
-        v = data.get(prefix + CHECK);
-        if (v != null)
-            setCheck(v.equals("true"));
+            v = data.get(prefix + CHECK);
+            if (v != null)
+                setCheck(v.equals("true"));
 
-        v = data.get(prefix + EXEC_MODE);
-        if (v != null)
-            setExecMode(ExecMode.valueOf(v));
+            v = data.get(prefix + EXEC_MODE);
+            if (v != null)
+                setExecMode(ExecMode.valueOf(v));
 
-        v = data.get(prefix + IGNORE);
-        if (v != null)
-            setIgnoreKind(IgnoreKind.valueOf(v));
+            v = data.get(prefix + IGNORE);
+            if (v != null)
+                setIgnoreKind(IgnoreKind.valueOf(v));
 
-        v = data.get(prefix + COMPILE_JDK);
-        if (v != null)
-            setCompileJDK(JDK.of(v));
+            v = data.get(prefix + COMPILE_JDK);
+            if (v != null)
+                setCompileJDK(JDK.of(v));
 
-        v = data.get(prefix + TEST_JDK);
-        if (v != null)
-            setTestJDK(JDK.of(v));
+            v = data.get(prefix + TEST_JDK);
+            if (v != null)
+                setTestJDK(JDK.of(v));
 
-        v = data.get(prefix + TEST_VM_OPTIONS);
-        if (v != null && v.length() > 0)
-            setTestVMOptions(Arrays.asList(StringUtils.splitSeparator("\n", v)));
+            v = data.get(prefix + TEST_VM_OPTIONS);
+            if (v != null && v.length() > 0)
+                setTestVMOptions(Arrays.asList(StringUtils.splitSeparator("\n", v)));
 
-        v = data.get(prefix + TEST_COMPILER_OPTIONS);
-        if (v != null && v.length() > 0)
-            setTestCompilerOptions(Arrays.asList(StringUtils.splitSeparator("\n", v)));
+            v = data.get(prefix + TEST_COMPILER_OPTIONS);
+            if (v != null && v.length() > 0)
+                setTestCompilerOptions(Arrays.asList(StringUtils.splitSeparator("\n", v)));
 
-        v = data.get(prefix + TEST_JAVA_OPTIONS);
-        if (v != null && v.length() > 0)
-            setTestJavaOptions(Arrays.asList(StringUtils.splitSeparator("\n", v)));
+            v = data.get(prefix + TEST_JAVA_OPTIONS);
+            if (v != null && v.length() > 0)
+                setTestJavaOptions(Arrays.asList(StringUtils.splitSeparator("\n", v)));
 
-        v = data.get(prefix + RETAIN_ARGS);
-        if (v != null && v.length() > 0)
-            setRetainArgs(Arrays.asList(StringUtils.splitSeparator("\n", v)));
+            v = data.get(prefix + RETAIN_ARGS);
+            if (v != null && v.length() > 0)
+                setRetainArgs(Arrays.asList(StringUtils.splitSeparator("\n", v)));
 
-        v = data.get(prefix + JUNIT);
-        if (v != null)
-            setJUnitPath(new SearchPath(v));
+            v = data.get(prefix + JUNIT);
+            if (v != null)
+                setJUnitPath(new SearchPath(v));
 
-        v = data.get(prefix + TESTNG);
-        if (v != null)
-            setTestNGPath(new SearchPath(v));
+            v = data.get(prefix + TESTNG);
+            if (v != null)
+                setTestNGPath(new SearchPath(v));
 
-        v = data.get(prefix + ASMTOOLS);
-        if (v != null)
-            setAsmToolsPath(new SearchPath(v));
+            v = data.get(prefix + ASMTOOLS);
+            if (v != null)
+                setAsmToolsPath(new SearchPath(v));
 
-        v = data.get(prefix + TIMELIMIT);
-        if (v != null)
-            setTimeLimit(Integer.parseInt(v));
+            v = data.get(prefix + TIMELIMIT);
+            if (v != null)
+                setTimeLimit(Integer.parseInt(v));
 
-        v = data.get(prefix + REPORTDIR);
-        if (v != null)
-            setReportDir(new File(v));
+            v = data.get(prefix + REPORTDIR);
+            if (v != null)
+                setReportDir(Path.of(v));
 
-        v = data.get(prefix + EXCLUSIVE_LOCK);
-        if (v != null)
-            setExclusiveLock(new File(v));
+            v = data.get(prefix + EXCLUSIVE_LOCK);
+            if (v != null)
+                setExclusiveLock(Path.of(v));
 
-        v = data.get(prefix + NATIVEDIR);
-        if (v != null)
-            setNativeDir(new File(v));
+            v = data.get(prefix + NATIVEDIR);
+            if (v != null)
+                setNativeDir(Path.of(v));
 
-        v = data.get(prefix + TIMEOUT_HANDLER);
-        if (v != null)
-            setTimeoutHandler(v);
+            v = data.get(prefix + TIMEOUT_HANDLER);
+            if (v != null)
+                setTimeoutHandler(v);
 
-        v = data.get(prefix + TIMEOUT_HANDLER_PATH);
-        if (v != null)
-            setTimeoutHandlerPath(v);
+            v = data.get(prefix + TIMEOUT_HANDLER_PATH);
+            if (v != null)
+                setTimeoutHandlerPath(v);
 
-        v = data.get(prefix + TIMEOUT_HANDLER_TIMEOUT);
-        if (v != null)
-            setTimeoutHandlerTimeout(v);
+            v = data.get(prefix + TIMEOUT_HANDLER_TIMEOUT);
+            if (v != null)
+                setTimeoutHandlerTimeout(v);
+
+        } catch (InvalidPathException e) {
+            // This is unlikely to happen, but pretty serious if it does.
+            // Since we only put valid paths into the parameters, there should be
+            // no issue retrieving them after the save-load sequence.
+            throw new Interview.Fault(i18n, "rp.badPath", e.getInput(), e.getMessage());
+        }
     }
 
     @Override @SuppressWarnings({"unchecked", "rawtypes"})
@@ -760,13 +777,13 @@ public class RegressionParameters
             data.put(prefix + TIMELIMIT, String.valueOf(timeLimit));
 
         if (reportDir != null)
-            data.put(prefix + REPORTDIR, reportDir.getPath());
+            data.put(prefix + REPORTDIR, reportDir.toString());
 
         if (exclusiveLock != null)
-            data.put(prefix + EXCLUSIVE_LOCK, exclusiveLock.getPath());
+            data.put(prefix + EXCLUSIVE_LOCK, exclusiveLock.toString());
 
         if (nativeDir != null)
-            data.put(prefix + NATIVEDIR, nativeDir.getPath());
+            data.put(prefix + NATIVEDIR, nativeDir.toString());
 
         if (timeoutHandlerClassName != null)
             data.put(prefix + TIMEOUT_HANDLER, timeoutHandlerClassName);
@@ -774,7 +791,7 @@ public class RegressionParameters
         if (timeoutHandlerPath != null) {
             StringBuilder sb = new StringBuilder();
             String sep = "";
-            for (File file: timeoutHandlerPath) {
+            for (Path file: timeoutHandlerPath) {
                 sb.append(sep).append(file);
                 sep = File.pathSeparator;
             }
@@ -963,19 +980,19 @@ public class RegressionParameters
 
     public SearchPath getJavaTestClassPath() {
         if (javaTestClassPath == null) {
-            File jtClsDir = ProductInfo.getJavaTestClassDir();
+            Path jtClsDir = ProductInfo.getJavaTestClassDir().toPath();
             javaTestClassPath = new SearchPath(jtClsDir);
 
-            if (jtClsDir.getName().equals("javatest.jar")) {
-                File installDir = jtClsDir.getParentFile();
+            if (jtClsDir.getFileName().toString().equals("javatest.jar")) {
+                Path installDir = jtClsDir.getParent();
                 // append jtreg.jar or exploded directory to the search path
-                File jtreg = new File(installDir, "jtreg.jar");
-                if (jtreg.exists()) {
+                Path jtreg = installDir.resolve("jtreg.jar");
+                if (Files.exists(jtreg)) {
                     javaTestClassPath.append(jtreg);
                 } else try {
                     // use code source location of this class instead
                     URL location = getClass().getProtectionDomain().getCodeSource().getLocation();
-                    javaTestClassPath.append(new File(location.toURI()));
+                    javaTestClassPath.append(Path.of(location.toURI()));
                 } catch (Exception e) { // including NullPointerException and URISyntaxException
                     throw new RuntimeException("Computation of Java test class-path failed", e);
                 }
@@ -1024,7 +1041,7 @@ public class RegressionParameters
         opts.addAll(getTestVMOptions());
         opts.addAll(getTestJavaOptions());
         if (nativeDir != null)
-            opts.add("-Djava.library.path=" + nativeDir.getAbsolutePath());
+            opts.add("-Djava.library.path=" + nativeDir.toAbsolutePath());
 
         return Collections.unmodifiableList(opts);
     }
@@ -1149,41 +1166,39 @@ public class RegressionParameters
 
     //---------------------------------------------------------------------
 
-    public void setReportDir(File reportDir) {
-        reportDir.getClass(); // null check
-        this.reportDir = reportDir;
+    public void setReportDir(Path reportDir) {
+        this.reportDir = Objects.requireNonNull(reportDir);
     }
 
-    public File getReportDir() {
+    public Path getReportDir() {
         return reportDir;
     }
 
-    private File reportDir;
+    private Path reportDir;
 
     //---------------------------------------------------------------------
 
-    public void setExclusiveLock(File exclusiveLock) {
-        exclusiveLock.getClass(); // null check
-        this.exclusiveLock = exclusiveLock;
+    public void setExclusiveLock(Path exclusiveLock) {
+        this.exclusiveLock = Objects.requireNonNull(exclusiveLock);
     }
 
-    public File getExclusiveLock() {
+    public Path getExclusiveLock() {
         return exclusiveLock;
     }
 
-    private File exclusiveLock;
+    private Path exclusiveLock;
 
     //---------------------------------------------------------------------
 
-    public void setNativeDir(File nativeDir) {
+    public void setNativeDir(Path nativeDir) {
         this.nativeDir = nativeDir;
     }
 
-    public File getNativeDir() {
+    public Path getNativeDir() {
         return nativeDir;
     }
 
-    private File nativeDir;
+    private Path nativeDir;
 
     //---------------------------------------------------------------------
 
@@ -1205,21 +1220,20 @@ public class RegressionParameters
         this.timeoutHandlerPath = new ArrayList<>();
         for (String f: timeoutHandlerPath.split(File.pathSeparator)) {
             if (f.length() > 0) {
-                this.timeoutHandlerPath.add(new File(f));
+                this.timeoutHandlerPath.add(Path.of(f));
             }
         }
     }
 
-    public void setTimeoutHandlerPath(List<File> timeoutHandlerPath) {
-        timeoutHandlerPath.getClass(); // null check
-        this.timeoutHandlerPath = timeoutHandlerPath;
+    public void setTimeoutHandlerPath(List<Path> timeoutHandlerPath) {
+        this.timeoutHandlerPath = Objects.requireNonNull(timeoutHandlerPath);
     }
 
-    List<File> getTimeoutHandlerPath() {
+    List<Path> getTimeoutHandlerPath() {
         return timeoutHandlerPath;
     }
 
-    private List<File> timeoutHandlerPath;
+    private List<Path> timeoutHandlerPath;
 
     //---------------------------------------------------------------------
 
@@ -1239,15 +1253,15 @@ public class RegressionParameters
 
     //---------------------------------------------------------------------
 
-    public void setMatchLists(File[] files) {
+    public void setMatchLists(Path[] files) {
         this.matchLists = Arrays.asList(files);
     }
 
-    List<File> getMatchLists() {
+    List<Path> getMatchLists() {
         return Collections.unmodifiableList(matchLists);
     }
 
-    private List<File> matchLists;
+    private List<Path> matchLists;
 
     //---------------------------------------------------------------------
 
@@ -1331,7 +1345,7 @@ public class RegressionParameters
             put(map, "test.jdk", getTestJDK(), JDK::getAbsolutePath);
             put(map, "compile.jdk", getCompileJDK(), JDK::getAbsolutePath);
             put(map, "test.timeout.factor", getTimeoutFactor(), String::valueOf);
-            put(map, "test.nativepath", getNativeDir(), File::getAbsolutePath);
+            put(map, "test.nativepath", getNativeDir(), p -> p.toAbsolutePath().toString());
             put(map, "test.root", getTestSuite().getRootDir(), File::getAbsolutePath);
             basicTestProperties = map;
         }
@@ -1372,4 +1386,6 @@ public class RegressionParameters
     private List<String> retainArgs;
     private final Set<Integer> retainStatusSet = new HashSet<>(4);
     private Pattern retainFilesPattern;
+
+    private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(RegressionParameters.class);
 }

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionTestSuite.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ public class RegressionTestSuite extends TestSuite
     }
 
     public GroupManager getGroupManager(PrintWriter out) throws IOException {
-        GroupManager g = new GroupManager(out, getRootDir(), properties.getGroupFiles());
+        GroupManager g = new GroupManager(out, getRootDir().toPath(), properties.getGroupFiles());
         RegressionTestFinder tf = (RegressionTestFinder) getTestFinder();
         g.setAllowedExtensions(tf.getAllowedExtensions());
         g.setIgnoredDirectories(tf.getIgnoredDirectories());

--- a/src/share/classes/com/sun/javatest/regtest/config/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/config/i18n.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ gm.group.includes.itself=group includes itself
 gm.group.not.found=group not found: {0}
 gm.group.prefix=group {0}: {2}
 gm.invalid.name.for.group=invalid name for group
+
+rp.badPath="Bad path: {0}: {1}
 
 tm.badGroupSpec=Bad group spec: {0}
 tm.badGroupTestSuite=Group spec does not specify a valid test suite: {0}

--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,6 +58,7 @@ import com.sun.javatest.regtest.config.ExecMode;
 import com.sun.javatest.regtest.config.Modules;
 import com.sun.javatest.regtest.config.OS;
 import com.sun.javatest.regtest.config.ParseException;
+import com.sun.javatest.regtest.util.FileUtils;
 import com.sun.javatest.regtest.util.StringUtils;
 
 
@@ -134,7 +137,7 @@ public abstract class Action extends ActionHelper {
     protected Map<String, String> getEnvVars(boolean nativeCode) {
         Map<String, String> envVars = script.getEnvVars();
         if (nativeCode) {
-            File nativeDir = script.getNativeDir();
+            Path nativeDir = script.getNativeDir();
             if (nativeDir != null) {
                 envVars = new LinkedHashMap<>(envVars);
                 String libPathName;
@@ -156,9 +159,9 @@ public abstract class Action extends ActionHelper {
                 }
                 String libPath = envVars.get(libPathName);
                 if (libPath == null) {
-                    envVars.put(libPathName, nativeDir.getPath());
+                    envVars.put(libPathName, nativeDir.toString());
                 } else {
-                    envVars.put(libPathName, libPath + File.pathSeparator + nativeDir.getPath());
+                    envVars.put(libPathName, libPath + File.pathSeparator + nativeDir);
                 }
                 envVars = Collections.unmodifiableMap(envVars);
             }
@@ -172,9 +175,9 @@ public abstract class Action extends ActionHelper {
     }
 
     public File getArgFile() {
-        File f = script.absTestWorkFile(getName() + "." + script.getNextSerial() + ".jta");
-        f.getParentFile().mkdirs();
-        return f;
+        Path f = script.absTestWorkFile(getName() + "." + script.getNextSerial() + ".jta");
+        FileUtils.createDirectories(f.getParent());
+        return f.toFile();
     }
 
    //------------------- parsing -----------------------------------------------
@@ -277,15 +280,14 @@ public abstract class Action extends ActionHelper {
      * @throws TestRunException if a problem occurred adding this grant entry.
      */
     protected File addGrantEntries(File fileName, File argFile) throws TestRunException {
-        File newPolicy = new File(script.absTestScratchDir(),
-                                  (fileName.getName()) + "_new");
+        File newPolicy = script.absTestScratchDir().resolve(fileName.getName() + "_new").toFile();
 
         try {
             try (FileWriter fw = new FileWriter(newPolicy)) {
                 fw.write("// The following grant entries were added by jtreg.  Do not edit." + LINESEP);
                 fw.write("grant {" + LINESEP);
                 fw.write("    permission java.io.FilePermission \""
-                        + script.absTestClsTopDir().getPath().replace(FILESEP, "{/}")
+                        + script.absTestClsTopDir().toString().replace(FILESEP, "{/}")
                         + "${/}-\", \"read\";" + LINESEP);
                 if (argFile != null) {
                     fw.write("    permission java.io.FilePermission \""
@@ -294,7 +296,7 @@ public abstract class Action extends ActionHelper {
                 }
                 fw.write("};" + LINESEP);
 
-                List<File> libs = new ArrayList<>();
+                List<Path> libs = new ArrayList<>();
                 libs.addAll(script.getJavaTestClassPath().asList());
                 if (script.isJUnitRequired()) {
                     libs.addAll(script.getJUnitPath().asList());
@@ -302,8 +304,8 @@ public abstract class Action extends ActionHelper {
                 if (script.isTestNGRequired()) {
                     libs.addAll(script.getTestNGPath().asList());
                 }
-                for (File lib : libs) {
-                    fw.write("grant codebase \"" + lib.toURI() + "\" {" + LINESEP);
+                for (Path lib : libs) {
+                    fw.write("grant codebase \"" + lib.toUri() + "\" {" + LINESEP);
                     fw.write("    permission java.security.AllPermission;" + LINESEP);
                     fw.write("};" + LINESEP);
                 }
@@ -320,9 +322,9 @@ public abstract class Action extends ActionHelper {
                 }
             }
         } catch (IOException e) {
-            throw new TestRunException(POLICY_WRITE_PROB + newPolicy.toString());
+            throw new TestRunException(POLICY_WRITE_PROB + newPolicy);
         } catch (SecurityException e) {
-            throw new TestRunException(POLICY_SM_PROB + newPolicy.toString());
+            throw new TestRunException(POLICY_SM_PROB + newPolicy);
         }
 
         return newPolicy;
@@ -342,7 +344,7 @@ public abstract class Action extends ActionHelper {
     protected File parsePolicy(String value) throws ParseException {
         if ((value == null) || value.equals(""))
             throw new ParseException(MAIN_NO_POLICY_NAME);
-        File policyFile = new File(script.absTestSrcDir(), value);
+        File policyFile = script.absTestSrcDir().resolve(value).toFile();
         if (!policyFile.exists())
             throw new ParseException(MAIN_CANT_FIND_POLICY + policyFile);
         return policyFile;
@@ -515,41 +517,41 @@ public abstract class Action extends ActionHelper {
             return Collections.emptySet();
 
         Set<String> results = new LinkedHashSet<>();
-        for (File dir: pp.asList()) {
+        for (Path dir: pp.asList()) {
             getModules(dir, results);
         }
         return results;
     }
 
-    private void getModules(File dir, Set<String> results) {
-        for (File f: dir.listFiles()) {
+    private void getModules(Path dir, Set<String> results) {
+        for (Path f: FileUtils.listFiles(dir)) {
             if (isModule(f)) {
-                results.add(f.getName());
-            } else if (f.getName().endsWith(".jar")) {
+                results.add(f.getFileName().toString());
+            } else if (f.getFileName().toString().endsWith(".jar")) {
                 results.add(getAutomaticModuleName(f));
             }
         }
     }
 
-    private boolean isModule(File f) {
-        if (f.isDirectory()) {
-            if (script.systemModules.contains(f.getName())) {
+    private boolean isModule(Path f) {
+        if (Files.isDirectory(f)) {
+            if (script.systemModules.contains(f.getFileName().toString())) {
                 return true;
             }
-            if (new File(f, "module-info.class").exists())
+            if (Files.exists(f.resolve("module-info.class")))
                 return true;
-            if (new File(f, "module-info.java").exists())
+            if (Files.exists(f.resolve("module-info.java")))
                 return true;
         }
         return false;
     }
 
-    private static final Map<File, String> automaticNames = new ConcurrentHashMap<>();
+    private static final Map<Path, String> automaticNames = new ConcurrentHashMap<>();
 
     // see java.lang.module.ModulePath.deriveModuleDescriptor
     // See ModuleFinder.of for info on determining automatic module names
     //    https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/module/ModuleFinder.html#of(java.nio.file.Path...)
-    private String getAutomaticModuleName(File f) {
+    private String getAutomaticModuleName(Path f) {
         // Step 0: see if already cached
         String cached = automaticNames.get(f);
         if (cached != null) {
@@ -557,7 +559,7 @@ public abstract class Action extends ActionHelper {
         }
 
         // Step 1: check for Automatic-Module-Name in thge main jar file manifest
-        try (JarFile jar = new JarFile(f)) {
+        try (JarFile jar = new JarFile(f.toFile())) {
             Manifest mf = jar.getManifest();
             Attributes attrs = mf.getMainAttributes();
             String amn = attrs.getValue("Automatic-Module-Name");
@@ -570,7 +572,7 @@ public abstract class Action extends ActionHelper {
         }
 
         // Step 2: infer the name from the jar file name
-        String fn = f.getName();
+        String fn = f.getFileName().toString();
 
         // drop .jar
         String mn = fn.substring(0, fn.length()-4);

--- a/src/share/classes/com/sun/javatest/regtest/exec/ActionRecorder.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ActionRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package com.sun.javatest.regtest.exec;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -83,7 +84,7 @@ public class ActionRecorder {
             pw.println(line);
     }
 
-    public void java(Map<String, String> envArgs, String javaCmd, Map<String, String> javaProps, List<String> javaOpts, String className, List<String> classArgs) {
+    public void java(Map<String, String> envArgs, Path javaCmd, Map<String, String> javaProps, List<String> javaOpts, String className, List<String> classArgs) {
         initPW();
         printWorkDir();
         // Env variables
@@ -92,7 +93,7 @@ public class ActionRecorder {
         }
         // Java executable
         String indent = "    ";
-        pw.println(indent + escape(javaCmd) + CONT);
+        pw.println(indent + escape(javaCmd.toString()) + CONT);
         // System properties
         indent += "    ";
         for (Map.Entry<String, String> e: javaProps.entrySet()) {
@@ -122,7 +123,7 @@ public class ActionRecorder {
         pw.println();
     }
 
-    void javac(Map<String, String> envArgs, String javacCmd, List<String> javacVMOpts, Map<String, String> javacProps, List<String> javacArgs) {
+    void javac(Map<String, String> envArgs, Path javacCmd, List<String> javacVMOpts, Map<String, String> javacProps, List<String> javacArgs) {
         initPW();
         printWorkDir();
         // Env variables
@@ -131,7 +132,7 @@ public class ActionRecorder {
         }
         // javac executable
         String indent = "    ";
-        pw.println(indent + escape(javacCmd) + CONT);
+        pw.println(indent + escape(javacCmd.toString()) + CONT);
         indent += "    ";
         // javac VM Options
         for (String o: javacVMOpts) {

--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -53,7 +53,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -887,7 +886,7 @@ public class Agent {
         }
 
         private static String getKey(File dir, JDK jdk, List<String> vmOpts) {
-            return (dir.getAbsolutePath() + " " + jdk.getAbsoluteFile() + " " + StringUtils.join(vmOpts, " "));
+            return (dir.getAbsolutePath() + " " + jdk.getAbsoluteHomeDirectory() + " " + StringUtils.join(vmOpts, " "));
         }
 
         private final Logger logger;

--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ public class Agent {
             this.logger = logger;
 
             List<String> cmd = new ArrayList<>();
-            cmd.add(jdk.getJavaProg().getPath());
+            cmd.add(jdk.getJavaProg().toString());
             cmd.addAll(vmOpts);
             if (policyFile != null)
                 cmd.add("-Djava.security.policy=" + policyFile.toURI());

--- a/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
@@ -160,7 +160,7 @@ public class AppletAction extends Action
 
     @Override
     public Set<File> getSourceFiles() {
-        return Collections.singleton(new File(script.absTestSrcDir(), htmlFN));
+        return Set.of(script.absTestSrcDir().resolve(htmlFN).toFile());
     }
 
     /**
@@ -238,7 +238,7 @@ public class AppletAction extends Action
         // "test.src" and "test.classes", respectively"
         List<String> command = new ArrayList<>(6);
         Map<String, String> env = new LinkedHashMap<>();
-        command.add(script.getJavaProg());
+        command.add(script.getJavaProg().toString());
         command.add("-classpath");
         command.add(execPaths.get(PathKind.CLASSPATH).toString());
 
@@ -296,7 +296,7 @@ public class AppletAction extends Action
 
             // RUN THE APPLET WRAPPER CLASS
             ProcessCommand cmd = new ProcessCommand();
-            cmd.setExecDir(script.absTestScratchDir());
+            cmd.setExecDir(script.absTestScratchDir().toFile());
 
             // Set the exit codes and their associated strings.  Note that we
             // require the use of a non-zero exit code for a passed test so
@@ -404,7 +404,7 @@ public class AppletAction extends Action
             String line;
             StringBuilder sb = new StringBuilder();
             //String htmlFN = script.relTestSrcDir() + FILESEP + args[0];
-            htmlFN = new File(script.absTestSrcDir(), htmlFN).getPath();
+            htmlFN = script.absTestSrcDir().resolve(htmlFN).toString();
             try (BufferedReader in = new BufferedReader(new FileReader(htmlFN))) {
                 while ((line = in.readLine()) != null) {
                     sb.append(line);

--- a/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package com.sun.javatest.regtest.exec;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -42,6 +43,7 @@ import com.sun.javatest.regtest.config.Locations;
 import com.sun.javatest.regtest.config.Locations.ClassLocn;
 import com.sun.javatest.regtest.config.Locations.LibLocn;
 import com.sun.javatest.regtest.config.ParseException;
+import com.sun.javatest.regtest.util.FileUtils;
 
 import static com.sun.javatest.regtest.RStatus.passed;
 
@@ -139,7 +141,7 @@ public class BuildAction extends Action
             // the arguments to build are classnames or package names with wildcards
             try {
                 for (ClassLocn cl: script.locations.locateClasses(arg)) {
-                    files.add(cl.absSrcFile);
+                    files.add(cl.absSrcFile.toFile());
                 }
             } catch (Locations.Fault ignore) {
             }
@@ -190,9 +192,10 @@ public class BuildAction extends Action
         for (String arg: args) {
             try {
                 for (ClassLocn cl: script.locations.locateClasses(arg)) {
-                    if (cl.absSrcFile.lastModified() > now) {
+                    long sfMillis = FileUtils.getLastModifiedTime(cl.absSrcFile).toMillis();
+                    if (sfMillis > now) {
                         pw.println(String.format(BUILD_FUTURE_SOURCE, cl.absSrcFile,
-                                DateFormat.getDateTimeInstance().format(new Date(cl.absSrcFile.lastModified()))));
+                                DateFormat.getDateTimeInstance().format(new Date(sfMillis))));
                         pw.println(BUILD_FUTURE_SOURCE_2);
                     }
                     if (!cl.isUpToDate()) {
@@ -216,8 +219,8 @@ public class BuildAction extends Action
         } else {
             status = null;
             // ensure that all directories are created for any library classes
-            for (File dir: script.locations.absLibClsList(LibLocn.Kind.PACKAGE)) {
-                dir.mkdirs();
+            for (Path dir: script.locations.absLibClsList(LibLocn.Kind.PACKAGE)) {
+                FileUtils.createDirectories(dir);
             }
 
             // compile libraries first
@@ -269,7 +272,7 @@ public class BuildAction extends Action
                     if (files == null) {
                         filesForModule.put(cl.optModule, files = new ArrayList<>());
                     }
-                    files.add(cl.absSrcFile);
+                    files.add(cl.absSrcFile.toFile());
                 }
                 for (Map.Entry<String, List<File>> e: filesForModule.entrySet()) {
                     Status s = compileFiles(libLocn, false, e.getKey(), e.getValue());
@@ -309,7 +312,7 @@ public class BuildAction extends Action
     private List<File> getSrcFiles(List<ClassLocn> classLocns) {
         List<File> files = new ArrayList<>();
         for (ClassLocn cl: classLocns) {
-            files.add(cl.absSrcFile);
+            files.add(cl.absSrcFile.toFile());
         }
         return files;
     }

--- a/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
@@ -71,7 +71,7 @@ public class CleanAction extends Action
      * @param reason Indication of why this action was invoked.
      * @param script The script.
      * @exception  ParseException If the options or arguments are not expected
-     *             for the action or are improperly formated.
+     *             for the action or are improperly formatted.
      */
     @Override
     public void init(Map<String,String> opts, List<String> args, String reason,
@@ -168,7 +168,7 @@ public class CleanAction extends Action
     public Set<File> getSourceFiles() {
         Set<File> files = new LinkedHashSet<File>();
         for (String arg: args) {
-            // the arguments to clean are classnames or package names with wildcards
+            // the arguments to clean are class names or package names with wildcards
             try {
                 for (ClassLocn cl: script.locations.locateClasses(arg)) {
                     if (Files.exists(cl.absSrcFile))

--- a/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.javatest.regtest.exec;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -124,7 +125,7 @@ public class CleanAction extends Action
                     // clean any package
                     String path = arg.substring(0, arg.length() -2);
                     path = path.replace('.', File.separatorChar);
-                    File dir = script.absTestClsDir();
+                    File dir = script.absTestClsDir().toFile();
                     if (!path.equals(""))
                         dir = new File(dir, path);
 
@@ -150,8 +151,8 @@ public class CleanAction extends Action
                     }
                 } else {
                     // clean class file
-                    File victim = new File(script.absTestClsDir(),
-                                           arg.replace('.', File.separatorChar) + ".class");
+                    File victim = script.absTestClsDir().resolve(
+                                           arg.replace('.', File.separatorChar) + ".class").toFile();
                     recorder.exec("rm -f " + victim);
                     if (victim.exists() && !victim.delete())
                         return error(CLEAN_RM_FAILED + victim);
@@ -170,8 +171,8 @@ public class CleanAction extends Action
             // the arguments to clean are classnames or package names with wildcards
             try {
                 for (ClassLocn cl: script.locations.locateClasses(arg)) {
-                    if (cl.absSrcFile.exists())
-                        files.add(cl.absSrcFile);
+                    if (Files.exists(cl.absSrcFile))
+                        files.add(cl.absSrcFile.toFile());
                 }
             } catch (Locations.Fault ignore) {
             }

--- a/src/share/classes/com/sun/javatest/regtest/exec/DefaultTimeoutHandler.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/DefaultTimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import com.sun.javatest.regtest.TimeoutHandler;
 
@@ -39,7 +41,7 @@ import com.sun.javatest.regtest.TimeoutHandler;
  */
 public class DefaultTimeoutHandler extends TimeoutHandler {
 
-    public DefaultTimeoutHandler(PrintWriter log, File outputDir, File testJdk) {
+    public DefaultTimeoutHandler(PrintWriter log, File outputDir, Path testJdk) {
         super(log, outputDir, testJdk);
     }
 
@@ -56,14 +58,14 @@ public class DefaultTimeoutHandler extends TimeoutHandler {
         try {
             log.println("Running jstack on process " + pid);
 
-            File jstack = findJstack();
+            Path jstack = findJstack();
             if (jstack == null) {
-                log.println("Warning: Could not find jstack in: " + testJdk.getAbsolutePath());
+                log.println("Warning: Could not find jstack in: " + testJdk.toAbsolutePath());
                 log.println("Will not dump jstack output.");
                 return;
             }
 
-            ProcessBuilder pb = new ProcessBuilder(jstack.getAbsolutePath(), pid + "");
+            ProcessBuilder pb = new ProcessBuilder(jstack.toAbsolutePath().toString(), pid + "");
             pb.redirectErrorStream(true);
 
             Process p = pb.start();
@@ -79,11 +81,11 @@ public class DefaultTimeoutHandler extends TimeoutHandler {
         }
     }
 
-    private File findJstack() {
-        File jstack = new File(new File(testJdk, "bin"), "jstack");
-        if (!jstack.exists()) {
-            jstack = new File(new File(testJdk, "bin"), "jstack.exe");
-            if (!jstack.exists()) {
+    private Path findJstack() {
+        Path jstack = testJdk.resolve("bin").resolve("jstack");
+        if (!Files.exists(jstack)) {
+            jstack = testJdk.resolve("bin").resolve("jstack.exe");
+            if (!Files.exists(jstack)) {
                 return null;
             }
         }

--- a/src/share/classes/com/sun/javatest/regtest/exec/DefaultTimeoutHandler.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/DefaultTimeoutHandler.java
@@ -60,7 +60,7 @@ public class DefaultTimeoutHandler extends TimeoutHandler {
 
             Path jstack = findJstack();
             if (jstack == null) {
-                log.println("Warning: Could not find jstack in: " + testJdk.toAbsolutePath());
+                log.println("Warning: Could not find jstack in: " + testJdk.getAbsolutePath());
                 log.println("Will not dump jstack output.");
                 return;
             }
@@ -82,9 +82,10 @@ public class DefaultTimeoutHandler extends TimeoutHandler {
     }
 
     private Path findJstack() {
-        Path jstack = testJdk.resolve("bin").resolve("jstack");
+        Path p = testJdk.toPath();
+        Path jstack = p.resolve("bin").resolve("jstack");
         if (!Files.exists(jstack)) {
-            jstack = testJdk.resolve("bin").resolve("jstack.exe");
+            jstack = p.resolve("bin").resolve("jstack.exe");
             if (!Files.exists(jstack)) {
                 return null;
             }

--- a/src/share/classes/com/sun/javatest/regtest/exec/Lock.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Lock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileLock;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -46,8 +47,8 @@ public abstract class Lock {
     public static synchronized Lock get(RegressionParameters params) {
         Lock lock = locks.get(params);
         if (lock == null) {
-            File el = params.getExclusiveLock();
-            lock = (el == null) ? new SimpleLock() : new MultiVMLock(el);
+            Path el = params.getExclusiveLock();
+            lock = (el == null) ? new SimpleLock() : new MultiVMLock(el.toFile());
             locks.put(params, lock);
         }
         return lock;

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -429,7 +430,7 @@ public class MainAction extends Action
             env.put("CLASSPATH", cp.toString());
         }
 
-        String javaCmd = script.getJavaProg();
+        Path javaCmd = script.getJavaProg();
         JDKOpts javaOpts = new JDKOpts();
 
         if (!useCLASSPATH) {
@@ -485,7 +486,7 @@ public class MainAction extends Action
         classArgs.addAll(runClassArgs);
 
         List<String> command = new ArrayList<>();
-        command.add(javaCmd);
+        command.add(javaCmd.toString());
         for (Map.Entry<String,String> e: javaProps.entrySet())
             command.add("-D" + e.getKey() + "=" + e.getValue());
         command.addAll(filterJavaOpts(javaOpts.toList()));
@@ -506,7 +507,7 @@ public class MainAction extends Action
 
             // RUN THE MAIN WRAPPER CLASS
             ProcessCommand cmd = new ProcessCommand();
-            cmd.setExecDir(script.absTestScratchDir());
+            cmd.setExecDir(script.absTestScratchDir().toFile());
 
             // Set the exit codes and their associated strings.  Note that we
             // require the use of a non-zero exit code for a passed test so
@@ -570,7 +571,7 @@ public class MainAction extends Action
                 script.getExecutionPaths(multiModule, runModuleName, useBootClassPath, true);
 
         JDK jdk = script.getTestJDK();
-        List<File> stdLibs = new SearchPath()
+        List<Path> stdLibs = new SearchPath()
                 .append(script.getJavaTestClassPath())
                 .append(jdk.getJDKClassPath())
                 .append(script.getJUnitPath())
@@ -600,7 +601,7 @@ public class MainAction extends Action
         // "test.src" and "test.classes", respectively"
         Map<String, String> javaProps = script.getTestProperties();
 
-        String javaProg = script.getJavaProg();
+        Path javaProg = script.getJavaProg();
         List<String> javaArgs = new ArrayList<>();
         javaArgs.add("-classpath");
         javaArgs.add(classpath.toString());

--- a/src/share/classes/com/sun/javatest/regtest/exec/ModuleConfig.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ModuleConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package com.sun.javatest.regtest.exec;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -237,32 +238,32 @@ public class ModuleConfig {
 
         if (modulePath != null) {
             String label = "module path:";
-            for (File file: modulePath.asList()) {
-                table.addRow(label, file.getPath());
+            for (Path file: modulePath.asList()) {
+                table.addRow(label, file.toString());
                 label = null;
             }
         }
 
         if (sourcePath != null) {
             String label = "source path:";
-            for (File file: sourcePath.asList()) {
-                table.addRow(label, file.getPath());
+            for (Path file: sourcePath.asList()) {
+                table.addRow(label, file.toString());
                 label = null;
             }
         }
 
         if (classPath != null) {
             String label = "class path:";
-            for (File file: classPath.asList()) {
-                table.addRow(label, file.getPath());
+            for (Path file: classPath.asList()) {
+                table.addRow(label, file.toString());
                 label = null;
             }
         }
 
         if (bootClassPathAppend != null) {
             String label = "boot class path (append):";
-            for (File file: bootClassPathAppend.asList()) {
-                table.addRow(label, file.getPath());
+            for (Path file: bootClassPathAppend.asList()) {
+                table.addRow(label, file.toString());
                 label = null;
             }
         }
@@ -271,8 +272,8 @@ public class ModuleConfig {
             String label = "patch:";
             for (Map.Entry<String, SearchPath> e: patch.entrySet()) {
                 String module = e.getKey();
-                for (File file: e.getValue().asList()) {
-                    table.addRow(label, module, file.getPath());
+                for (Path file: e.getValue().asList()) {
+                    table.addRow(label, module, file.toString());
                     label = null;
                     module = null;
                 }

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -334,7 +334,7 @@ public class RegressionScript extends Script {
     private void printJDKInfo(PrintWriter pw, String label, JDK jdk, List<String> opts) {
         pw.print(label);
         pw.print(": ");
-        pw.println(jdk.getAbsoluteFile());
+        pw.println(jdk.getAbsoluteHomeDirectory());
         String v = jdk.getVersionText(opts, pw::println);
         if (v.length() > 0) {
             pw.println(v);

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -25,19 +25,19 @@
 
 package com.sun.javatest.regtest.exec;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -76,6 +76,7 @@ import com.sun.javatest.regtest.config.RegressionParameters;
 import com.sun.javatest.regtest.config.RegressionTestSuite;
 import com.sun.javatest.regtest.report.TestNGReporter;
 import com.sun.javatest.regtest.tool.Version;
+import com.sun.javatest.regtest.util.FileUtils;
 import com.sun.javatest.regtest.util.StringUtils;
 
 import static com.sun.javatest.regtest.RStatus.error;
@@ -184,7 +185,7 @@ public class RegressionScript extends Script {
                 needJUnit = true;
                 needTestNG = true;
             } else {
-                for (Action a: actionList) {
+                for (Action a : actionList) {
                     if (a instanceof JUnitAction) {
                         needJUnit = true;
                     } else if (a instanceof TestNGAction) {
@@ -205,8 +206,8 @@ public class RegressionScript extends Script {
             } else {
                 // check actions for test-specific modules
                 actionLoop:
-                for (Action a: actionList) {
-                    for (String m: a.getModules()) {
+                for (Action a : actionList) {
+                    for (String m : a.getModules()) {
                         if (systemModules.contains(m)) {
                             usePatchModules = true;
                             break actionLoop;
@@ -235,7 +236,7 @@ public class RegressionScript extends Script {
                     printJDKInfo(msgPW, "test JDK", getTestJDK(), getTestVMOptions());
                 }
 
-                for (LibLocn lib: locations.getLibs()) {
+                for (LibLocn lib : locations.getLibs()) {
                     String kind;
                     switch (lib.kind) {
                         case PACKAGE:
@@ -257,14 +258,14 @@ public class RegressionScript extends Script {
                     if (lib.absSrcDir != null) {
                         msgPW.println("   source directory: " + lib.absSrcDir);
                     }
-                    if (lib.absClsDir.isFile() && lib.absClsDir.getName().endsWith(".jar")) {
+                    if (Files.isRegularFile(lib.absClsDir) && lib.absClsDir.getFileName().toString().endsWith(".jar")) {
                         msgPW.println("   jar file: " + lib.absClsDir);
                     } else {
                         msgPW.println("   class directory: " + lib.absClsDir);
                     }
                 }
 
-                while (! actionList.isEmpty()) {
+                while (!actionList.isEmpty()) {
                     Action action = actionList.remove();
                     status = action.run();
                     if (status.getType() != Status.PASSED)
@@ -283,8 +284,19 @@ public class RegressionScript extends Script {
                 | Modules.Fault
                 | ParseActionsException
                 | TestRunException
-                | TestSuite.Fault e) {
+                | TestSuite.Fault
+                | FileUtils.NIOFileOperationException e) {
             status = error(e.getMessage());
+        } catch (UncheckedIOException e) {
+            String msg = "IO exception: " + e.getMessage();
+            if (e.getCause() != null)
+                msg += " (" + e.getCause() + ")";
+            status = error(msg);
+        } catch (InvalidPathException e) {
+            String msg = "Invalid path: " + e.getInput() + "; " + e.getMessage();
+            if (e.getCause() != null)
+                msg += " (" + e.getCause() + ")";
+            status = error(msg);
         } finally {
             int elapsed = (int) (System.currentTimeMillis() - started);
             int millis = (elapsed % 1000);
@@ -684,7 +696,7 @@ public class RegressionScript extends Script {
     /**
      * Path to native components.
      */
-    File getNativeDir() {
+    Path getNativeDir() {
         return params.getNativeDir();
     }
 
@@ -721,29 +733,29 @@ public class RegressionScript extends Script {
 
     //----------------------- computing paths ---------------------------------
 
-    File absTestWorkFile(String name) {
+    Path absTestWorkFile(String name) {
         return locations.absTestWorkFile(name);
     }
 
-    File absTestSrcDir() {
+    Path absTestSrcDir() {
         return locations.absTestSrcDir();
     } // absTestSrcDir()
 
-    File absTestClsDir() {
+    Path absTestClsDir() {
         return locations.absTestClsDir();
     } // absTestClsDir()
 
-    File absTestScratchDir() {
-        return scratchDirectory.dir.getAbsoluteFile();
+    Path absTestScratchDir() {
+        return scratchDirectory.dir.toPath().toAbsolutePath();
     } // absTestScratchDir()
 
-    File absTestClsTopDir() {
+    Path absTestClsTopDir() {
         return locations.absBaseClsDir();
     } // absTestClsTopDir()
 
-    private boolean useBootClassPath(File classdir) throws TestClassException {
+    private boolean useBootClassPath(Path classdir) throws TestClassException {
         try {
-            String rel = locations.absBaseClsDir().toURI().relativize(classdir.toURI()).getPath();
+            String rel = locations.absBaseClsDir().toUri().relativize(classdir.toFile().toURI()).getPath();
             return testSuite.useBootClassPath(rel);
         } catch (TestSuite.Fault f) {
             throw new TestClassException(f.toString());
@@ -773,7 +785,7 @@ public class RegressionScript extends Script {
             if (multiModule) {
                 msp.append(locations.absTestSrcDir());
             } else {
-                File testSrcDir = locations.absTestSrcDir(module);
+                Path testSrcDir = locations.absTestSrcDir(module);
                 sp.append(testSrcDir);
                 // Ideally, the source directory need only go on the source path
                 // but some tests rely on precompiled .class files existing in
@@ -801,7 +813,7 @@ public class RegressionScript extends Script {
             if (multiModule)
                 msp.append(libLocn.absSrcDir);
             else if (module != null)
-                sp.append(new File(libLocn.absSrcDir, module));
+                sp.append(libLocn.absSrcDir.resolve(module));
         }
 
         if (module == null) {
@@ -826,7 +838,7 @@ public class RegressionScript extends Script {
                 // Put necessary jar files onto the module path as automatic modules.
                 // We cannot use the ${jtreg.home}/lib directory directly since it contains
                 // other jar files which are not valid as automatic modules.
-                File md = workDir.getFile("modules");
+                Path md = workDir.getFile("modules").toPath();
                 if (needJUnit)
                     install(params.getJUnitPath(), md);
                 if (needTestNG)
@@ -927,7 +939,7 @@ public class RegressionScript extends Script {
                 // Put necessary jar files onto the module path as automatic modules.
                 // We cannot use the ${jtreg.home}/lib directory directly since it contains
                 // other jar files which are not valid as automatic modules.
-                File md = workDir.getFile("modules");
+                Path md = workDir.getFile("modules").toPath();
                 if (needJUnit)
                     install(params.getJUnitPath(), md);
                 if (needTestNG)
@@ -976,26 +988,26 @@ public class RegressionScript extends Script {
         return map;
     }
 
-    private void install(SearchPath path, File dir) throws TestRunException {
+    private void install(SearchPath path, Path dir) throws TestRunException {
         synchronized (params.getWorkDirectory()) { // avoid multiple tests doing simultaneous install
-            if (dir.exists()) {
-                if (!dir.isDirectory())
+            if (Files.exists(dir)) {
+                if (!Files.isDirectory(dir))
                     throw new TestRunException("modules in work directory is not a directory");
             } else {
-                dir.mkdirs();
+                FileUtils.createDirectories(dir);
             }
 
-            for (File jar: path.asList()) {
-                File target = new File(dir, jar.getName());
-                if (target.exists()
-                        && target.length() == jar.length()
-                        && target.lastModified() == jar.lastModified()) {
+            for (Path jar: path.asList()) {
+                Path target = dir.resolve(jar.getFileName());
+                if (Files.exists(target)
+                        && FileUtils.size(target) == FileUtils.size(jar)
+                        && FileUtils.compareLastModifiedTimes(target, jar) == 0) {
                     return;
                 }
 
                 // Eventually replace with java.nio.file.Files::copy
-                try (OutputStream out = new BufferedOutputStream(new FileOutputStream(target));
-                        InputStream in = new BufferedInputStream(new FileInputStream(jar))) {
+                try (OutputStream out = Files.newOutputStream(target);
+                        InputStream in = Files.newInputStream(jar)) {
                     byte[] buf = new byte[8192];
                     int n;
                     while ((n = in.read(buf)) != -1) {
@@ -1004,7 +1016,11 @@ public class RegressionScript extends Script {
                 } catch (IOException e) {
                     throw new TestRunException("cannot init modules directory", e);
                 }
-                target.setLastModified(jar.lastModified());
+                try {
+                    Files.setLastModifiedTime(target, FileUtils.getLastModifiedTime(jar));
+                } catch (IOException e) {
+                    throw new TestRunException("cannot set last modified time for " + target, e);
+                }
             }
         }
     }
@@ -1018,10 +1034,10 @@ public class RegressionScript extends Script {
     }
 
     boolean hasTestPatchMods() {
-        File testModulesDir = locations.absTestPatchDir();
-        if (testModulesDir.isDirectory()) {
-            for (File f: testModulesDir.listFiles()) {
-                if (f.isDirectory())
+        Path testModulesDir = locations.absTestPatchDir();
+        if (Files.isDirectory(testModulesDir)) {
+            for (Path f : FileUtils.listFiles(testModulesDir)) {
+                if (Files.isDirectory(f))
                     return true;
             }
         }
@@ -1034,10 +1050,10 @@ public class RegressionScript extends Script {
     }
 
     boolean hasTestUserMods() {
-        File testModulesDir = locations.absTestModulesDir();
-        if (testModulesDir.isDirectory()) {
-            for (File f: testModulesDir.listFiles()) {
-                if (f.isDirectory())
+        Path testModulesDir = locations.absTestModulesDir();
+        if (Files.isDirectory(testModulesDir)) {
+            for (Path f : FileUtils.listFiles(testModulesDir)) {
+                if (Files.isDirectory(f))
                     return true;
             }
         }
@@ -1117,8 +1133,8 @@ public class RegressionScript extends Script {
         return getTestJDK().getVersion(params, msgPW::println);
     }
 
-    String getJavaProg() {
-        return params.getTestJDK().getJavaProg().getPath();
+    Path getJavaProg() {
+        return params.getTestJDK().getJavaProg();
     }
 
     //--------------------------------------------------------------------------
@@ -1131,8 +1147,8 @@ public class RegressionScript extends Script {
         return getCompileJDK().getVersion(params, msgPW::println);
     }
 
-    String getJavacProg() {
-        return params.getCompileJDK().getJavacProg().getPath();
+    Path getJavacProg() {
+        return params.getCompileJDK().getJavacProg();
     }
 
     //--------------------------------------------------------------------------
@@ -1144,10 +1160,10 @@ public class RegressionScript extends Script {
         Map<String, String> p = new LinkedHashMap<>(params.getBasicTestProperties());
         // add test-specific properties
         p.put("test.name", testResult.getTestName());
-        p.put("test.file", locations.absTestFile().getPath());
-        p.put("test.src", locations.absTestSrcDir().getPath());
+        p.put("test.file", locations.absTestFile().toString());
+        p.put("test.src", locations.absTestSrcDir().toString());
         p.put("test.src.path", toString(locations.absTestSrcPath()));
-        p.put("test.classes", locations.absTestClsDir().getPath());
+        p.put("test.classes", locations.absTestClsDir().toString());
         p.put("test.class.path", toString(locations.absTestClsPath()));
         if (getExecMode() == ExecMode.AGENTVM) {
             // The following will be added to javac.class.path on the test VM
@@ -1177,11 +1193,17 @@ public class RegressionScript extends Script {
         return Collections.unmodifiableMap(p);
     }
     // where
-    private String toString(List<File> files) {
+    private String toString(List<Path> files) {
         return files.stream()
-                .map(File::getPath)
+                .map(Path::toString)
                 .collect(Collectors.joining(File.pathSeparator));
     }
+//    // where
+//    private String toString(List<File> files) {
+//        return files.stream()
+//                .map(File::getPath)
+//                .collect(Collectors.joining(File.pathSeparator));
+//    }
 
     File getTestRootDir() {
         return params.getTestSuite().getRootDir();
@@ -1197,7 +1219,7 @@ public class RegressionScript extends Script {
         vmOpts.addAll("-classpath", classpath.toString());
         vmOpts.addAll(testVMOpts);
         if (params.getTestJDK().hasModules()) {
-            vmOpts.addAllPatchModules(new SearchPath(params.getWorkDirectory().getFile("patches")));
+            vmOpts.addAllPatchModules(new SearchPath(params.getWorkDirectory().getFile("patches").toPath()));
         }
 
         /*
@@ -1207,7 +1229,7 @@ public class RegressionScript extends Script {
          * record the agents that the script has already obtained for use.
          */
         for (Agent agent: agents) {
-            if (agent.matches(absTestScratchDir(), jdk, vmOpts.toList())) {
+            if (agent.matches(absTestScratchDir().toFile(), jdk, vmOpts.toList())) {
                 return agent;
             }
         }
@@ -1222,7 +1244,7 @@ public class RegressionScript extends Script {
         envVars.put("CLASSPATH", cp.toString());
 
         Agent.Pool p = Agent.Pool.instance(params);
-        Agent agent = p.getAgent(absTestScratchDir(), jdk, vmOpts.toList(), envVars);
+        Agent agent = p.getAgent(absTestScratchDir().toFile(), jdk, vmOpts.toList(), envVars);
         agents.add(agent);
         return agent;
     }
@@ -1269,8 +1291,8 @@ public class RegressionScript extends Script {
 
     //----------internal classes-----------------------------------------------
 
-    void saveScratchFile(File file, File dest) {
-        scratchDirectory.retainFile(file, dest);
+    void saveScratchFile(Path file, Path dest) {
+        scratchDirectory.retainFile(file.toFile(), dest.toFile());
     }
 
     //----------internal classes-----------------------------------------------

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -30,7 +30,6 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -237,7 +236,7 @@ public class ShellAction extends Action
 
             List<String> command = new ArrayList<>();
             if (script.useWindowsSubsystemForLinux()) {
-                Path java_exe = script.getTestJDK().getFile().resolve("bin").resolve("java.exe");
+                Path java_exe = script.getTestJDK().getHomeDirectory().resolve("bin").resolve("java.exe");
                 env.put("NULL", "/dev/null");
                 if (Files.exists(java_exe)) {
                     // invoking a Windows binary: use standard Windows separator characters

--- a/src/share/classes/com/sun/javatest/regtest/exec/TestNGAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/TestNGAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
 
 package com.sun.javatest.regtest.exec;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -40,6 +40,7 @@ import com.sun.javatest.regtest.agent.TestNGRunner;
 import com.sun.javatest.regtest.config.Locations;
 import com.sun.javatest.regtest.config.Locations.LibLocn;
 import com.sun.javatest.regtest.config.ParseException;
+import com.sun.javatest.regtest.util.FileUtils;
 
 /**
  * This class implements the implicit "testng" action for TestNG tests.
@@ -72,7 +73,7 @@ public class TestNGAction extends MainAction {
      * @param reason Indication of why this action was invoked.
      * @param script The script.
      * @exception  ParseException If the options or arguments are not expected
-     *             for the action or are improperly formated.
+     *             for the action or are improperly formatted.
      */
     @Override
     public void init(Map<String,String> opts, List<String> args, String reason,
@@ -113,14 +114,14 @@ public class TestNGAction extends MainAction {
                 buildArgs.addAll(listClasses(locations.absLibSrcList(LibLocn.Kind.PACKAGE)));
             }
             try {
-                File testSrcDir = locations.absTestSrcDir();
+                Path testSrcDir = locations.absTestSrcDir();
                 switch (locations.getDirKind(testSrcDir)) {
                     case PACKAGE:
-                        buildArgs.addAll(listClasses(Collections.singletonList(testSrcDir)));
+                        buildArgs.addAll(listClasses(List.of(testSrcDir)));
                         break;
                     case SYS_MODULE:
                     case USER_MODULE:
-                        buildArgs.addAll(listModules(Collections.singletonList(testSrcDir)));
+                        buildArgs.addAll(listModules(List.of(testSrcDir)));
                         break;
                 }
             } catch (Locations.Fault e) {
@@ -131,37 +132,39 @@ public class TestNGAction extends MainAction {
         }
     }
 
-    private List<String> listClasses(List<File> roots) {
+    private List<String> listClasses(List<Path> roots) {
         List<String> classes = new ArrayList<>();
-        for (File root: roots)
+        for (Path root: roots)
             listClasses(root, null, classes);
         return classes;
     }
 
-    private void listClasses(File dir, String pkg, List<String> classes) {
-        for (File f: dir.listFiles()) {
-            String f_name = f.getName();
-            if (f.isDirectory())
+    private void listClasses(Path dir, String pkg, List<String> classes) {
+        // candidate for Files.walkFileTree
+        for (Path f : FileUtils.listFiles(dir)) {
+            String f_name = f.getFileName().toString();
+            if (Files.isDirectory(f)) {
                 listClasses(f, pkg == null ? f_name : pkg + "." + f_name, classes);
-            else if (f_name.endsWith(".java")) {
+            } else if (f_name.endsWith(".java")) {
                 String c_name = f_name.substring(0, f_name.length() - 5);
                 classes.add(pkg == null ? c_name : pkg + "." + c_name);
             }
         }
     }
 
-    private Set<String> listModules(List<File> roots) {
+    private Set<String> listModules(List<Path> roots) {
         Set<String> modules = new LinkedHashSet<>();
-        for (File root: roots) {
-            for (File f: root.listFiles()) {
-                if (f.isDirectory())
-                    modules.add(f.getName() + "/*");
+        for (Path root: roots) {
+            for (Path f : FileUtils.listFiles(root)) {
+                if (Files.isDirectory(f)) {
+                    modules.add(f.getFileName() + "/*");
+                }
             }
         }
         return modules;
     }
 
-    private static final File TESTNG_RESULTS_XML = new File("testng-results.xml");
+    private static final Path TESTNG_RESULTS_XML = Path.of("testng-results.xml");
 
     @Override
     public void endAction(Status s) {
@@ -171,7 +174,7 @@ public class TestNGAction extends MainAction {
         script.getTestNGReporter().add(script.getTestResult(), section);
         String jtrPath = script.getTestResult().getWorkRelativePath();
         String tngPath = jtrPath.replaceAll("\\.jtr$", ".testng-results.xml");
-        script.saveScratchFile(TESTNG_RESULTS_XML, new File(tngPath));
+        script.saveScratchFile(TESTNG_RESULTS_XML, Path.of(tngPath));
     }
 
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/TimeoutHandlerProvider.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/TimeoutHandlerProvider.java
@@ -96,7 +96,7 @@ public class TimeoutHandlerProvider {
     public TimeoutHandler createHandler(Class<? extends Action> actionClass, RegressionScript script, Section section) {
         PrintWriter log = section.getMessageWriter();
         File outDir = script.absTestScratchDir().toFile();
-        Path testJDK = script.getTestJDK().getAbsoluteFile();
+        Path testJDK = script.getTestJDK().getAbsoluteHomeDirectory();
 
         if (className != null) {
             try {

--- a/src/share/classes/com/sun/javatest/regtest/exec/TimeoutHandlerProvider.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/TimeoutHandlerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -61,11 +62,11 @@ public class TimeoutHandlerProvider {
      * @throws java.net.MalformedURLException if any of the files on the path cannot be converted
      *      to a URL
      */
-    public void setClassPath(List<File> path) throws MalformedURLException {
+    public void setClassPath(List<Path> path) throws MalformedURLException {
         URL[] urls = new URL[path.size()];
         int u = 0;
-        for (File f: path) {
-            urls[u++] = f.toURI().toURL();
+        for (Path f: path) {
+            urls[u++] = f.toUri().toURL();
         }
         loader = new URLClassLoader(urls);
     }
@@ -94,14 +95,14 @@ public class TimeoutHandlerProvider {
      */
     public TimeoutHandler createHandler(Class<? extends Action> actionClass, RegressionScript script, Section section) {
         PrintWriter log = section.getMessageWriter();
-        File outDir = script.absTestScratchDir();
-        File testJDK = script.getTestJDK().getAbsoluteFile();
+        File outDir = script.absTestScratchDir().toFile();
+        Path testJDK = script.getTestJDK().getAbsoluteFile();
 
         if (className != null) {
             try {
                 Class<? extends TimeoutHandler> clz = loadClass();
                 Constructor<? extends TimeoutHandler> ctor = clz.getDeclaredConstructor(PrintWriter.class, File.class, File.class);
-                TimeoutHandler th = ctor.newInstance(log, outDir, testJDK);
+                TimeoutHandler th = ctor.newInstance(log, outDir, testJDK.toFile());
                 th.setTimeout(timeout);
                 return th;
             } catch (Exception ex) {

--- a/src/share/classes/com/sun/javatest/regtest/report/RegressionReporter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/RegressionReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.util.Arrays;
 import java.util.Date;
@@ -64,7 +66,7 @@ public class RegressionReporter {
 
     public void report(RegressionParameters params, ElapsedTimeHandler elapsedTimeHandler,
                        TestStats testStats, TestFilter filter, boolean quiet) {
-        File rd = params.getReportDir();
+        File rd = params.getReportDir().toFile();
         File wd = params.getWorkDirectory().getRoot();
 
         try {
@@ -125,7 +127,7 @@ public class RegressionReporter {
 
     public void report(TestManager testManager) throws Fault {
         this.testManager = testManager;
-        this.reportDir = testManager.getReportDirectory();
+        this.reportDir = testManager.getReportDirectory().toFile();
 
         parent = getCommonParent(testManager.getTestSuites());
         // ignore the case where the common parent is just the root directory
@@ -143,7 +145,7 @@ public class RegressionReporter {
 
             writeIndex();
 
-            fixupReports(reportDir, testManager.getWorkDirectory());
+            fixupReports(reportDir, testManager.getWorkDirectory().toFile());
 
             logReportWritten(reportDir);
         } catch (IOException e) {
@@ -211,9 +213,9 @@ public class RegressionReporter {
                 html.endTag(HTMLWriter.TD);
                 html.startTag(HTMLWriter.TD);
                 html.startTag(HTMLWriter.A);
-                File rd = testManager.getReportDirectory(testSuite);
-                html.writeAttr(HTMLWriter.HREF, "../" + encode(rd.getName()) + "/index.html");
-                html.write(rd.getName());
+                Path rd = testManager.getReportDirectory(testSuite);
+                html.writeAttr(HTMLWriter.HREF, "../" + encode(rd.getFileName().toString()) + "/index.html");
+                html.write(rd.getFileName().toString());
                 html.endTag(HTMLWriter.A);
                 html.endTag(HTMLWriter.TD);
                 html.endTag(HTMLWriter.TR);
@@ -360,9 +362,9 @@ public class RegressionReporter {
         File report = new File(textDir, "summary.txt");
         try (BufferedWriter summaryOut = new BufferedWriter(new FileWriter(report))) {
             for (RegressionTestSuite ts: testManager.getTestSuites()) {
-                File f = new File(new File(testManager.getReportDirectory(ts), "text"), "summary.txt");
-                if (f.exists()) {
-                    String s = read(f);
+                Path f = testManager.getReportDirectory(ts).resolve("text").resolve("summary.txt");
+                if (Files.exists(f)) {
+                    String s = Files.readString(f);
                     if (!s.endsWith("\n"))
                         s += "\n";
                     summaryOut.write(s);

--- a/src/share/classes/com/sun/javatest/regtest/tool/Help.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Help.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -109,15 +110,15 @@ public class Help {
             @Override
             public void showVersion(PrintWriter out) {
                 try {
-                    for (File jar: path.asList()) {
-                        try (JarFile j = new JarFile(jar)) {
+                    for (Path jar: path.asList()) {
+                        try (JarFile j = new JarFile(jar.toFile())) {
                             Attributes attrs = j.getManifest().getMainAttributes();
                             String v = attrs.getValue(Attributes.Name.IMPLEMENTATION_VERSION);
                             if (v == null) {
                                 v = attrs.getValue("Bundle-Version");
                             }
                             String suffix = (path.asList().size() == 1)
-                                    ? "" : " (" + jar.getName() + ")";
+                                    ? "" : " (" + jar.getFileName() + ")";
                             out.println(name + suffix + ": version " + (v == null ? "unknown" : v)); // need i18n
                         }
                     }
@@ -476,8 +477,8 @@ public class Help {
         if (p != null)
             return p;
 
-        List<File> cp = new SearchPath(System.getProperty("java.class.path")).asList();
-        if (cp.size() == 1 && cp.get(0).getName().equals("jtreg.jar")) {
+        List<Path> cp = new SearchPath(System.getProperty("java.class.path")).asList();
+        if (cp.size() == 1 && cp.get(0).getFileName().toString().equals("jtreg.jar")) {
             return "java -jar jtreg.jar ";
         }
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/JCovManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/JCovManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -53,14 +54,18 @@ import static com.sun.javatest.regtest.tool.Option.ArgType.*;
  * Manager to drive jcov code coverage tool.
  */
 public class JCovManager {
-    public JCovManager(File libDir) {
-        jcov_jar = new JarFinder("jcov.jar").libDir(libDir).getFile();
-        jcov_network_saver_jar = new JarFinder("jcov_network_saver.jar").libDir(libDir).getFile();
+    public JCovManager(Path libDir) {
+        jcov_jar = toFile(new JarFinder("jcov.jar").libDir(libDir).getFile());
+        jcov_network_saver_jar = toFile(new JarFinder("jcov_network_saver.jar").libDir(libDir).getFile());
 
         if (System.getProperty("jcov.port") != null)
             grabberPort = Integer.getInteger("jcov.port");
         if (System.getProperty("jcov.command_port") != null)
             grabberCommandPort = Integer.getInteger("jcov.command_port");
+    }
+
+    private static File toFile(Path p) {
+        return p == null ? null : p.toFile();
     }
 
     public static final String JCOV = "jcov";
@@ -438,7 +443,7 @@ public class JCovManager {
         public void run() {
             try {
                 List<String> args = new ArrayList<String>();
-                args.add(jdk.getJavaProg().getPath());
+                args.add(jdk.getJavaProg().toString());
                 args.add("-jar");
                 args.add(jcov_jar.getPath());
                 args.addAll(opts);

--- a/src/share/classes/com/sun/javatest/regtest/tool/JarFinder.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/JarFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,10 +43,10 @@ public class JarFinder {
 
     private List<String> jars;
     private List<String> classes;
-    private File libDir;
+    private Path libDir;
 
     JarFinder(String first, String... rest) {
-        jars = new ArrayList<String>();
+        jars = new ArrayList<>();
         jars.add(first);
         jars.addAll(Arrays.asList(rest));
     }
@@ -56,13 +57,13 @@ public class JarFinder {
     }
 
     JarFinder classes(Class<?>... classes) {
-        this.classes = new ArrayList<String>();
+        this.classes = new ArrayList<>();
         for (Class<?> c : classes)
             this.classes.add(c.getName());
         return this;
     }
 
-    JarFinder libDir(File libDir) {
+    JarFinder libDir(Path libDir) {
         this.libDir = libDir;
         return this;
     }
@@ -80,9 +81,9 @@ public class JarFinder {
 
         String home = System.getProperty("jtreg.home");
         if (home != null) {
-            File lib = new File(home, "lib");
+            Path lib = Path.of(home).resolve("lib");
             for (String jar : jars) {
-                result.append(new File(lib, jar));
+                result.append(lib.resolve(jar));
             }
             if (!result.isEmpty())
                 return result;
@@ -107,7 +108,7 @@ public class JarFinder {
                             uri = new URI("file://" + ssp.substring(0, sep));
                         }
                         if (uri.getScheme().equals("file"))
-                            result.append(new File(uri.getPath()));
+                            result.append(Path.of(uri));
                     }
                 } catch (URISyntaxException ignore) {
                     ignore.printStackTrace(System.err);
@@ -119,17 +120,17 @@ public class JarFinder {
 
         if (libDir != null) {
             for (String jar : jars) {
-                result.append(new File(libDir, jar));
+                result.append(libDir.resolve(jar));
             }
         }
 
         return result;
     }
 
-    File getFile() {
+    Path getFile() {
         SearchPath p = getPath();
         if (p != null) {
-            List<File> files = p.asList();
+            List<Path> files = p.asList();
             if (files.size() == 1)
                 return files.get(0);
         }

--- a/src/share/classes/com/sun/javatest/regtest/tool/OptionDecoder.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/OptionDecoder.java
@@ -25,7 +25,6 @@
 
 package com.sun.javatest.regtest.tool;
 
-import java.io.File;
 import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -192,10 +191,6 @@ public class OptionDecoder {
             throw new BadArgs(i18n, "opt.bad.path.for.option", arg, e.getInput(), e.getMessage());
         }
     }
-
-//    public void addFile(File file) throws BadArgs {
-//        fileOption.process(null, file.getPath());
-//    }
 
     public void addFile(String path) throws BadArgs {
         fileOption.process(null, path);

--- a/src/share/classes/com/sun/javatest/regtest/tool/OptionDecoder.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/OptionDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.javatest.regtest.tool;
 
 import java.io.File;
+import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -185,12 +186,16 @@ public class OptionDecoder {
         if (debugOptions)
             System.err.println("OptionDecoder.decodeArg: " + name + " " + value);
 
-        o.process(arg, value);
+        try {
+            o.process(arg, value);
+        } catch (InvalidPathException e) {
+            throw new BadArgs(i18n, "opt.bad.path.for.option", arg, e.getInput(), e.getMessage());
+        }
     }
 
-    public void addFile(File file) throws BadArgs {
-        fileOption.process(null, file.getPath());
-    }
+//    public void addFile(File file) throws BadArgs {
+//        fileOption.process(null, file.getPath());
+//    }
 
     public void addFile(String path) throws BadArgs {
         fileOption.process(null, path);

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -47,6 +47,8 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -201,7 +203,6 @@ public class Tool {
                 p.waitFor();
 
                 checkJavaOSVersion(expectVersion);
-                return;
 
             } catch (IOException | InterruptedException e) {
                 System.err.println("Error getting OS version: " + e);
@@ -336,7 +337,7 @@ public class Tool {
         new Option(OLD, MAIN, "", "-w", "-workDir") {
             @Override
             public void process(String opt, String arg) {
-                workDirArg = new File(arg);
+                workDirArg = Path.of(arg);
             }
         },
 
@@ -365,7 +366,7 @@ public class Tool {
         new Option(OLD, MAIN, "", "-r", "-reportDir") {
             @Override
             public void process(String opt, String arg) {
-                reportDirArg = new File(arg);
+                reportDirArg = Path.of(arg);
             }
         },
 
@@ -480,7 +481,7 @@ public class Tool {
         new Option(STD, MAIN, "", "-dir") {
             @Override
             public void process(String opt, String arg) {
-                baseDirArg = new File(arg);
+                baseDirArg = Path.of(arg);
             }
         },
 
@@ -511,7 +512,7 @@ public class Tool {
             @Override
             public void process(String opt, String arg) {
                 File f = getNormalizedFile(new File(arg));
-                excludeListArgs.add(f);
+                excludeListArgs.add(f.toPath());
             }
         },
 
@@ -519,7 +520,7 @@ public class Tool {
             @Override
             public void process(String opt, String arg) {
                 File f = getNormalizedFile(new File(arg));
-                matchListArgs.add(f);
+                matchListArgs.add(f.toPath());
             }
         },
 
@@ -547,7 +548,7 @@ public class Tool {
                 for (String f: arg.split(File.pathSeparator)) {
                     if (f.length() == 0)
                         continue;
-                    observerPathArg.add(new File(f));
+                    observerPathArg.add(Path.of(f));
                 }
             }
         },
@@ -569,7 +570,7 @@ public class Tool {
                 for (String f: arg.split(File.pathSeparator)) {
                     if (f.length() == 0)
                         continue;
-                    timeoutHandlerPathArg.add(new File(f));
+                    timeoutHandlerPathArg.add(Path.of(f));
                 }
             }
         },
@@ -664,7 +665,7 @@ public class Tool {
                 } catch (IOException e) {
                     throw new BadArgs(i18n, "main.cantCreateLockFile", arg);
                 }
-                exclusiveLockArg = f;
+                exclusiveLockArg = f.toPath();
             }
         },
 
@@ -678,7 +679,7 @@ public class Tool {
                     throw new BadArgs(i18n, "main.nativePathNotExist", arg);
                 if (!f.isDirectory())
                     throw new BadArgs(i18n, "main.nativePathNotDir", arg);
-                nativeDirArg = f;
+                nativeDirArg = f.toPath();
             }
         },
 
@@ -787,7 +788,7 @@ public class Tool {
                 for (String f: arg.split(File.pathSeparator)) {
                     if (f.length() == 0)
                         continue;
-                    classPathAppendArg.add(new File(f));
+                    classPathAppendArg.add(Path.of(f));
                 }
             }
         },
@@ -1023,11 +1024,11 @@ public class Tool {
                     testGroupArgs.add(arg);
                 } else if (fileIdPtn.matcher(arg).matches()) {
                     int sep = arg.lastIndexOf("#");
-                    File file = new File(arg.substring(0, sep));
+                    Path file = Path.of(arg.substring(0, sep));
                     String id = arg.substring(sep + 1);
                     testFileIdArgs.add(new TestManager.FileId(file, id));
                 } else {
-                    testFileArgs.add(new File(arg));
+                    testFileArgs.add(Path.of(arg));
                 }
             }
 
@@ -1054,14 +1055,14 @@ public class Tool {
                 .classes(Harness.class)
                 .getFile();
         if (javatest_jar != null) {
-            System.setProperty("javatestClassDir", javatest_jar.getPath());
+            System.setProperty("javatestClassDir", javatest_jar.toString());
         }
 
         jtreg_jar = new JarFinder("jtreg.jar")
                 .classes(getClass())
                 .getFile();
         if (jtreg_jar != null) {
-            jcovManager = new JCovManager(jtreg_jar.getParentFile());
+            jcovManager = new JCovManager(jtreg_jar.getParent());
             if (jcovManager.isJCovInstalled()) {
                 options = new ArrayList<>(options);
                 options.addAll(jcovManager.options);
@@ -1071,7 +1072,7 @@ public class Tool {
         help = new Help(options);
         if (javatest_jar != null) {
             help.addVersionHelper(o -> {
-                try (JarFile jf = new JarFile(javatest_jar)) {
+                try (JarFile jf = new JarFile(javatest_jar.toFile())) {
                     JarEntry e = jf.getJarEntry("META-INF/buildInfo.txt");
                     if (e != null) {
                         try (InputStream in = jf.getInputStream(e)) {
@@ -1137,18 +1138,18 @@ public class Tool {
             }
         }
 
-        File baseDir;
+        Path baseDir;
         if (baseDirArg == null) {
-            baseDir = new File(System.getProperty("user.dir"));
+            baseDir = Path.of(System.getProperty("user.dir"));
         } else {
-            if (!baseDirArg.exists())
+            if (!Files.exists(baseDirArg))
                 throw new Fault(i18n, "main.cantFindFile", baseDirArg);
-            baseDir = baseDirArg.getAbsoluteFile();
+            baseDir = baseDirArg.toAbsolutePath();
         }
 
         String antFileList = System.getProperty(JAVATEST_ANT_FILE_LIST);
         if (antFileList != null)
-            antFileArgs.addAll(readFileList(new File(antFileList)));
+            antFileArgs.addAll(readFileList(Path.of(antFileList)));
 
         final TestManager testManager = new TestManager(out, baseDir, new TestFinder.ErrorHandler() {
             @Override
@@ -1208,7 +1209,7 @@ public class Tool {
                     && f.getName().toLowerCase().equals("jre")
                     && f.getParentFile() != null)
                 f = f.getParentFile();
-            testJDK = com.sun.javatest.regtest.config.JDK.of(f);
+            testJDK = com.sun.javatest.regtest.config.JDK.of(f.toPath());
         }
 
         JDK_Version testJDK_version = checkJDK(testJDK);
@@ -1252,11 +1253,11 @@ public class Tool {
         }
 
         if (workDirArg == null) {
-            workDirArg = new File("JTwork");
+            workDirArg = Path.of("JTwork");
         }
 
         if (reportDirArg == null && reportMode != ReportMode.NONE) {
-            reportDirArg = new File("JTreport");
+            reportDirArg = Path.of("JTreport");
         }
 
         makeDir(workDirArg, false);
@@ -1287,18 +1288,18 @@ public class Tool {
             return EXIT_OK;
         }
 
-        makeDir(new File(workDirArg, "scratch"), true);
+        makeDir(workDirArg.resolve("scratch"), true);
 
         if (reportMode != ReportMode.NONE) {
             makeDir(reportDirArg, false);
             testManager.setReportDirectory(reportDirArg);
 
             if (expandedArgs != null) {
-                File reportTextDir = new File(reportDirArg, "text");
+                Path reportTextDir = reportDirArg.resolve("text");
                 makeDir(reportTextDir, true);
-                File cmdArgsFile = new File(reportTextDir, "cmdArgs.txt");
+                Path cmdArgsFile = reportTextDir.resolve("cmdArgs.txt");
                 // update to use try-with-resources and lambda
-                try (BufferedWriter cmdArgsWriter = new BufferedWriter(new FileWriter(cmdArgsFile))) {
+                try (BufferedWriter cmdArgsWriter = Files.newBufferedWriter(cmdArgsFile)) {
                     for (String arg: expandedArgs) {
                         cmdArgsWriter.append(arg);
                         cmdArgsWriter.newLine();
@@ -1311,8 +1312,8 @@ public class Tool {
 
         if (jcovManager.isEnabled()) {
             jcovManager.setTestJDK(testJDK);
-            jcovManager.setWorkDir(getNormalizedFile(workDirArg));
-            jcovManager.setReportDir(getNormalizedFile(reportDirArg));
+            jcovManager.setWorkDir(getNormalizedFile(workDirArg.toFile()));
+            jcovManager.setReportDir(getNormalizedFile(reportDirArg.toFile()));
             jcovManager.instrumentClasses();
             final String XBOOTCLASSPATH_P = "-Xbootclasspath/p:";
             final String XMS = "-Xms";
@@ -1382,7 +1383,7 @@ public class Tool {
                         Agent.Pool p = Agent.Pool.instance(params);
                         if (allowSetSecurityManagerFlag) {
                             initPolicyFile();
-                            p.setSecurityPolicy(policyFile);
+                            p.setSecurityPolicy(policyFile.toFile());
                         }
                         if (timeoutFactorArg != null) {
                             p.setTimeoutFactor(timeoutFactorArg);
@@ -1434,7 +1435,7 @@ public class Tool {
                     r.report(testManager);
                 }
                 if (!reportOnlyFlag) {
-                    out.println("Results written to " + canon(workDirArg));
+                    out.println("Results written to " + canon(workDirArg.toFile()));
                 }
             }
 
@@ -1497,9 +1498,9 @@ public class Tool {
         // Check that we're not trying to use a Linux JDK when running on a Windows JDK,
         // and vice versa.
         JDK jtregJDK = com.sun.javatest.regtest.config.JDK.of(System.getProperty("java.home"));
-        File jtregJava = jtregJDK.getProg("java", true);
-        File jdkJava = jdk.getProg("java", true);
-        if (!jdkJava.getName().equals(jtregJava.getName())) {
+        Path jtregJava = jtregJDK.getProg("java", true);
+        Path jdkJava = jdk.getProg("java", true);
+        if (!jdkJava.getFileName().equals(jtregJava.getFileName())) {
             throw new Fault(i18n, "main.incompatibleJDK", jdk, jtregJDK);
         }
 
@@ -1538,12 +1539,12 @@ public class Tool {
                 } else {
                     for (String g: gset) {
                         try {
-                            Set<File> files = gm.getFiles(g);
+                            Set<Path> files = gm.getFiles(g);
                             out.print(g);
                             out.print(":");
                             Set<String> fset = new TreeSet<>(new NaturalComparator(false));
-                            for (File f : files)
-                                fset.add(ts.getRootDir().toURI().relativize(f.toURI()).getPath());
+                            for (Path f : files)
+                                fset.add(ts.getRootDir().toURI().relativize(f.toUri()).getPath());
                             for (String f: fset) {
                                 out.print(" ");
                                 out.print(f);
@@ -1639,27 +1640,13 @@ public class Tool {
         }
     }
 
-    private static List<File> readFileList(File file) throws Fault {
-        BufferedReader r;
+    private static List<Path> readFileList(Path file) throws Fault {
         try {
-            r = new BufferedReader(new FileReader(file));
-        } catch (FileNotFoundException e) {
-            throw new Fault(i18n, "main.cantOpenFile", file);
-        }
-        try {
-            List<File> list = new ArrayList<>();
-            String line;
-            while ((line = r.readLine()) != null)
-                list.add(new File(line));
-            return list;
+            List<String> lines = Files.readAllLines(file);
+            return lines.stream().map(Path::of).collect(Collectors.toList());
         } catch (IOException e) {
             throw new Fault(i18n, "main.cantRead", file, e);
-        } finally {
-            try {
-                r.close();
-            } catch (IOException e) {
-                // ignore
-            }
+
         }
     }
 
@@ -1678,15 +1665,15 @@ public class Tool {
             throw new Fault(i18n, "main.cantFind.jtreg.jar");
         }
 
-        File libDir = jtreg_jar.getParentFile();
+        Path libDir = jtreg_jar.getParent();
 
         asmtoolsPath = new JarFinder("asmtools.jar")
                 .classes("org.openjdk.asmtools.Main")
                 .libDir(libDir)
                 .getPath();
         help.addVersionHelper(out -> {
-            for (File f : asmtoolsPath.asList()) {
-                try (JarFile jf = new JarFile(f)) {
+            for (Path f : asmtoolsPath.asList()) {
+                try (JarFile jf = new JarFile(f.toFile())) {
                     JarEntry e = jf.getJarEntry("org/openjdk/asmtools/util/productinfo.properties");
                     if (e != null) {
                         try (InputStream in = jf.getInputStream(e)) {
@@ -1712,9 +1699,9 @@ public class Tool {
         // handle TestNG specially
         help.addVersionHelper(out -> {
             List<URL> urls = new ArrayList<>();
-            for (File f : testngPath.asList()) {
+            for (Path f : testngPath.asList()) {
                 try {
-                    urls.add(f.toURI().toURL());
+                    urls.add(f.toUri().toURL());
                 } catch (MalformedURLException e) {
                     // ignore
                 }
@@ -1730,8 +1717,8 @@ public class Tool {
             out.println("TestNG (testng.jar): version " + (v == null ? "unknown" : v)); // need i18n
         });
         SearchPath notTestNGPath = new SearchPath();
-        for (File f : testngPath.asList()) {
-            if (!f.getName().equals("testng.jar")) {
+        for (Path f : testngPath.asList()) {
+            if (!f.getFileName().toString().equals("testng.jar")) {
                 notTestNGPath.append(f);
             }
         }
@@ -1750,11 +1737,11 @@ public class Tool {
         // Write a policy file into the work directory granting all permissions
         // to jtreg.
         // Note: don't use scratch directory, which is cleared before tests run
-        File pfile = new File(workDirArg, "jtreg.policy");
-        try (BufferedWriter pout = new BufferedWriter(new FileWriter(pfile))) {
+        Path pfile = workDirArg.resolve("jtreg.policy");
+        try (BufferedWriter pout = Files.newBufferedWriter(pfile)) {
             String LINESEP = System.getProperty("line.separator");
-            for (File f: Arrays.asList(jtreg_jar, javatest_jar)) {
-                pout.write("grant codebase \"" + f.toURI().toURL() + "\" {" + LINESEP);
+            for (Path f: Arrays.asList(jtreg_jar, javatest_jar)) {
+                pout.write("grant codebase \"" + f.toUri().toURL() + "\" {" + LINESEP);
                 pout.write("    permission java.security.AllPermission;" + LINESEP);
                 pout.write("};" + LINESEP);
             }
@@ -1762,6 +1749,21 @@ public class Tool {
             throw new Fault(i18n, "main.cantWritePolicyFile", e);
         }
         policyFile = pfile;
+    }
+
+    private void makeDir(Path dir, boolean quiet) throws Fault {
+        // FIXME: I18N
+        if (Files.isDirectory(dir))
+            return;
+        if (!quiet)
+            out.println("Directory \"" + dir + "\" not found: creating");
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            Fault f = new Fault(i18n, "main.cantCreateDir", dir);
+            f.initCause(e);
+            throw f;
+        }
     }
 
     private void makeDir(File dir, boolean quiet) throws Fault {
@@ -1776,19 +1778,19 @@ public class Tool {
         }
     }
 
-    private static List<File> pathToFiles(String path) {
-        List<File> files = new ArrayList<>();
+    private static List<Path> pathToFiles(String path) {
+        List<Path> files = new ArrayList<>();
         for (String f: path.split(File.pathSeparator)) {
             if (f.length() > 0)
-                files.add(new File(f));
+                files.add(Path.of(f));
         }
         return files;
     }
 
-    private static SearchPath filesToAbsolutePath(List<File> files) {
+    private static SearchPath filesToAbsolutePath(List<Path> files) {
         SearchPath p = new SearchPath();
-        for (File f: files) {
-            p.append(getNormalizedFile(f));
+        for (Path f: files) {
+            p.append(getNormalizedFile(f.toFile()).toPath());
         }
         return p;
     }
@@ -1825,8 +1827,8 @@ public class Tool {
                 rp.setKeywordsExpr(expr);
             }
 
-            rp.setExcludeLists(excludeListArgs.toArray(new File[excludeListArgs.size()]));
-            rp.setMatchLists(matchListArgs.toArray(new File[matchListArgs.size()]));
+            rp.setExcludeLists(excludeListArgs.toArray(new Path[0]));
+            rp.setMatchLists(matchListArgs.toArray(new Path[0]));
 
             if (priorStatusValuesArg == null || priorStatusValuesArg.length() == 0)
                 rp.setPriorStatusValues(null);
@@ -1872,7 +1874,7 @@ public class Tool {
                 rp.setTimeoutHandlerTimeout(timeoutHandlerTimeoutArg);
             }
 
-            File rd = testManager.getReportDirectory(testSuite);
+            Path rd = testManager.getReportDirectory(testSuite);
             if (rd != null)
                 rp.setReportDir(rd);
 
@@ -1951,7 +1953,7 @@ public class Tool {
         }
     }
 
-    private static Harness.Observer getObserver(List<File> observerPath, String observerClassName)
+    private static Harness.Observer getObserver(List<Path> observerPath, String observerClassName)
             throws Fault {
         try {
             Class<?> observerClass;
@@ -1960,9 +1962,9 @@ public class Tool {
             else {
                 URL[] urls = new URL[observerPath.size()];
                 int u = 0;
-                for (File f: observerPath) {
+                for (Path f: observerPath) {
                     try {
-                        urls[u++] = f.toURI().toURL();
+                        urls[u++] = f.toUri().toURL();
                     } catch (MalformedURLException ignore) {
                     }
                 }
@@ -2399,8 +2401,8 @@ public class Tool {
         if (isWindows()) {
             String PATH = System.getenv("PATH");
             if (PATH != null) {
-                for (File f : new SearchPath(PATH).asList()) {
-                    if (new File(f, "wsl.exe").exists()) {
+                for (Path f : new SearchPath(PATH).asList()) {
+                    if (Files.exists(f.resolve("wsl.exe"))) {
                         return true;
                     }
                 }
@@ -2440,24 +2442,24 @@ public class Tool {
     private List<String> expandedArgs;
 
     // this first group of args are the "standard" JavaTest args
-    private File workDirArg;
+    private Path workDirArg;
     private List<String> retainArgs;
-    private List<File> excludeListArgs = new ArrayList<>();
+    private List<Path> excludeListArgs = new ArrayList<>();
     private String userKeywordExpr;
     private String extraKeywordExpr;
     private String concurrencyArg;
     private Float timeoutFactorArg;
     private String priorStatusValuesArg;
-    private File reportDirArg;
+    private Path reportDirArg;
     public List<String> testGroupArgs = new ArrayList<>();
-    public List<File> testFileArgs = new ArrayList<>();
+    public List<Path> testFileArgs = new ArrayList<>();
     public List<TestManager.FileId> testFileIdArgs = new ArrayList<>();
     // TODO: consider making this a "pathset" to detect redundant specification
     // of directories and paths within them.
-    public final List<File> antFileArgs = new ArrayList<>();
+    public final List<Path> antFileArgs = new ArrayList<>();
 
     // these args are jtreg extras
-    private File baseDirArg;
+    private Path baseDirArg;
     private ExecMode execMode;
     private JDK compileJDK;
     private JDK testJDK;
@@ -2471,9 +2473,9 @@ public class Tool {
     private boolean httpdFlag;
     private String timeLimitArg;
     private String observerClassName;
-    private List<File> observerPathArg;
+    private List<Path> observerPathArg;
     private String timeoutHandlerClassName;
-    private List<File> timeoutHandlerPathArg;
+    private List<Path> timeoutHandlerPathArg;
     private long timeoutHandlerTimeoutArg = -1; // -1: default; 0: no timeout; >0: timeout in seconds
     private int maxPoolSize = -1;
     private Duration poolIdleTimeout = Duration.ofSeconds(30);
@@ -2486,22 +2488,22 @@ public class Tool {
     private boolean showGroupsFlag;
     private List<String> envVarArgs = new ArrayList<>();
     private IgnoreKind ignoreKind;
-    private List<File> classPathAppendArg = new ArrayList<>();
-    private File nativeDirArg;
+    private List<Path> classPathAppendArg = new ArrayList<>();
+    private Path nativeDirArg;
     private Boolean useWindowsSubsystemForLinux;
     private boolean jitFlag = true;
     private Help help;
     private boolean xmlFlag;
     private boolean xmlVerifyFlag;
-    private File exclusiveLockArg;
-    private List<File> matchListArgs = new ArrayList<>();
+    private Path exclusiveLockArg;
+    private List<Path> matchListArgs = new ArrayList<>();
 
-    private File javatest_jar;
-    private File jtreg_jar;
+    private Path javatest_jar;
+    private Path jtreg_jar;
     private SearchPath junitPath;
     private SearchPath testngPath;
     private SearchPath asmtoolsPath;
-    private File policyFile;
+    private Path policyFile;
 
     JCovManager jcovManager;
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -510,6 +510,7 @@ main.warn.cygwin.specified.found.wsl=Warning: -cygwin specified, but WSL detecte
 main.windowsOnly=This option is only for use on Windows: {0}
 
 opt.bad.format=Bad format for option: {0}
+opt.bad.path.for.option=bad path for option {0}: {1}; {2}
 opt.conflict=Invalid option combination: {0} and {1}
 opt.duplicate=Duplicate option: {0}
 opt.empty=Invalid option: (empty)

--- a/src/share/classes/com/sun/javatest/regtest/util/FileUtils.java
+++ b/src/share/classes/com/sun/javatest/regtest/util/FileUtils.java
@@ -1,0 +1,155 @@
+package com.sun.javatest.regtest.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utilities for handling files.
+ */
+public class FileUtils {
+    /**
+     * An unchecked IO exception to be thrown when various NIO file operations fail,
+     * and throw a checked IO exception.
+     */
+    public static class NIOFileOperationException extends UncheckedIOException {
+        private static final long serialVersionUID = 0;
+
+        /**
+         * The operation that caused an exception.
+         */
+        enum Op {MKDIRS, LAST_MOD, LIST, SIZE}
+
+        /**
+         * Creates an unchecked IO exception for a checked IO exception
+         * that was caused by an operation on a file.
+         *
+         * @param op    the operation
+         * @param p     the file
+         * @param cause the IO exception
+         */
+        NIOFileOperationException(Op op, Path p, IOException cause) {
+            super(getMessage(op, p), cause);
+        }
+
+        private static String getMessage(Op op, Path p) {
+            switch (op) {
+                case MKDIRS:
+                    return "Cannot create directories for " + p;
+                case LAST_MOD:
+                    return "Cannot access last-modified time for " + p;
+                case LIST:
+                    return "Cannot list directory " + p;
+                case SIZE:
+                    return "Cannot determine size of file " + p;
+                default:
+                    return "Cannot perform unknown operation for " + p;
+            }
+        }
+    }
+
+    private FileUtils() { }
+
+    /**
+     * Returns the size of a file, in  bytes.
+     *
+     * @param p the file
+     * @return the size of a file, in  bytes
+     * @throws NIOFileOperationException if an IO exception arose while accessing the size
+     */
+    public static long size(Path p) throws NIOFileOperationException {
+        try {
+            return Files.size(p);
+        } catch (IOException e) {
+            throw new NIOFileOperationException(NIOFileOperationException.Op.SIZE, p, e);
+        }
+    }
+
+    /**
+     * Returns the time that a file was last modified.
+     *
+     * @param p the file
+     * @return the time the file was last modified
+     * @throws NIOFileOperationException if an IO exception arose while accessing the time
+     */
+    public static FileTime getLastModifiedTime(Path p) throws NIOFileOperationException {
+        try {
+            return Files.getLastModifiedTime(p);
+        } catch (IOException e) {
+            throw new NIOFileOperationException(NIOFileOperationException.Op.LAST_MOD, p, e);
+        }
+    }
+
+    /**
+     * Compares the times that a pair of files were last modified.
+     *
+     * @param p1 the first file
+     * @param p2 the second file
+     * @return {@code -1}, {@code 0} or {@code 1} according to whether the last modified time of the first file
+     *          is less than, equal to, or greater than the last modified time of the second file
+     *
+     * @throws NIOFileOperationException if an IO exception arose while accessing the time for either file
+     */
+    public static int compareLastModifiedTimes(Path p1, Path p2) {
+        return getLastModifiedTime(p1).compareTo(getLastModifiedTime(p2));
+    }
+
+    /**
+     * Creates a directory by creating all non-existent parent directories first.
+     * No exception is thrown if the directory already exists.
+     *
+     * @param dir the directory
+     *
+     * @throws NIOFileOperationException if an IO exception arose while creating the directories
+     *
+     * @see Files#createDirectories(Path, FileAttribute[])
+     */
+    public static void createDirectories(Path dir) {
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            throw new NIOFileOperationException(NIOFileOperationException.Op.MKDIRS, dir, e);
+        }
+    }
+
+    /**
+     * Returns the list of contents of a directory.
+     *
+     * @param dir the directory
+     *
+     * @return the list of contents
+     */
+    public static List<Path> listFiles(Path dir) {
+        List<Path> files = new ArrayList<>();
+        try (DirectoryStream<Path> ds = Files.newDirectoryStream(dir)) {
+            for (Path p : ds) {
+                files.add(p);
+            }
+        } catch (IOException e) {
+            throw new NIOFileOperationException(NIOFileOperationException.Op.LIST, dir, e);
+        }
+        return files;
+    }
+
+    /**
+     * Converts an array of paths to an array of file.
+     *
+     * @param paths the array of paths
+     * @return the array of files
+     */
+    public static File[] toFiles(Path[] paths) {
+        return Stream.of(paths)
+                .map(Path::toFile)
+                .collect(Collectors.toList())
+                .toArray(new File[0]);
+    }
+}

--- a/src/share/classes/com/sun/javatest/regtest/util/FileUtils.java
+++ b/src/share/classes/com/sun/javatest/regtest/util/FileUtils.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package com.sun.javatest.regtest.util;
 
 import java.io.File;
@@ -60,10 +85,12 @@ public class FileUtils {
     private FileUtils() { }
 
     /**
-     * Returns the size of a file, in  bytes.
+     * Returns the size of a file, in bytes.
      *
      * @param p the file
-     * @return the size of a file, in  bytes
+     *
+     * @return the size of a file, in bytes
+     *
      * @throws NIOFileOperationException if an IO exception arose while accessing the size
      */
     public static long size(Path p) throws NIOFileOperationException {
@@ -78,7 +105,9 @@ public class FileUtils {
      * Returns the time that a file was last modified.
      *
      * @param p the file
+     *
      * @return the time the file was last modified
+     *
      * @throws NIOFileOperationException if an IO exception arose while accessing the time
      */
     public static FileTime getLastModifiedTime(Path p) throws NIOFileOperationException {
@@ -94,6 +123,7 @@ public class FileUtils {
      *
      * @param p1 the first file
      * @param p2 the second file
+     *
      * @return {@code -1}, {@code 0} or {@code 1} according to whether the last modified time of the first file
      *          is less than, equal to, or greater than the last modified time of the second file
      *
@@ -144,6 +174,7 @@ public class FileUtils {
      * Converts an array of paths to an array of file.
      *
      * @param paths the array of paths
+     *
      * @return the array of files
      */
     public static File[] toFiles(Path[] paths) {

--- a/test/basic/Basic.java
+++ b/test/basic/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Hashtable;
 import java.util.Iterator;
 
@@ -354,7 +355,7 @@ public class Basic
 
             rp.setWorkDirectory(workDir);
             rp.setTests((String[])null);
-            rp.setExcludeLists(new File[0]);
+            rp.setExcludeLists(new Path[0]);
             rp.setKeywordsExpr("!manual");
             rp.setPriorStatusValues(null);
         }

--- a/test/streams/StreamsTest.gmk
+++ b/test/streams/StreamsTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,11 @@ $(BUILDDIR)/StreamsTest.othervm.ok: \
 			> $(@:%.ok=%/jt.log)
 	#
 	count=`$(GREP) -c 'Hello World' $(@:%.ok=%)/work/StreamsTest.jtr` ; \
-	if [ "$$count" -ne 3 ]; then echo "error: output does not contain expected lines" ; exit 1 ; fi
+	if [ "$$count" -ne 3 ]; then \
+		echo "***" $(@:%.ok=%/jt.log) ; cat $(@:%.ok=%/jt.log) ; \
+		echo "***" $(@:%.ok=%)/work/StreamsTest.jtr ; cat $(@:%.ok=%)/work/StreamsTest.jtr ; \
+		echo "error: output does not contain expected lines" ; exit 1 ; \
+	fi
 	#
 	$(GREP) 'This is being written to stdout' $(@:%.ok=%)/work/FileDescriptorTest.jtr
 	$(GREP) 'This is being written to stderr' $(@:%.ok=%)/work/FileDescriptorTest.jtr


### PR DESCRIPTION
Please review a medium-big, conceptually simple but occasionally tricky update to jtreg, to use `java.nio.file.Path` instead of `java.io.File` where reasonable.

While most of the changes are formulaic and follow the obvious patterns, there were some noteworthy points:

* The most complicated class to change was `Locations`, which does the most work to derive new paths. In particular, the semantics of `new File(a, b)` do not always match `Path.of(a).resolve(b)` for corner cases like when `a` is`null` or empty, or when `b` is absolute.

* The NIO equivalent for some operations on `File` throw checked IO exceptions.  These methods were wrapped to to throw a custom unchecked IO exception.

* The NIO equivalent for creating a new file (`Path`) throws an unchecked `InvalidPathException` exception. The use sites are too numerous to handle individually.  The solution is to catch exceptions like these (and the ones described in the previous bullet) at strategic points where they can be handled or wrapped back into (existing) checked exceptions.

The development has been iterative, frequently running the jtreg internal tests locally (on a Mac) and occasionally building on a CI system (Linux).  We should do more exhaustive testing with JDK before this work ever gets promoted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903091](https://bugs.openjdk.java.net/browse/CODETOOLS-7903091): Convert jtreg to use NIO


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to c2e545438f6d817113881242b0933e554d18e195


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.java.net/jtreg pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/50.diff">https://git.openjdk.java.net/jtreg/pull/50.diff</a>

</details>
