### PR TITLE
7903120: os.simpleArch is x64 for linux-loongarch64/mips64/mips64el in @require context

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/OS.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/OS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/config/OS.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/OS.java
@@ -123,6 +123,9 @@ public class OS {
                  && !arch.equals("ppc64")
                  && !arch.equals("ppc64le")
                  && !arch.equals("zArch_64")
+                 && !arch.equals("loongarch64")
+                 && !arch.equals("mips64")
+                 && !arch.equals("mips64el")
                  && !arch.equals("aarch64"))
             simple_arch = "x64";
         else if (arch.contains("86"))
@@ -131,6 +134,8 @@ public class OS {
             simple_arch = "ppc";
         else if (arch.equals("s390x") || arch.equals("zArch_64"))
             simple_arch = "s390x";
+        else if (arch.equals("mips64") || arch.equals("mips64el"))
+            simple_arch = "mips64";
         else
             simple_arch = arch;
 

--- a/src/share/classes/com/sun/javatest/regtest/config/OS.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/OS.java
@@ -124,8 +124,6 @@ public class OS {
                  && !arch.equals("ppc64le")
                  && !arch.equals("zArch_64")
                  && !arch.equals("loongarch64")
-                 && !arch.equals("mips64")
-                 && !arch.equals("mips64el")
                  && !arch.equals("aarch64"))
             simple_arch = "x64";
         else if (arch.contains("86"))


### PR DESCRIPTION
Also set simpleArch to mips64, when os.arch is mips64el.

Tested on loongarch64 and mips64. After the patch, [test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java](https://github.com/openjdk/jdk/blob/jdk-19%2B13/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java) was successfully skipped on loongarch64 and mips64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [CODETOOLS-7903120](https://bugs.openjdk.java.net/browse/CODETOOLS-7903120): os.simpleArch is x64 for linux-loongarch64/mips64/mips64el in @require context


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/jtreg pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/64.diff">https://git.openjdk.java.net/jtreg/pull/64.diff</a>

</details>
