### PR TITLE
CODETOOLS-7903096: remove old @author tags

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,13 +6,18 @@ Original Author:
 Tag Specification:
     Mark Reinhold
 
-Currently Maintained By:
-    Jonathan Gibbons
+Currently Maintained As Part Of:
+    OpenJDK CodeTools Project
 
-Other Contributors:
+Other Early Contributors:
     Brian Kurotsuchi
     Dawn Phillips
     Jessica Mauvais
+    John Rose
     Maurizio Cimadamore
     Kumar Srinivasan
+
+Since open-sourcing the code in 2006, and the use of first Mercurial and
+subsequently Git, the Contributors are tracked in the SCM metadata.
+For all recent contributors and contributions, see `git shortlog` or `git log`.
 

--- a/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AppletWrapper.java
@@ -60,8 +60,6 @@ import java.util.HashMap;
 
 /**
   * This class is the wrapper for all applet tests.
-  *
-  * @author Iris A Garcia
   */
 @SuppressWarnings("removal") // Applet and related APIs
 public class AppletWrapper

--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -32,8 +32,6 @@ import java.lang.reflect.Method;
 
 /**
  * TestRunner to run JUnit tests.
- *
- * @author John R. Rose
  */
 public class JUnitRunner implements MainActionHelper.TestRunner {
     private static final String

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
@@ -32,8 +32,6 @@ import java.lang.reflect.Method;
 
 /**
   * This class is the wrapper for all main/othervm tests.
-  *
-  * @author Iris A Garcia
   */
 public class MainWrapper
 {

--- a/src/share/classes/com/sun/javatest/regtest/agent/StringArray.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/StringArray.java
@@ -33,8 +33,6 @@ import java.util.List;
  * an append method and several methods to split strings based on separators,
  * terminators, whitespace, etc.
  * Limited to -target 1.1, so no generics.
- *
- * @author Iris A Garcia
  */
 public class StringArray {
 

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -45,8 +45,7 @@ import static org.testng.ITestResult.SUCCESS;
 import static org.testng.ITestResult.SUCCESS_PERCENTAGE_FAILURE;
 
 /**
- *
- * @author jjg
+ * TestRunner to run TestNG tests.
  */
 public class TestNGRunner implements MainActionHelper.TestRunner {
 

--- a/src/share/classes/com/sun/javatest/regtest/config/ParseException.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/ParseException.java
@@ -31,8 +31,6 @@ import com.sun.javatest.regtest.exec.TestRunException;
  * This class defines any error in parsing the provided test description. A
  * parsing error may occur either during initial examination of the tags in
  * the finder or during more extensive verification of the run action.
- *
- * @author Iris A Garcia
  */
 public class ParseException extends TestRunException
 {

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionContext.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionContext.java
@@ -36,9 +36,7 @@ import java.util.function.Consumer;
 import com.sun.javatest.regtest.agent.JDK_Version;
 
 /**
- *
- * @author Dmitry Fazunenko
- * @author jjg
+ * The set of named values used for evaluating expressions in test descriptions.
  */
 public class RegressionContext implements Expr.Context {
     /**
@@ -56,7 +54,7 @@ public class RegressionContext implements Expr.Context {
     }
 
     /**
-     * Creates a context for used with nteh specified parameters.
+     * Creates a context for used with the specified parameters.
      *
      * @param params the parameters
      * @param logger an object to which to write logging messages

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionTestFinder.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionTestFinder.java
@@ -62,7 +62,6 @@ import com.sun.javatest.util.I18NResourceBundle;
   * A test description consists of a single block comment in either Java files
   * or shell-script files.  A file may contain multiple test descriptions.
   *
-  * @author Iris A Garcia
   * @see com.sun.javatest.TestFinder
   * @see com.sun.javatest.finder.TagTestFinder
   */

--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -71,8 +71,6 @@ import com.sun.javatest.regtest.util.StringUtils;
  * Action abstract class contains a variety of protected methods for parsing and
  * logging.  All static strings used in Action implementations are also defined
  * here.
- *
- * @author Iris A Garcia
  */
 public abstract class Action extends ActionHelper {
     /**

--- a/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
@@ -59,7 +59,6 @@ import static com.sun.javatest.regtest.RStatus.*;
  * This class implements the "applet" action as described by the JDK tag
  * specification.
  *
- * @author Iris A Garcia
  * @see Action
  */
 public class AppletAction extends Action

--- a/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
@@ -51,7 +51,6 @@ import static com.sun.javatest.regtest.RStatus.passed;
  * This class implements the "build" action as described by the JDK tag
  * specification.
  *
- * @author Iris A Garcia
  * @see Action
  */
 public class BuildAction extends Action

--- a/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CleanAction.java
@@ -46,7 +46,6 @@ import static com.sun.javatest.regtest.RStatus.passed;
  * This class implements the "clean" action as described by the JDK tag
  * specification.
  *
- * @author Iris A Garcia
  * @see Action
  */
 public class CleanAction extends Action

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -78,7 +78,6 @@ import static com.sun.javatest.regtest.RStatus.passed;
  * specification. It is also invoked implicitly as needed by the "build"
  * action.
  *
- * @author Iris A Garcia
  * @see Action
  * @see com.sun.javatest.regtest.agent.MainActionHelper
  */

--- a/src/share/classes/com/sun/javatest/regtest/exec/IgnoreAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/IgnoreAction.java
@@ -39,7 +39,6 @@ import static com.sun.javatest.regtest.RStatus.passed;
  * This class implements the "ignore" action as described by the JDK tag
  * specification.
  *
- * @author Iris A Garcia
  * @see Action
  */
 public class IgnoreAction extends Action

--- a/src/share/classes/com/sun/javatest/regtest/exec/JUnitAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/JUnitAction.java
@@ -34,7 +34,6 @@ import com.sun.javatest.regtest.config.ParseException;
 /**
  * This class implements the "junit" action, which is a variation of "main".
  *
- * @author John R. Rose
  * @see MainAction
  */
 public class JUnitAction extends MainAction

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -67,7 +67,6 @@ import static com.sun.javatest.regtest.RStatus.passed;
  * This class implements the "main" action as described by the JDK tag
  * specification.
  *
- * @author Iris A Garcia
  * @see Action
  * @see com.sun.javatest.regtest.agent.MainActionHelper
  */

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -87,7 +87,6 @@ import static com.sun.javatest.regtest.RStatus.passed;
   * This class interprets the TestDescription as specified by the JDK tag
   * specification.
   *
-  * @author Iris A Garcia
   * @see com.sun.javatest.Script
   */
 public class RegressionScript extends Script {

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -50,7 +50,6 @@ import static com.sun.javatest.regtest.RStatus.*;
  * This class implements the "shell" action as described by the JDK tag
  * specification.
  *
- * @author Iris A Garcia
  * @see Action
  */
 public class ShellAction extends Action

--- a/src/share/classes/com/sun/javatest/regtest/exec/TestRunException.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/TestRunException.java
@@ -27,8 +27,6 @@ package com.sun.javatest.regtest.exec;
 
 /**
  * This class defines any exception thrown by the Regression extensions.
- *
- * @author Iris A Garcia
  */
 public class TestRunException extends Exception
 {

--- a/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
@@ -63,8 +63,6 @@ import com.sun.javatest.TestResult.Section;
 /**
  * Write out results in JUnit-compatible XML format, for processing by tools
  * that can process such files, such as CI systems like Hudson and Jenkins.
- *
- * @author ksrini
  */
 public class XMLWriter {
     static final String PASSED = "Passed.";


### PR DESCRIPTION
Please review a patch to remove the few remaining `@author` tags, and to update the CONTRIBUTORS file accordingly.
The authors in the legacy tags are now in the CONTRIBUTORS file, which is also updated to describe the use of SCM metadata for contributors and contributions, which is a much better mechanism than poorly maintained `@author` tags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903096](https://bugs.openjdk.java.net/browse/CODETOOLS-7903096): remove old @author tags


### Reviewers
 * [Christian Stein](https://openjdk.java.net/census#cstein) (@sormuras - no project role)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.java.net/jtreg pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/56.diff">https://git.openjdk.java.net/jtreg/pull/56.diff</a>

</details>
