### PR TITLE
CODETOOLS-7903143: jtreg includes `-javaoption` values in rerun section for @compile tasks in agentvm mode.

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -688,7 +688,7 @@ public class CompileAction extends Action {
             showCmd("compile", javacArgs, section);
 
         Path javacProg = script.getJavacProg();
-        List<String> javacVMOpts = script.getTestVMJavaOptions();
+        List<String> javacVMOpts = script.getTestVMOptions();
         recorder.javac(script.getEnvVars(), javacProg, javacVMOpts, javacProps, javacArgs);
 
         Agent agent;

--- a/test/rerun/std/AppletTest.agentvm.out
+++ b/test/rerun/std/AppletTest.agentvm.out
@@ -8,7 +8,6 @@ PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/javac \
         -J-Dmy.vm.option=x \
-        -J-Dmy.java.option=x \
         -J-Dtest.vm.opts=-Dmy.vm.option=x \
         -J-Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
         -J-Dtest.compiler.opts=-XDmy.javac.option=x \

--- a/test/rerun/std/BuildTest.agentvm.out
+++ b/test/rerun/std/BuildTest.agentvm.out
@@ -12,7 +12,6 @@ PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/javac \
         -J-Dmy.vm.option=x \
-        -J-Dmy.java.option=x \
         -J-Dtest.vm.opts=-Dmy.vm.option=x \
         -J-Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
         -J-Dtest.compiler.opts=-XDmy.javac.option=x \

--- a/test/rerun/std/CompileTest.agentvm.out
+++ b/test/rerun/std/CompileTest.agentvm.out
@@ -8,7 +8,6 @@ PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/javac \
         -J-Dmy.vm.option=x \
-        -J-Dmy.java.option=x \
         -J-Dtest.vm.opts=-Dmy.vm.option=x \
         -J-Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
         -J-Dtest.compiler.opts=-XDmy.javac.option=x \

--- a/test/rerun/std/JUnitTest.agentvm.out
+++ b/test/rerun/std/JUnitTest.agentvm.out
@@ -8,7 +8,6 @@ PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/javac \
         -J-Dmy.vm.option=x \
-        -J-Dmy.java.option=x \
         -J-Dtest.vm.opts=-Dmy.vm.option=x \
         -J-Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
         -J-Dtest.compiler.opts=-XDmy.javac.option=x \

--- a/test/rerun/std/MainTest.agentvm.out
+++ b/test/rerun/std/MainTest.agentvm.out
@@ -8,7 +8,6 @@ PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/javac \
         -J-Dmy.vm.option=x \
-        -J-Dmy.java.option=x \
         -J-Dtest.vm.opts=-Dmy.vm.option=x \
         -J-Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
         -J-Dtest.compiler.opts=-XDmy.javac.option=x \

--- a/test/rerun/std/TestNGTest.agentvm.out
+++ b/test/rerun/std/TestNGTest.agentvm.out
@@ -8,7 +8,6 @@ PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/javac \
         -J-Dmy.vm.option=x \
-        -J-Dmy.java.option=x \
         -J-Dtest.vm.opts=-Dmy.vm.option=x \
         -J-Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
         -J-Dtest.compiler.opts=-XDmy.javac.option=x \

--- a/test/rerun/testng/TestNGTest.agentvm.out
+++ b/test/rerun/testng/TestNGTest.agentvm.out
@@ -8,7 +8,6 @@ PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/javac \
         -J-Dmy.vm.option=x \
-        -J-Dmy.java.option=x \
         -J-Dtest.vm.opts=-Dmy.vm.option=x \
         -J-Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
         -J-Dtest.compiler.opts=-XDmy.javac.option=x \


### PR DESCRIPTION
Please review a trivial code fix and corresponding bug fix, to address the issue that jtreg incorrectly reports inapplicable options in the rerun info for a `@compile` section.

Background, values for the `-javaoption` should only be applied when running tests (@run main, etc) and not when compiling tests (@compile, @build).   That is true when the test is executed, but not true when generating the `rerun` script.
For `othervm` it's not an issue, because the `rerun` script is more directly derived from the command that is executed, but for `agentvm` the rerun info is just a synthesized approximation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903143](https://bugs.openjdk.java.net/browse/CODETOOLS-7903143): jtreg includes `-javaoption` values in rerun section for @compile tasks in agentvm mode.


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/jtreg pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/67.diff">https://git.openjdk.java.net/jtreg/pull/67.diff</a>

</details>
