### PR TITLE
CODETOOLS-7903098: CODETOOLS-7903093 breaks some `basic` tests

### DIFF
--- a/test/basic/Basic.java
+++ b/test/basic/Basic.java
@@ -167,8 +167,8 @@ public class Basic
         numMain   += 1;
 
         // clean
-        numPassed += 4; numFailed += 0; numError  += 6;
-        numClean  += 10;
+        numPassed += 5; numFailed += 0; numError  += 7;
+        numClean  += 12;
         numShell  += 1;
 
         // compile

--- a/test/basic/ReportOnlyTest.gmk
+++ b/test/basic/ReportOnlyTest.gmk
@@ -38,7 +38,7 @@ $(BUILDDIR)/ReportOnlyTest.ok: $(BUILDDIR)/Basic.othervm.ok \
 		$(TESTDIR)/share/basic \
 			> $(@:%.ok=%.jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: 92; failed: 44; error: 87' $(@:%.ok=%.jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: 93; failed: 44; error: 88' $(@:%.ok=%.jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 ifndef HEADLESS


### PR DESCRIPTION
Please review the fixes for a couple of broken tests, after a couple of new test cases were added to the venerable `basic` set of tests.

In the [review for CODETOOLS-7903098](https://github.com/openjdk/jtreg/commit/86d0b3b077be7e89f984a8dcd44c256393c7ec98)
see the two new test cases added for the `@clean` action: one good, one bad.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903098](https://bugs.openjdk.java.net/browse/CODETOOLS-7903098): CODETOOLS-7903093 breaks some `basic` tests


### Reviewers
 * [Christian Stein](https://openjdk.java.net/census#cstein) (@sormuras - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/jtreg pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/55.diff">https://git.openjdk.java.net/jtreg/pull/55.diff</a>

</details>
