### PR TITLE
7903093: Detect/report invalid class names given to @clean action

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
@@ -37,6 +37,8 @@ import com.sun.javatest.regtest.config.Locations;
 import com.sun.javatest.regtest.config.Locations.ClassLocn;
 import com.sun.javatest.regtest.config.ParseException;
 
+import javax.lang.model.SourceVersion;
+
 import static com.sun.javatest.regtest.RStatus.error;
 import static com.sun.javatest.regtest.RStatus.passed;
 
@@ -87,8 +89,7 @@ public class CleanAction extends Action
             throw new ParseException(CLEAN_NO_CLASSNAME);
 
         for (String currArg : args) {
-            if ((currArg.indexOf(File.separatorChar) != -1)
-                    || (currArg.indexOf('/') != -1))
+            if (!SourceVersion.isName(currArg))
                 throw new ParseException(CLEAN_BAD_CLASSNAME + currArg);
         }
     } // init()

--- a/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
@@ -88,9 +88,13 @@ public class CleanAction extends Action
         if (args.isEmpty())
             throw new ParseException(CLEAN_NO_CLASSNAME);
 
-        for (String currArg : args) {
-            if (!SourceVersion.isName(currArg))
-                throw new ParseException(CLEAN_BAD_CLASSNAME + currArg);
+        for (String arg : args) {
+            if ("*".equals(arg)) // allow "clean default package" marker
+                continue;
+            // allow "clean any package" pattern
+            String name = arg.endsWith(".*") ? arg.substring(0, arg.length() - 2) : arg;
+            if (!SourceVersion.isName(name))
+                throw new ParseException(CLEAN_BAD_CLASSNAME + arg);
         }
     } // init()
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
@@ -89,12 +89,15 @@ public class CleanAction extends Action
             throw new ParseException(CLEAN_NO_CLASSNAME);
 
         for (String arg : args) {
-            if ("*".equals(arg)) // allow "clean default package" marker
+            // allow "clean default package" marker
+            if ("*".equals(arg))
                 continue;
-            // allow "clean any package" pattern
+            // allow qualified class name with optional "clean any package" pattern
             String name = arg.endsWith(".*") ? arg.substring(0, arg.length() - 2) : arg;
-            if (!SourceVersion.isName(name))
-                throw new ParseException(CLEAN_BAD_CLASSNAME + arg);
+            if (SourceVersion.isName(name))
+                continue;
+            // detected a syntactically invalid class name
+            throw new ParseException(CLEAN_BAD_CLASSNAME + arg);
         }
     } // init()
 

--- a/test/basic/Basic.gmk
+++ b/test/basic/Basic.gmk
@@ -63,7 +63,7 @@ $(BUILDDIR)/Basic.check.ok: \
 		$(TESTDIR)/share/basic \
 		> $(@:%.ok=%/log) 2>&1|| \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: 155; error: 83' $(@:%.ok=%/log)  > /dev/null
+	$(GREP) -s 'Test results: passed: 156; error: 84' $(@:%.ok=%/log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 INITIAL_TESTS += \

--- a/test/share/basic/clean/BadTag.java
+++ b/test/share/basic/clean/BadTag.java
@@ -45,3 +45,8 @@
  * @summary Error: Parse Exception: Bad classname provided for `clean': dir/Test
  * @clean dir/Test
  */
+
+/* @test
+ * @summary Error: Parse Exception: Bad classname provided for `clean': JARandom.class
+ * @run clean JARandom.class
+ */

--- a/test/share/basic/clean/Pass.java
+++ b/test/share/basic/clean/Pass.java
@@ -33,7 +33,12 @@
 
 /* @test
  * @summary Passed: Clean Successful
- * @run clean JARandom.class
+ * @run clean JARandom
+ */
+
+/* @test
+ * @summary Passed: Clean Successful
+ * @run clean abc.def.JARandom
  */
 
 /* @test


### PR DESCRIPTION
Check the validity of all given class names by delegating the check to the `javax.lang.model.SourceVersion#isName` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903093](https://bugs.openjdk.java.net/browse/CODETOOLS-7903093): Detect/report invalid class names given to @clean action


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.java.net/jtreg pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/53.diff">https://git.openjdk.java.net/jtreg/pull/53.diff</a>

</details>
