### PR TITLE
CODETOOLS-7903102: Remove obsolete traces of references to JavaHelp

### DIFF
--- a/make/build.properties
+++ b/make/build.properties
@@ -31,14 +31,6 @@ jtreg.build.resources = /opt
 # JTHarness or JavaTest (should be should be 6.0 or better)
 javatest.home = ${jtreg.build.resources}/jtharness/6.0
 javatest.jar = ${javatest.home}/lib/javatest.jar
-#   the following is only true for older versions of JavaTest.
-#   can't use <available> to set it automatically for some reason
-#javatest.includes.javahelp.ok = true
-
-# JavaHelp (should be version 2.0 or better)
-javahelp.home = ${jtreg.build.resources}/javahelp/2.0
-jhall.jar = ${javahelp.home}/javahelp/lib/jhall.jar
-jh.jar = ${javahelp.home}/javahelp/lib/jh.jar
 
 # JUnit (should be 4.10 or better)
 junit.jar = ${jtreg.build.resources}/junit/4.10/junit-4.10.jar

--- a/make/build.properties
+++ b/make/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/build.xml
+++ b/make/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it

--- a/make/build.xml
+++ b/make/build.xml
@@ -144,7 +144,7 @@
             <manifest>
                 <attribute name="Built-By" value="${user.name}"/>
                 <attribute name="Main-Class" value="com.sun.javatest.regtest.Main"/>
-                <attribute name="Class-Path" value="javatest.jar jh.jar junit.jar"/>
+                <attribute name="Class-Path" value="javatest.jar junit.jar"/>
                 <attribute name="jtreg-Name" value="jtreg"/>
                 <attribute name="jtreg-Version" value="${build.version}"/>
                 <attribute name="jtreg-Milestone" value="${build.milestone}"/>
@@ -188,7 +188,7 @@
         <!-- have to set fork=true because otherwise output redirection gets screwed up -->
         <mkdir dir="${build.dir}/jtreg"/>
         <java fork="true" failonerror="true"
-            classname="com.sun.javatest.regtest.Main" classpath="${build.classes.dir}:${javatest.jar}:${junit.jar}:${jh.jar}"
+            classname="com.sun.javatest.regtest.Main" classpath="${build.classes.dir}:${javatest.jar}:${junit.jar}"
             output="${build.dir}/jtreg/usage.txt">
             <jvmarg value="-Dprogram=jtreg"/>
             <arg value="-help"/>
@@ -209,7 +209,7 @@
 
     <!-- ********** imports ************************************************ -->
 
-    <target name="import-javatest" depends="-init,import-javahelp" if="javatest.ok">
+    <target name="import-javatest" depends="-init" if="javatest.ok">
         <copy todir="${dist.jtreg.dir}/doc/javatest" file="${javatest.home}/doc/javatest/javatestGUI.pdf"/>
         <copy tofile="${dist.jtreg.dir}/legal/javatest/copyright.html" file="${javatest.home}/COPYRIGHT-javatest.html"/>
         <copy file="${javatest.jar}" tofile="${dist.jtreg.dir}/lib/javatest.jar"/>
@@ -236,14 +236,10 @@
         <copy file="${jcov.home}/lib/jcov_network_saver.jar" tofile="${dist.jtreg.dir}/lib/jcov_network_saver.jar"/>
     </target>
 
-    <target name="import-jtharness" depends="-init,import-javahelp" if="jtharness.ok">
+    <target name="import-jtharness" depends="-init" if="jtharness.ok">
         <copy todir="${dist.jtreg.dir}/legal/jtharness" file="${javatest.home}/legal/copyright.txt"/>
         <copy todir="${dist.jtreg.dir}/legal/jtharness" file="${javatest.home}/legal/license.txt"/>
         <copy file="${javatest.jar}" tofile="${dist.jtreg.dir}/lib/javatest.jar"/>
-    </target>
-
-    <target name="import-javahelp" unless="javatest.includes.javahelp.ok">
-        <copy file="${jh.jar}" tofile="${dist.jtreg.dir}/lib/jh.jar"/>
     </target>
 
     <!-- ********** jct-utils ********************************************** -->

--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -218,11 +218,6 @@ $(JTREG_IMAGEJARDIR)/jtreg.jar: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(TARGETS.JAR.jtreg)
 
-ifdef JAVAHELP_JAR
-$(JTREG_IMAGEJARDIR)/jtreg.jar: \
-	$(JTREG_IMAGEJARDIR)/jh.jar 
-endif
-
 TARGETS.ZIP.jtreg += $(JTREG_IMAGEJARDIR)/jtreg.jar
 
 #----------------------------------------------------------------------

--- a/make/netbeans/jtreg/nbproject/project.xml
+++ b/make/netbeans/jtreg/nbproject/project.xml
@@ -113,7 +113,7 @@
         <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/4">
             <compilation-unit>
                 <package-root>${root}/src/share/classes</package-root>
-                <classpath mode="compile">${javatest.jar}:${jh.jar}:${ant.jar}:${junit.jar}:${testng.jar}</classpath>
+                <classpath mode="compile">${javatest.jar}:$${ant.jar}:${junit.jar}:${testng.jar}</classpath>
                 <source-level>1.7</source-level>
             </compilation-unit>
         </java-data>

--- a/make/netbeans/jtreg/nbproject/project.xml
+++ b/make/netbeans/jtreg/nbproject/project.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/test/7113596/T7113596.gmk
+++ b/test/7113596/T7113596.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/7113596/T7113596.gmk
+++ b/test/7113596/T7113596.gmk
@@ -27,8 +27,7 @@
 
 $(BUILDDIR)/T7113596.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(LN) -s $(JDKHOME) $(@:%.ok=%)/jdk
 	cd $(@:%.ok=%) && $(JDKJAVA) -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \

--- a/test/TestWhiteSpaceFiles.gmk
+++ b/test/TestWhiteSpaceFiles.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/TestWhiteSpaceFiles.gmk
+++ b/test/TestWhiteSpaceFiles.gmk
@@ -28,7 +28,6 @@
 $(BUILDDIR)/TestWhiteSpaceFiles.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR) \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(BUILDDIR)/tmp/$(@F:%.ok=%)
 	$(MKDIR) -p $(BUILDDIR)/tmp/$(@F:%.ok=%)

--- a/test/autovm/AutoVMTests.gmk
+++ b/test/autovm/AutoVMTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/autovm/AutoVMTests.gmk
+++ b/test/autovm/AutoVMTests.gmk
@@ -29,8 +29,7 @@ AUTOVM_FILES := $(shell find $(TESTDIR)/autovm -type f )
 		
 $(BUILDDIR)/autovm.ok: $(AUTOVM_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	for ts in none agentvm othervm; do \
 	    $(MKDIR) -p $(BUILDDIR)/autovm/tests/default.$$ts ; \
 	    rsync --recursive --delete $(TESTDIR)/autovm/ $(BUILDDIR)/autovm/tests/default.$$ts/ ; \

--- a/test/basic/Basic.gmk
+++ b/test/basic/Basic.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/basic/Basic.gmk
+++ b/test/basic/Basic.gmk
@@ -47,7 +47,6 @@ endif
 $(BUILDDIR)/Basic.check.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR) \
 		$(JTREG_IMAGEDIR)/lib/junit.jar \
 		$(JTREG_IMAGEDIR)/lib/testng.jar \
 		$(BUILDDIR)/i18n.com.sun.javatest.regtest.ok \
@@ -101,7 +100,6 @@ $(BUILDDIR)/Basic.othervm.ok \
 $(BUILDDIR)/Basic.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR) \
 		$(JTREG_IMAGEDIR)/lib/junit.jar \
 		$(JTREG_IMAGEDIR)/lib/testng.jar \
 		$(TESTDIR)/basic/Basic.java \

--- a/test/classIsolation/ClassIsolationTest.gmk
+++ b/test/classIsolation/ClassIsolationTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/classIsolation/ClassIsolationTest.gmk
+++ b/test/classIsolation/ClassIsolationTest.gmk
@@ -31,8 +31,7 @@ UCD_FILES := $(shell find $(TESTDIR)/classIsolation -type f )
 
 $(BUILDDIR)/ClassIsolation.disable.b07.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) -p  $(@:%.ok=%)/jtreg
 	$(CP) -R $(JTREG_IMAGEDIR)/* $(@:%.ok=%)/jtreg
@@ -53,8 +52,7 @@ $(BUILDDIR)/ClassIsolation.disable.b07.ok: $(UCD_FILES) \
 
 $(BUILDDIR)/ClassIsolation.disable.b08.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) -p  $(@:%.ok=%)/jtreg
 	$(CP) -R $(JTREG_IMAGEDIR)/* $(@:%.ok=%)/jtreg
@@ -74,8 +72,7 @@ $(BUILDDIR)/ClassIsolation.disable.b08.ok: $(UCD_FILES) \
 
 $(BUILDDIR)/ClassIsolation.default.b08.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) -p  $(@:%.ok=%)/jtreg
 	$(CP) -R $(JTREG_IMAGEDIR)/* $(@:%.ok=%)/jtreg
@@ -95,8 +92,7 @@ $(BUILDDIR)/ClassIsolation.default.b08.ok: $(UCD_FILES) \
 
 $(BUILDDIR)/ClassIsolation.enable.b08.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) -p  $(@:%.ok=%)/jtreg
 	$(CP) -R $(JTREG_IMAGEDIR)/* $(@:%.ok=%)/jtreg

--- a/test/env/EnvTest.gmk
+++ b/test/env/EnvTest.gmk
@@ -27,8 +27,7 @@ ENV.files := $(shell find $(TESTDIR)/env -type f)
 
 $(BUILDDIR)/EnvTest.simple.ok: $(ENV.files) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR) \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) $(@:%.ok=%)
@@ -52,8 +51,7 @@ $(BUILDDIR)/EnvTest.simple.ok: $(ENV.files) \
 
 $(BUILDDIR)/EnvTest.full.ok: $(ENV.files) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR) \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) $(@:%.ok=%)

--- a/test/env/EnvTest.gmk
+++ b/test/env/EnvTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ ENV.files := $(shell find $(TESTDIR)/env -type f)
 
 $(BUILDDIR)/EnvTest.simple.ok: $(ENV.files) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) $(@:%.ok=%)
@@ -51,7 +51,7 @@ $(BUILDDIR)/EnvTest.simple.ok: $(ENV.files) \
 
 $(BUILDDIR)/EnvTest.full.ok: $(ENV.files) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) $(@:%.ok=%)

--- a/test/exclude/ExcludeTest.gmk
+++ b/test/exclude/ExcludeTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/exclude/ExcludeTest.gmk
+++ b/test/exclude/ExcludeTest.gmk
@@ -28,8 +28,7 @@
 $(BUILDDIR)/exclude.othervm.ok \
 $(BUILDDIR)/exclude.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/fixup/FixupTest.gmk
+++ b/test/fixup/FixupTest.gmk
@@ -27,7 +27,6 @@
 
 $(BUILDDIR)/fixupSingle.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR) \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)

--- a/test/fixup/FixupTest.gmk
+++ b/test/fixup/FixupTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/i18n/i18n.com.sun.javatest.regtest.gmk
+++ b/test/i18n/i18n.com.sun.javatest.regtest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/i18n/i18n.com.sun.javatest.regtest.gmk
+++ b/test/i18n/i18n.com.sun.javatest.regtest.gmk
@@ -57,7 +57,7 @@ $(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok: \
 		$(JAVADIR)/com/sun/javatest/regtest/tool/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
-	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)$(PS)$(JAVAHELP_JAR)" \
+	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
 	    $(JDKJAVA) -Djavatest.i18n.log=com.sun.javatest.regtest.tool \
 		$(JCOV_JARS) \
 		com.sun.javatest.regtest.Main -help all \

--- a/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
+++ b/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
@@ -28,8 +28,7 @@
 $(BUILDDIR)/ignoresymbolfile.othervm.ok \
 $(BUILDDIR)/ignoresymbolfile.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR) 
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/jcov/jcov.gmk
+++ b/test/jcov/jcov.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/jcov/jcov.gmk
+++ b/test/jcov/jcov.gmk
@@ -29,7 +29,6 @@ $(BUILDDIR)/jcov.othervm.ok \
 $(BUILDDIR)/jcov.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR) \
 		$(JTREG_IMAGEDIR)/lib/jcov.jar \
 		$(JTREG_IMAGEDIR)/lib/jcov_network_saver.jar 
 	$(RM) $(@:%.ok=%/lib) $(@:%.ok=%/work) $(@:%.ok=%/report)

--- a/test/libBuildArgs/LibBuildArgsTest.gmk
+++ b/test/libBuildArgs/LibBuildArgsTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/libBuildArgs/LibBuildArgsTest.gmk
+++ b/test/libBuildArgs/LibBuildArgsTest.gmk
@@ -28,8 +28,7 @@
 
 $(BUILDDIR)/LibBuildArgsTest.good.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \
@@ -43,8 +42,7 @@ $(BUILDDIR)/LibBuildArgsTest.good.ok: \
 
 $(BUILDDIR)/LibBuildArgsTest.bad.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/libdirs/LibDirsTest.gmk
+++ b/test/libdirs/LibDirsTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/libdirs/LibDirsTest.gmk
+++ b/test/libdirs/LibDirsTest.gmk
@@ -28,8 +28,7 @@
 
 $(BUILDDIR)/LibDirsTest.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/match/MatchTest.gmk
+++ b/test/match/MatchTest.gmk
@@ -28,8 +28,7 @@
 $(BUILDDIR)/match.othervm.ok \
 $(BUILDDIR)/match.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/match/MatchTest.gmk
+++ b/test/match/MatchTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/multirun/MultiRunTest.gmk
+++ b/test/multirun/MultiRunTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/multirun/MultiRunTest.gmk
+++ b/test/multirun/MultiRunTest.gmk
@@ -27,7 +27,6 @@
 
 $(BUILDDIR)/multirun.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR) \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -64,7 +63,6 @@ $(BUILDDIR)/multirun.ok: \
 
 $(BUILDDIR)/multirun.noreport.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR) \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)

--- a/test/problemList/ProblemList.gmk
+++ b/test/problemList/ProblemList.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/problemList/ProblemList.gmk
+++ b/test/problemList/ProblemList.gmk
@@ -38,7 +38,6 @@
 
 $(BUILDDIR)/ProblemList.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR) \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)

--- a/test/statsTests/StatsTests.gmk
+++ b/test/statsTests/StatsTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/statsTests/StatsTests.gmk
+++ b/test/statsTests/StatsTests.gmk
@@ -44,8 +44,7 @@ endif
 
 $(BUILDDIR)/StatsTxt.1.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JDKJAVA) \
 	    -Djtreg.stats.format="TEST-STATS: StatsTxt run=%r failed=%F excluded=%x" \
@@ -67,8 +66,7 @@ TESTS.jtreg += $(BUILDDIR)/StatsTxt.1.ok
 
 $(BUILDDIR)/StatsTxt.2.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGE_JAVAHELP_JAR)
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JDKJAVA) \
 	    -Djtreg.stats.format="TEST-STATS: StatsTxt passed=%p failed=%F ignored=%i" \

--- a/test/statusFilter/StatusFilterTest.gmk
+++ b/test/statusFilter/StatusFilterTest.gmk
@@ -28,8 +28,7 @@
 
 $(BUILDDIR)/StatusFilter.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-		$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	#

--- a/test/statusFilter/StatusFilterTest.gmk
+++ b/test/statusFilter/StatusFilterTest.gmk
@@ -1,5 +1,5 @@
  #
-# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/testng/TestNGLibTest.gmk
+++ b/test/testng/TestNGLibTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/testng/TestNGLibTest.gmk
+++ b/test/testng/TestNGLibTest.gmk
@@ -28,8 +28,7 @@
 
 $(BUILDDIR)/TestNGLibTest.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/testprops/TestPropsTest.gmk
+++ b/test/testprops/TestPropsTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/testprops/TestPropsTest.gmk
+++ b/test/testprops/TestPropsTest.gmk
@@ -28,8 +28,7 @@
 
 $(BUILDDIR)/TestPropsTest.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/versionCheck/TestVersionCheck.gmk
+++ b/test/versionCheck/TestVersionCheck.gmk
@@ -27,8 +27,7 @@
 
 $(BUILDDIR)/TestVersionCheck.match.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \
@@ -54,8 +53,7 @@ endif
 
 $(BUILDDIR)/TestVersionCheck.mismatch.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	    	$(JTREG_IMAGE_JAVAHELP_JAR)
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \

--- a/test/versionCheck/TestVersionCheck.gmk
+++ b/test/versionCheck/TestVersionCheck.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review a build-only fix to remove obsolete references to the old JavaHelp system, which was removed back in 2016. [CODETOOLS-7901673](https://bugs.openjdk.java.net/browse/CODETOOLS-7901673)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903102](https://bugs.openjdk.java.net/browse/CODETOOLS-7903102): Remove obsolete traces of references to JavaHelp


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jtreg pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/58.diff">https://git.openjdk.java.net/jtreg/pull/58.diff</a>

</details>
