### PR TITLE
Upload build artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,10 @@ jobs:
         HEADLESS: 1
       run: |
         bash make/build.sh --jdk ${JAVA_HOME_11_X64} --skip-download
+
+    - name: 'Upload build artifact'
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}-build-${{ github.sha }}
+        path: build


### PR DESCRIPTION
That artifact is composed of all files beneath the `build` directory if a workflow is fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.java.net/jtreg pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/51.diff">https://git.openjdk.java.net/jtreg/pull/51.diff</a>

</details>
