### PR TITLE
CODETOOLS-7903147: unrooted relative paths in checkI18NProps.sh

### DIFF
--- a/test/i18n/checkI18NProps.sh
+++ b/test/i18n/checkI18NProps.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright (c) 2000, 2007, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,15 +30,15 @@
 # The message keys are extracted by a combination of static and dynamic
 # analysis.
 
-srcDir=$1
-dynProps=$2
+baseDir=$1  # base directory, for temp files
+srcDir=$2   # source directory, to scan for i18n coding patterns
+dynProps=$3 # optional log with 18n tracing info
 
-base=`basename $0`.$$
-requiredProps=$base.reqd.tmp
-definedProps=$base.defd.tmp
-diffs=$base.diff.tmp
-reqdNotDefd=$base.rqnd.tmp
-defdNotReqd=$base.dfnr.tmp
+requiredProps=$baseDir/required.txt
+definedProps=$baseDir/defined.txt
+diffs=$baseDir/diff.txt
+reqdNotDefd=$baseDir/required-not-defined.txt
+defdNotReqd=$baseDir/defined-not-required.txt
 
 # this is the command to extract the keys from the source files
 # customize as required
@@ -86,5 +86,4 @@ if [ -s $defdNotReqd ]; then
   exitCode=1
 fi
 
-rm -f $requiredProps $definedProps $diffs $reqdNotDefd $defdNotReqd
 exit ${exitCode:-0}

--- a/test/i18n/i18n.com.sun.javatest.diff.gmk
+++ b/test/i18n/i18n.com.sun.javatest.diff.gmk
@@ -30,7 +30,6 @@ $(BUILDDIR)/i18n.com.sun.javatest.diff.ok: \
 		$(JAVADIR)/com/sun/javatest/diff/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.diff.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
-	
 	$(MKDIR) -p $(@:%.ok=%)
 	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
 		$(JDKJAVA) -Djavatest.i18n.log=com.sun.javatest.diff \

--- a/test/i18n/i18n.com.sun.javatest.diff.gmk
+++ b/test/i18n/i18n.com.sun.javatest.diff.gmk
@@ -30,11 +30,13 @@ $(BUILDDIR)/i18n.com.sun.javatest.diff.ok: \
 		$(JAVADIR)/com/sun/javatest/diff/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.diff.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
+	
+	$(MKDIR) -p $(@:%.ok=%)
 	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
 		$(JDKJAVA) -Djavatest.i18n.log=com.sun.javatest.diff \
 			com.sun.javatest.diff.Main -help all \
-			> $(@:%.ok=%.log) 2>&1
-	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(JAVADIR)/com/sun/javatest/diff $(@:%.ok=%.log)
+			> $(@:%.ok=%/i18n-log.txt) 2>&1
+	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/diff $(@:%.ok=%/i18n-log.txt)
 	echo $@ passed at `date` > $@
 
 TESTS.jtdiff += $(BUILDDIR)/i18n.com.sun.javatest.diff.ok

--- a/test/i18n/i18n.com.sun.javatest.regtest.gmk
+++ b/test/i18n/i18n.com.sun.javatest.regtest.gmk
@@ -28,25 +28,28 @@ $(BUILDDIR)/i18n.com.sun.javatest.regtest.config.ok: \
 		$(JAVADIR)/com/sun/javatest/regtest/config/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
-	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(JAVADIR)/com/sun/javatest/regtest/config
+	$(MKDIR) -p $(@:%.ok=%)
+	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/regtest/config
 	echo $@ passed at `date` > $@
 
 $(BUILDDIR)/i18n.com.sun.javatest.regtest.report.ok: \
 		$(JAVADIR)/com/sun/javatest/regtest/report/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
-	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(JAVADIR)/com/sun/javatest/regtest/report
+	$(MKDIR) -p $(@:%.ok=%)
+	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/regtest/report
 	echo $@ passed at `date` > $@
 
 $(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok: \
 		$(JAVADIR)/com/sun/javatest/regtest/tool/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
+	$(MKDIR) -p $(@:%.ok=%)
 	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
 	    $(JDKJAVA) -Djavatest.i18n.log=com.sun.javatest.regtest.tool \
 		com.sun.javatest.regtest.Main -help all \
-		> $(@:%.ok=%.log) 2>&1
-	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(JAVADIR)/com/sun/javatest/regtest/tool $(@:%.ok=%.log)
+		> $(@:%.ok=%/i18n-log.txt) 2>&1
+	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/regtest/tool $(@:%.ok=%/i18n-log.txt)
 	echo $@ passed at `date` > $@
 
 # convenience target


### PR DESCRIPTION
Please review a reasonably small fix to improve the test that checks localization resources.

Previously, the code created temporary files in the source directory for the script itself.  The script is changed to accept a new leading parameter which is a directory in which to store temporary files.

In addition, the names of the temporary files are made longer and less cryptic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903147](https://bugs.openjdk.java.net/browse/CODETOOLS-7903147): unrooted relative paths in checkI18NProps.sh


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/jtreg pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/68.diff">https://git.openjdk.java.net/jtreg/pull/68.diff</a>

</details>
