### PR TITLE
7903095: Use diamond operator in jtreg

### DIFF
--- a/src/share/classes/com/sun/javatest/diff/Diff.java
+++ b/src/share/classes/com/sun/javatest/diff/Diff.java
@@ -47,7 +47,7 @@ public abstract class Diff {
     protected boolean diff(List<File> files, File outFile)
             throws Fault, InterruptedException {
         this.outFile = outFile;
-        List<DiffReader> list = new ArrayList<DiffReader>();
+        List<DiffReader> list = new ArrayList<>();
         for (File f: files)
             list.add(open(f));
 
@@ -68,8 +68,8 @@ public abstract class Diff {
             reporter.setComparator(comparator);
             reporter.setReaders(list);
 
-            List<int[]> testCounts = new ArrayList<int[]>();
-            MultiMap<String, TestResult> table = new MultiMap<String, TestResult>();
+            List<int[]> testCounts = new ArrayList<>();
+            MultiMap<String, TestResult> table = new MultiMap<>();
             for (DiffReader r: list) {
                 int index = table.addColumn(r.getFile().getPath());
                 int[] counts = new int[Status.NUM_STATES];

--- a/src/share/classes/com/sun/javatest/diff/Help.java
+++ b/src/share/classes/com/sun/javatest/diff/Help.java
@@ -67,7 +67,7 @@ public class Help {
 
     void setCommandLineHelpQuery(String query) {
         if (commandLineHelpQuery == null)
-            commandLineHelpQuery = new ArrayList<String>();
+            commandLineHelpQuery = new ArrayList<>();
         if (query != null)
             commandLineHelpQuery.addAll(Arrays.asList(query.trim().split("\\s+")));
     }
@@ -224,13 +224,13 @@ public class Help {
 
         // first, group the options by their group, and sort within group
         // by their first name
-        Set<String> groups = new LinkedHashSet<String>();
+        Set<String> groups = new LinkedHashSet<>();
         for (Option o: options)
             groups.add(o.group);
         Map<String, SortedMap<String, Option>> map =
-                new LinkedHashMap<String, SortedMap<String, Option>>();
+            new LinkedHashMap<>();
         for (String g: groups)
-            map.put(g, new TreeMap<String, Option>(new CaseInsensitiveStringComparator()));
+            map.put(g, new TreeMap<>(new CaseInsensitiveStringComparator()));
         for (Option o: options) {
             if (o.names.length > 0)
                 map.get(o.group).put(o.names[0], o);
@@ -240,7 +240,7 @@ public class Help {
         for (String g: groups) {
             SortedMap<String, Option> optionsForGroup = map.get(g);
 //                continue;
-            List<HelpTree.Node> nodesForGroup = new ArrayList<HelpTree.Node>();
+            List<HelpTree.Node> nodesForGroup = new ArrayList<>();
             for (Option o: optionsForGroup.values())
                 nodesForGroup.add(createOptionHelpNode(o));
             HelpTree.Node groupNode = new HelpTree.Node(i18n, "help." + g.toLowerCase(),

--- a/src/share/classes/com/sun/javatest/diff/MultiMap.java
+++ b/src/share/classes/com/sun/javatest/diff/MultiMap.java
@@ -56,7 +56,7 @@ public class MultiMap<K, V> implements Map<K, MultiMap.Entry<V>> {
                 throw new IndexOutOfBoundsException();
 
             if (list == null)
-                list = new ArrayList<V>(index);
+                list = new ArrayList<>(index);
 
             if (index < list.size())
                 list.set(index, value);
@@ -86,8 +86,8 @@ public class MultiMap<K, V> implements Map<K, MultiMap.Entry<V>> {
 
     /** Creates a new instance of MultiMap */
     public MultiMap() {
-        names = new ArrayList<String>();
-        map = new TreeMap<K, Entry<V>>();
+        names = new ArrayList<>();
+        map = new TreeMap<>();
     }
 
     int getColumns() {
@@ -116,7 +116,7 @@ public class MultiMap<K, V> implements Map<K, MultiMap.Entry<V>> {
     void addRow(int index, K k, V v) {
         Entry<V> de = get(k);
         if (de == null)
-            put(k, de = new Entry<V>(this));
+            put(k, de = new Entry<>(this));
         de.put(index, v);
     }
 

--- a/src/share/classes/com/sun/javatest/diff/ReportReader.java
+++ b/src/share/classes/com/sun/javatest/diff/ReportReader.java
@@ -88,7 +88,7 @@ public class ReportReader implements DiffReader {
     }
 
     private List<TestResult> readSummary() {
-        List<TestResult> list = new ArrayList<TestResult>();
+        List<TestResult> list = new ArrayList<>();
         File root = getRoot();
         File f;
         if (file.isFile() && file.getName().equals(SUMMARY_TXT))

--- a/src/share/classes/com/sun/javatest/diff/Reporter.java
+++ b/src/share/classes/com/sun/javatest/diff/Reporter.java
@@ -69,7 +69,7 @@ public abstract class Reporter {
     abstract void write(MultiMap<String, TestResult> table) throws IOException;
 
     protected List<DiffReader> readers;
-    protected List<int[]> testCounts = new ArrayList<int[]>();
+    protected List<int[]> testCounts = new ArrayList<>();
     protected Comparator<TestResult> comparator;
     protected String title;
     protected int diffs;

--- a/src/share/classes/com/sun/javatest/diff/SuperDiff.java
+++ b/src/share/classes/com/sun/javatest/diff/SuperDiff.java
@@ -85,7 +85,7 @@ class SuperDiff extends Diff {
 
     private boolean diffPlatforms(YearDay yearDay, File outDir) throws Fault, InterruptedException {
         Map<String, File> pMap = table.get(yearDay);
-        List<File> pDirs = new ArrayList<File>();
+        List<File> pDirs = new ArrayList<>();
         for (String platform : table.platforms) {
             File dir = pMap.get(platform);
             if (dir != null) {
@@ -99,7 +99,7 @@ class SuperDiff extends Diff {
     }
 
     private boolean diffHistory(String platform, File outDir) throws Fault, InterruptedException {
-        List<File> pDirs = new ArrayList<File>();
+        List<File> pDirs = new ArrayList<>();
         for (YearDay yearDay: table.getRecentKeys(historySize, platform)) {
             pDirs.add(table.get(yearDay).get(platform));
         }
@@ -132,8 +132,8 @@ class SuperDiff extends Diff {
 
     private SuperTable table;
     private String baseTitle;
-    private Map<String, File> historyIndex = new LinkedHashMap<String, File>();
-    private Map<String, File> platformIndex = new LinkedHashMap<String, File>();
+    private Map<String, File> historyIndex = new LinkedHashMap<>();
+    private Map<String, File> platformIndex = new LinkedHashMap<>();
 
     private static DateFormat monthDayFormat = new SimpleDateFormat("MMM d");
     private static DateFormat mediumDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM);
@@ -244,7 +244,7 @@ class SuperDiff extends Diff {
             YearDay yd = new YearDay(year, day);
             Map<String, File> pMap = get(yd);
             if (pMap == null) {
-                pMap = new HashMap<String, File>();
+                pMap = new HashMap<>();
                 put(yd, pMap);
             }
             pMap.put(platform, dir);
@@ -267,8 +267,8 @@ class SuperDiff extends Diff {
         }
 
         List<YearDay> getRecentKeys(int n, String platform) {
-            LinkedList<YearDay> results = new LinkedList<YearDay>();
-            List<YearDay> keys = new ArrayList<YearDay>(keySet());
+            LinkedList<YearDay> results = new LinkedList<>();
+            List<YearDay> keys = new ArrayList<>(keySet());
             for (ListIterator<YearDay> iter = keys.listIterator(keys.size());
                     iter.hasPrevious() && results.size() < n; ) {
                 YearDay key = iter.previous();
@@ -282,8 +282,8 @@ class SuperDiff extends Diff {
             return infoTable.get(path);
         }
 
-        final Set<String> platforms = new TreeSet<String>();
-        final Map<String, Info> infoTable = new HashMap<String, Info>();
+        final Set<String> platforms = new TreeSet<>();
+        final Map<String, Info> infoTable = new HashMap<>();
     }
 
     static class YearDay implements Comparable<YearDay> {

--- a/src/share/classes/com/sun/javatest/regtest/agent/ActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/ActionHelper.java
@@ -84,7 +84,7 @@ public class ActionHelper {
             // Do this first, to ensure we reset permissions
             try {
                 if (System.getSecurityManager() != secMgr) {
-                    AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                    AccessController.doPrivileged(new PrivilegedAction<>() {
                         @Override
                         public Object run() {
                             System.setSecurityManager(secMgr);
@@ -110,7 +110,7 @@ public class ActionHelper {
             try {
                 final Provider[] sp = Security.getProviders();
                 if (!equal(securityProviders, sp)) {
-                    AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                    AccessController.doPrivileged(new PrivilegedAction<>() {
                         @Override
                         public Object run() {
                             for (Provider p : sp) {
@@ -192,7 +192,7 @@ public class ActionHelper {
     //----------for saving/restoring properties---------------------------------
 
     private static Map<?, ?> copyProperties(Properties p) {
-        Map<Object, Object> h = new HashMap<Object, Object>();
+        Map<Object, Object> h = new HashMap<>();
         for (Enumeration<?> e = p.propertyNames(); e.hasMoreElements(); ) {
             Object key = e.nextElement();
             h.put(key, p.get(key));

--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -317,7 +317,7 @@ public class AgentServer implements ActionHelper.OutputHandler {
 
     static List<String> readList(DataInputStream in) throws IOException {
         int n = in.readShort();
-        List<String> l = new ArrayList<String>(n);
+        List<String> l = new ArrayList<>(n);
         for (int i = 0; i < n; i++)
             l.add(in.readUTF());
         return l;
@@ -325,7 +325,7 @@ public class AgentServer implements ActionHelper.OutputHandler {
 
     static Set<String> readSet(DataInputStream in) throws IOException {
         int n = in.readShort();
-        Set<String> s = new LinkedHashSet<String>(n);
+        Set<String> s = new LinkedHashSet<>(n);
         for (int i = 0; i < n; i++)
             s.add(in.readUTF());
         return s;
@@ -333,7 +333,7 @@ public class AgentServer implements ActionHelper.OutputHandler {
 
     static Map<String, String> readMap(DataInputStream in) throws IOException {
         int n = in.readShort();
-        Map<String, String> p = new HashMap<String, String>(n, 1.0f);
+        Map<String, String> p = new HashMap<>(n, 1.0f);
         for (int i = 0; i < n; i++) {
             String key = in.readUTF();
             String value = in.readUTF();
@@ -375,7 +375,7 @@ public class AgentServer implements ActionHelper.OutputHandler {
     private final PrintStream traceOut = System.err;
     private final PrintWriter logWriter;
     private final int id;
-    private final Map<OutputKind, Writer> writers = new EnumMap<OutputKind, Writer>(OutputKind.class);
+    private final Map<OutputKind, Writer> writers = new EnumMap<>(OutputKind.class);
 
     /**
      * Create an output stream for output to be sent back to the client via the server connection.

--- a/src/share/classes/com/sun/javatest/regtest/agent/JDK_Version.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JDK_Version.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 public class JDK_Version implements Comparable<JDK_Version> {
     private static final Map<String, JDK_Version> values
-            = new HashMap<String,JDK_Version>();
+            = new HashMap<>();
 
     public static JDK_Version V1_1 = JDK_Version.forName("1.1");
     public static JDK_Version V1_5 = JDK_Version.forName("1.5");

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
@@ -145,7 +145,7 @@ public class MainActionHelper extends ActionHelper {
                 loader = ModuleHelper.addModules(modulepath.asList(), addMods);
             }
             if (classpath != null && !classpath.isEmpty()) {
-                List<URL> urls = new ArrayList<URL>();
+                List<URL> urls = new ArrayList<>();
                 for (Path f : classpath.asList()) {
                     try {
                         urls.add(f.toUri().toURL());
@@ -423,7 +423,7 @@ public class MainActionHelper extends ActionHelper {
                 Thread[] threads = new Thread[estSize];
                 int num = enumerate(threads);
                 if (num < threads.length) {
-                    ArrayList<Thread> list = new ArrayList<Thread>(num);
+                    ArrayList<Thread> list = new ArrayList<>(num);
                     for (int i = 0; i < num; i++) {
                         Thread t = threads[i];
                         if (t.isAlive()

--- a/src/share/classes/com/sun/javatest/regtest/config/CachingTestFilter.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/CachingTestFilter.java
@@ -49,7 +49,7 @@ public abstract class CachingTestFilter extends TestFilter {
             this.value = v;
         }
     }
-    private final Map<String, Entry> cache = new HashMap<String, Entry>();
+    private final Map<String, Entry> cache = new HashMap<>();
 
     /**
      * Creates a CachingTestFilter.

--- a/src/share/classes/com/sun/javatest/regtest/config/GroupManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/GroupManager.java
@@ -176,12 +176,12 @@ public class GroupManager {
 
         final Map<Group, TarjanNode<Group>> nodes = new HashMap<>();
         for (Group g: groups.values()) {
-            nodes.put(g, new TarjanNode<Group>(g) {
+            nodes.put(g, new TarjanNode<>(g) {
                 @Override
                 public Iterable<? extends TarjanNode<Group>> getDependencies() {
-                    List<TarjanNode<Group>> deps = new ArrayList<> ();
-                    for (Entry e: data.entries) {
-                        for (Group g: e.includeGroups) {
+                    List<TarjanNode<Group>> deps = new ArrayList<>();
+                    for (Entry e : data.entries) {
+                        for (Group g : e.includeGroups) {
                             deps.add(nodes.get(g));
                         }
                     }

--- a/src/share/classes/com/sun/javatest/regtest/config/Locations.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/Locations.java
@@ -773,7 +773,7 @@ public class Locations {
 
     private static final AtomicInteger uniqueId = new AtomicInteger(0);
 
-    private static final ThreadLocal<Integer> uniqueNum = new ThreadLocal<Integer>() {
+    private static final ThreadLocal<Integer> uniqueNum = new ThreadLocal<>() {
         @Override
         protected Integer initialValue() {
             return uniqueId.getAndIncrement();

--- a/src/share/classes/com/sun/javatest/regtest/config/OS.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/OS.java
@@ -141,7 +141,7 @@ public class OS {
             if (!Character.isDigit(c) && c != '.')
                 break;
         }
-        List<Integer> v = new ArrayList<Integer>();
+        List<Integer> v = new ArrayList<>();
         for (String s: version.substring(0, index).split("\\.")) {
             if (s.length() > 0)
                 v.add(Integer.valueOf(s));

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionContext.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionContext.java
@@ -67,7 +67,7 @@ public class RegressionContext implements Expr.Context {
         this.params = params;
         validPropNames = null;
 
-        values = new HashMap<String, String>();
+        values = new HashMap<>();
         values.put("null", "null");
 
         JDK_Version jdkVersion;
@@ -149,8 +149,8 @@ public class RegressionContext implements Expr.Context {
     private void processVMOptions(List<String> vmOptions) {
         String gc = null;
         String compMode = null;
-        Map<String, Boolean> vmBools = new HashMap<String, Boolean>();
-        Map<String, String> vmProps = new HashMap<String, String>();
+        Map<String, Boolean> vmBools = new HashMap<>();
+        Map<String, String> vmProps = new HashMap<>();
 
         for (String opt: vmOptions) {
             if (opt.equals("-" + MODE_MIXED)) {

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionEnvironment.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionEnvironment.java
@@ -33,7 +33,7 @@ import com.sun.javatest.TestEnvironment;
 public class RegressionEnvironment extends TestEnvironment
 {
     RegressionEnvironment(RegressionParameters params) throws Fault {
-        super("regtest", new ArrayList<Map<String, String>>(), new String[] { });
+        super("regtest", new ArrayList<>(), new String[] { });
         this.params = params;
     }
 

--- a/src/share/classes/com/sun/javatest/regtest/config/TestProperties.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestProperties.java
@@ -303,7 +303,7 @@ public class TestProperties {
             private Set<File> initFileSet(Set<File> parent, String propertyName, File baseDir) {
                 String[] values = StringUtils.splitWS(properties.getProperty(propertyName));
                 if (parent == null || values.length > 0) {
-                    Set<File> set = (parent == null) ? new LinkedHashSet<File>() : new LinkedHashSet<>(parent);
+                    Set<File> set = (parent == null) ? new LinkedHashSet<>() : new LinkedHashSet<>(parent);
                     //set.addAll(Arrays.asList(values));
                     for (String v: values) {
                         File f = toFile(baseDir, v);
@@ -319,7 +319,7 @@ public class TestProperties {
             private Set<String> initLibDirSet(Set<String> parent, String propertyName, File baseDir) {
                 String[] values = StringUtils.splitWS(properties.getProperty(propertyName));
                 if (parent == null || values.length > 0) {
-                    Set<String> set = (parent == null) ? new LinkedHashSet<String>() : new LinkedHashSet<>(parent);
+                    Set<String> set = (parent == null) ? new LinkedHashSet<>() : new LinkedHashSet<>(parent);
                     for (String v: values) {
                         if (v.startsWith("/")) {
                             set.add(v);
@@ -342,7 +342,7 @@ public class TestProperties {
             private Set<String> initKeywordSet(Set<String> parent, String propertyName) {
                 String[] values = StringUtils.splitWS(properties.getProperty(propertyName));
                 if (parent == null || values.length > 0) {
-                    Set<String> set = (parent == null) ? new LinkedHashSet<String>() : new LinkedHashSet<>(parent);
+                    Set<String> set = (parent == null) ? new LinkedHashSet<>() : new LinkedHashSet<>(parent);
                     for (String v: values) {
                         try {
                             RegressionKeywords.validateKey(v);
@@ -361,7 +361,7 @@ public class TestProperties {
             private Set<String> initSimpleSet(Set<String> parent, String propertyName) {
                 String[] values = StringUtils.splitWS(properties.getProperty(propertyName));
                 if (parent == null || values.length > 0) {
-                    Set<String> set = (parent == null) ? new LinkedHashSet<String>() : new LinkedHashSet<>(parent);
+                    Set<String> set = (parent == null) ? new LinkedHashSet<>() : new LinkedHashSet<>(parent);
                     set.addAll(Arrays.asList(values));
                     return Collections.unmodifiableSet(set);
                 } else {

--- a/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
@@ -166,7 +166,7 @@ public class CleanAction extends Action
 
     @Override
     public Set<File> getSourceFiles() {
-        Set<File> files = new LinkedHashSet<File>();
+        Set<File> files = new LinkedHashSet<>();
         for (String arg: args) {
             // the arguments to clean are class names or package names with wildcards
             try {

--- a/src/share/classes/com/sun/javatest/regtest/exec/ProcessCommand.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ProcessCommand.java
@@ -58,7 +58,7 @@ public class ProcessCommand
      */
     public ProcessCommand setStatusForExit(int exitCode, Status status) {
         if (statusTable == null) {
-            statusTable = new HashMap<Integer, Status>();
+            statusTable = new HashMap<>();
             if (defaultStatus == null) {
                 defaultStatus = Status.error("unrecognized exit code");
             }
@@ -81,7 +81,7 @@ public class ProcessCommand
      */
     public ProcessCommand setDefaultStatus(Status status) {
         if (statusTable == null) {
-            statusTable = new HashMap<Integer, Status>();
+            statusTable = new HashMap<>();
         }
         defaultStatus = status;
         return this;

--- a/src/share/classes/com/sun/javatest/regtest/exec/ScratchDirectory.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ScratchDirectory.java
@@ -107,7 +107,7 @@ abstract class ScratchDirectory {
         }
     }
 
-    private static final Set<File> badDirs = new HashSet<File>();
+    private static final Set<File> badDirs = new HashSet<>();
 
     private static synchronized boolean isBadDir(File dir) {
         return badDirs.contains(dir);
@@ -167,7 +167,7 @@ abstract class ScratchDirectory {
     private void deleteFilesWithRetry(File dir, Pattern p, boolean match, PrintWriter log)
             throws Fault, InterruptedException {
         long startTime = System.currentTimeMillis();
-        Set<File> cantDelete = new LinkedHashSet<File>();
+        Set<File> cantDelete = new LinkedHashSet<>();
 
         do {
             if (deleteFiles(dir, p, match, false, cantDelete, log)) {
@@ -423,7 +423,7 @@ abstract class ScratchDirectory {
             }
         }
 
-        private static ThreadLocal<ThreadInfo> threadInfo = new ThreadLocal<ThreadInfo>() {
+        private static ThreadLocal<ThreadInfo> threadInfo = new ThreadLocal<>() {
             @Override
             public ThreadInfo initialValue() {
                 return new ThreadInfo();

--- a/src/share/classes/com/sun/javatest/regtest/tool/Help.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Help.java
@@ -354,7 +354,7 @@ public class Help {
             groups.add(o.group);
         Map<String, SortedMap<String, Option>> map = new LinkedHashMap<>();
         for (String g: groups)
-            map.put(g, new TreeMap<String, Option>(new CaseInsensitiveStringComparator()));
+            map.put(g, new TreeMap<>(new CaseInsensitiveStringComparator()));
         for (Option o: options) {
             if (o.names.length > 0)
                 map.get(o.group).put(o.names[0], o);

--- a/src/share/classes/com/sun/javatest/regtest/tool/JCovManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/JCovManager.java
@@ -175,7 +175,7 @@ public class JCovManager {
     }
 
     void instrumentClasses() {
-        List<String> opts = new ArrayList<String>();
+        List<String> opts = new ArrayList<>();
         opts.add("instr");
 
         delete(instrClasses);
@@ -248,7 +248,7 @@ public class JCovManager {
 
         results.delete();
 
-        List<String> opts = new ArrayList<String>();
+        List<String> opts = new ArrayList<>();
         opts.add("grabber");
         opts.add("-port");
         opts.add("0");
@@ -309,7 +309,7 @@ public class JCovManager {
     }
 
     void stopGrabber() {
-        List<String> opts = new ArrayList<String>();
+        List<String> opts = new ArrayList<>();
         opts.add("grabberManager");
 
         if (printEnv)
@@ -333,7 +333,7 @@ public class JCovManager {
     }
 
     void writeReport() {
-        List<String> opts = new ArrayList<String>();
+        List<String> opts = new ArrayList<>();
         opts.add("repgen");
 
         opts.add("-source");
@@ -364,7 +364,7 @@ public class JCovManager {
     }
 
     void writePatchReport() {
-        List<String> opts = new ArrayList<String>();
+        List<String> opts = new ArrayList<>();
         opts.add("diffcoverage");
 
         opts.add("-replaceDiff");
@@ -412,7 +412,7 @@ public class JCovManager {
     }
 
     List<String> splitLines(File f) throws IOException {
-        List<String> lines = new ArrayList<String>();
+        List<String> lines = new ArrayList<>();
         BufferedReader in = new BufferedReader(new FileReader(f));
         String line;
         try {
@@ -442,7 +442,7 @@ public class JCovManager {
 
         public void run() {
             try {
-                List<String> args = new ArrayList<String>();
+                List<String> args = new ArrayList<>();
                 args.add(jdk.getJavaProg().toString());
                 args.add("-jar");
                 args.add(jcov_jar.getPath());
@@ -484,8 +484,8 @@ public class JCovManager {
     private SearchPath source;
     private String verbose;
     private boolean printEnv;
-    private List<String> includeOpts = new ArrayList<String>();
-    private List<String> excludeOpts = new ArrayList<String>();
+    private List<String> includeOpts = new ArrayList<>();
+    private List<String> excludeOpts = new ArrayList<>();
 
     JDK testJDK;
     File instrClasses;

--- a/src/share/classes/com/sun/javatest/regtest/tool/OptionDecoder.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/OptionDecoder.java
@@ -234,11 +234,11 @@ public class OptionDecoder {
     }
 
 
-    private Map<String, Option> simpleOptions = new HashMap<String, Option>();
-    private List<Option> matchOptions = new ArrayList<Option>();
+    private Map<String, Option> simpleOptions = new HashMap<>();
+    private List<Option> matchOptions = new ArrayList<>();
     private Option fileOption;
 
-    private Map<String, String> locks = new HashMap<String, String>();
+    private Map<String, String> locks = new HashMap<>();
     private boolean inFiles;
 
     protected static boolean debugOptions = Boolean.getBoolean("javatest.regtest.debugOptions");

--- a/src/share/classes/com/sun/jct/utils/i18ncheck/Main.java
+++ b/src/share/classes/com/sun/jct/utils/i18ncheck/Main.java
@@ -193,8 +193,8 @@ public class Main {
 
     boolean report(Map<String, NameInfo> table) {
         // invert the data structure to get File -> Set<name>
-        Map<File, Set<String>> undefinedNames = new TreeMap<File, Set<String>>();
-        Map<File, Set<String>> unusedNames = new TreeMap<File, Set<String>>();
+        Map<File, Set<String>> undefinedNames = new TreeMap<>();
+        Map<File, Set<String>> unusedNames = new TreeMap<>();
         for (NameInfo e: table.values()) {
             if (e.definitions == null || e.definitions.size() == 0)
                 insert(undefinedNames, e.name, e.references);
@@ -212,7 +212,7 @@ public class Main {
         for (File f: files) {
             Set<String> s = table.get(f);
             if (s == null)
-                table.put(f, s = new TreeSet<String>());
+                table.put(f, s = new TreeSet<>());
             s.add(name);
         }
     }
@@ -235,7 +235,7 @@ public class Main {
             nameTable.put(name, e);
         }
         if (e.definitions == null)
-            e.definitions = new TreeSet<File>();
+            e.definitions = new TreeSet<>();
         e.definitions.add(file);
     }
 
@@ -246,7 +246,7 @@ public class Main {
             nameTable.put(name, e);
         }
         if (e.references == null)
-            e.references = new TreeSet<File>();
+            e.references = new TreeSet<>();
         e.references.add(file);
     }
 
@@ -303,7 +303,7 @@ public class Main {
 
         public void addFileSet(FileSet fs) {
             if (fileSets == null)
-                fileSets = new ArrayList<FileSet>();
+                fileSets = new ArrayList<>();
             fileSets.add(fs);
         }
 
@@ -326,10 +326,10 @@ public class Main {
         }
     }
 
-    List<File> patternFiles = new ArrayList<File>();
-    List<File> argFiles = new ArrayList<File>();
+    List<File> patternFiles = new ArrayList<>();
+    List<File> argFiles = new ArrayList<>();
 
-    Map<String, NameInfo> nameTable = new TreeMap<String, NameInfo>();
-    List<PatternInfo> patterns = new ArrayList<PatternInfo>();
+    Map<String, NameInfo> nameTable = new TreeMap<>();
+    List<PatternInfo> patterns = new ArrayList<>();
     Pattern groupNumber = Pattern.compile("\\\\([0-9]*)");
 }


### PR DESCRIPTION
Update jtreg to use the diamond operator to eliminate reduct use of type arguments.