### PR TITLE
CODETOOLS-7903150: Restructure generated files for jtreg self-tests

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -76,6 +76,7 @@ ifndef BUILDDIR
 endif
 override BUILDDIR := $(call FullPath, $(BUILDDIR))
 
+BUILDTESTDIR=$(BUILDDIR)/test
 
 #----------------------------------------------------------------------
 #

--- a/make/Makefile
+++ b/make/Makefile
@@ -57,7 +57,21 @@ new-images: $(NEWVERBOSEZIPFILES)
 clean:
 	$(RM) $(BUILDDIR)
 
-.NO_PARALLEL: clean
+clean-except-deps:
+	for i in $(BUILDDIR)/* ; do \
+	    case $$i in \
+		*/deps ) ;; \
+		* ) $(RM) $$i ;; \
+	    esac \
+	done
+
+clean-deps:
+	$(RM) $(BUILDDIR)/deps
+
+clean-tests:
+	$(RM) $(BUILDTESTDIR)
+
+.NO_PARALLEL: clean clean-except-deps clean-deps clean-tests
 
 sanity:
 ifdef JDK8HOME

--- a/make/Makefile
+++ b/make/Makefile
@@ -42,11 +42,11 @@ include Rules.gmk
 
 build: $(BUILDFILES)
 
-test: checkJavaOSVersion $(INITIAL_TESTS) $(TESTS) $(FINAL_TESTS)
+test: checkJavaOSVersion $(BUILDTESTDIR) $(INITIAL_TESTS) $(TESTS) $(FINAL_TESTS)
 	count=`echo $+ | wc -w` ; \
 	echo "All ($${count}) selected tests completed successfully"
 
-quick-test: checkJavaOSVersion $(INITIAL_TESTS)
+quick-test: checkJavaOSVersion $(BUILDTESTDIR) $(INITIAL_TESTS)
 	count=`echo $+ | wc -w` ; \
 	echo "All ($${count}) selected tests completed successfully"
 
@@ -101,6 +101,11 @@ endif
 	@echo "BUILD_VERSION       = $(BUILD_VERSION)"
 	@echo "BUILD_MILESTONE     = $(BUILD_MILESTONE)"
 	@echo "BUILD_NUMBER        = $(BUILD_NUMBER)"
+
+#----------------------------------------------------------------------
+
+$(BUILDTESTDIR):
+	$(MKDIR) -p $@
 
 #----------------------------------------------------------------------
 

--- a/test/4499340/T4499340.gmk
+++ b/test/4499340/T4499340.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/T4499340.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T4499340.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/4499340/lib/HelloWorld.java \
 		$(TESTDIR)/4499340/test/dir/Test.java \
@@ -44,5 +44,5 @@ $(BUILDDIR)/T4499340.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report -v:fail -jdk:$(JDKHOME) $(@:%.ok=%)/test
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T4499340.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T4499340.ok
 

--- a/test/4730538/T4730538.gmk
+++ b/test/4730538/T4730538.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/T4730538.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T4730538.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/4730538/test/Test.java \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -33,8 +33,8 @@ $(BUILDDIR)/T4730538.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(MKDIR) $(@:%.ok=%)
 	JTHOME=$(JTREG_IMAGEDIR) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report -v:fail \
-		-jdk:$(JDKHOME) $(@:$(BUILDDIR)/T%.ok=$(TESTDIR)/%/test)
+		-jdk:$(JDKHOME) $(@:$(BUILDTESTDIR)/T%.ok=$(TESTDIR)/%/test)
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T4730538.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T4730538.ok
 

--- a/test/6517728/T6517728.gmk
+++ b/test/6517728/T6517728.gmk
@@ -28,7 +28,7 @@
 # only run the ...A test case by default, because the ...B test cases
 # checks the default when the test times out
 
-$(BUILDDIR)/T6517728.ok: \
+$(BUILDTESTDIR)/T6517728.ok: \
 		$(TESTDIR)/6517728/T6517728A.java \
 		$(TESTDIR)/6517728/T6517728B.java \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
@@ -46,5 +46,5 @@ $(BUILDDIR)/T6517728.ok: \
 		$(TESTDIR)/6517728/T6517728A.java
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6517728.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6517728.ok
 

--- a/test/6517916/T6517916.gmk
+++ b/test/6517916/T6517916.gmk
@@ -31,7 +31,7 @@ T6517916-ENVIRONMENT-NORMALIZATIONS = \
 	-e '/^JAVA_MAIN_CLASS_<pid>=/s|MainWrapper|<mainclass>|' \
 	-e '/^JAVA_MAIN_CLASS_<pid>=/s|AgentServer|<mainclass>|'
 
-$(BUILDDIR)/T6517916.ok: \
+$(BUILDTESTDIR)/T6517916.ok: \
 		$(TESTDIR)/6517916/T6517916.java \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar
@@ -63,6 +63,6 @@ $(BUILDDIR)/T6517916.ok: \
 	echo "test passed at `date`" > $@
 
 ifneq ($(OS_NAME), windows)
-TESTS.jtreg += $(BUILDDIR)/T6517916.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6517916.ok
 endif
 

--- a/test/6519296/T6519296.gmk
+++ b/test/6519296/T6519296.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/T6519296.ok: \
+$(BUILDTESTDIR)/T6519296.ok: \
 		$(TESTDIR)/6519296/T6519296.java \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar
@@ -37,5 +37,5 @@ $(BUILDDIR)/T6519296.ok: \
 		$(TESTDIR)/6519296
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6519296.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6519296.ok
 

--- a/test/6527624/T6527624.gmk
+++ b/test/6527624/T6527624.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/T6527624.ok:\
+$(BUILDTESTDIR)/T6527624.ok:\
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
@@ -38,5 +38,5 @@ $(BUILDDIR)/T6527624.ok:\
 	echo "test passed at `date`" > $@
 
 ifneq ($(OS_NAME), windows)
-TESTS.jtreg += $(BUILDDIR)/T6527624.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6527624.ok
 endif

--- a/test/6533043/T6533043.gmk
+++ b/test/6533043/T6533043.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 6533043: support failureProperty and errorProperty in <jtreg> task
-$(BUILDDIR)/T6533043.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T6533043.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	JAVA_HOME=$(JDKHOME) $(ANT) -f $(TESTDIR)/6533043/build.xml \
@@ -37,6 +37,6 @@ $(BUILDDIR)/T6533043.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 
 ifdef ANT
 ifdef JDK5HOME
-TESTS.jtreg += $(BUILDDIR)/T6533043.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6533043.ok
 endif
 endif

--- a/test/6533074/T6533074.gmk
+++ b/test/6533074/T6533074.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 6533074: allow additional compiler options to be specified
-$(BUILDDIR)/T6533074.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T6533074.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	JAVA_HOME=$(JDKHOME) $(ANT) -f $(TESTDIR)/6533074/build.xml \
@@ -37,7 +37,7 @@ $(BUILDDIR)/T6533074.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 
 ifdef ANT
 ifdef JDK5HOME
-TESTS.jtreg += $(BUILDDIR)/T6533074.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6533074.ok
 endif
 endif
 

--- a/test/6533136/T6533136.gmk
+++ b/test/6533136/T6533136.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 6533136: use -dir as a base directory for test files and directories on the command line
-$(BUILDDIR)/T6533136.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T6533136.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/share/basic/main/Pass.java \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -49,5 +49,5 @@ $(BUILDDIR)/T6533136.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-dir:$(TESTDIR)/share/simple/ Pass.java
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6533136.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6533136.ok
 

--- a/test/6585912/T6585912.gmk
+++ b/test/6585912/T6585912.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 6585912: jtreg should be able to really ignore @ignore tests
-$(BUILDDIR)/T6585912.ok: \
+$(BUILDTESTDIR)/T6585912.ok: \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -55,5 +55,5 @@ $(BUILDDIR)/T6585912.ok: \
 		grep "Test results: passed: 2; failed: 1" > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6585912.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6585912.ok
 

--- a/test/6590657/T6590657.gmk
+++ b/test/6590657/T6590657.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 6590657: @clean will occasionally fail to delete @clean files
-$(BUILDDIR)/T6590657.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T6590657.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/6590657/T6590657.java \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -40,5 +40,5 @@ $(BUILDDIR)/T6590657.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(GREP) "T6590657.java  Passed. Build successful" < $(@:%.ok=%)/report/text/summary.txt
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6590657.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6590657.ok
 

--- a/test/6590671/T6590671.gmk
+++ b/test/6590671/T6590671.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 6590671: RegressionTestFinder should ignore , files
-$(BUILDDIR)/T6590671.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T6590671.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/6590671/T6590671.java \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -41,5 +41,5 @@ $(BUILDDIR)/T6590671.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(@:%.ok=%)/test
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6590671.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6590671.ok
 

--- a/test/6622433/T6622433.gmk
+++ b/test/6622433/T6622433.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 6622433: support passing opts to java command only (i.e. without passing to javac)
-$(BUILDDIR)/T6622433.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/T6622433.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/6622433/TestJava.java \
 		$(TESTDIR)/6622433/TestShell.sh \
@@ -55,5 +55,5 @@ $(BUILDDIR)/T6622433.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(GREP) 'TESTVMOPTION=Y' $(@:%.ok=%)/work/TestCompile2.jtr > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6622433.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6622433.ok
 

--- a/test/6783039/T6783039.gmk
+++ b/test/6783039/T6783039.gmk
@@ -25,24 +25,24 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/T6783039.ok: \
+$(BUILDTESTDIR)/T6783039.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar 
-	$(RM) $(BUILDDIR)/6783039/
+	$(RM) $(BUILDTESTDIR)/6783039/
 	for p in p1 p2 ; do for y in 2007 2008 ; do for d in 1 2 3 ; do \
-	    mkdir -p $(BUILDDIR)/6783039/$$p/$$y/$$d/JTreport/text/ ; touch $(BUILDDIR)/6783039/$$p/$$y/$$d/JTreport/text/summary.txt ; \
+	    mkdir -p $(BUILDTESTDIR)/6783039/$$p/$$y/$$d/JTreport/text/ ; touch $(BUILDTESTDIR)/6783039/$$p/$$y/$$d/JTreport/text/summary.txt ; \
 	done ; done ; done
 	$(JDKJAVA) -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar com.sun.javatest.diff.Main \
-		$(BUILDDIR)/6783039/*/*/*/JTreport/text/summary.txt > $(BUILDDIR)/6783039/stdout
+		$(BUILDTESTDIR)/6783039/*/*/*/JTreport/text/summary.txt > $(BUILDTESTDIR)/6783039/stdout
 	$(JDKJAVA) -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar com.sun.javatest.diff.Main \
-		-o $(BUILDDIR)/6783039/out.txt $(BUILDDIR)/6783039/*/*/*/JTreport/text/summary.txt
-	diff $(BUILDDIR)/6783039/stdout $(BUILDDIR)/6783039/out.txt
-	mkdir $(BUILDDIR)/6783039/super
+		-o $(BUILDTESTDIR)/6783039/out.txt $(BUILDTESTDIR)/6783039/*/*/*/JTreport/text/summary.txt
+	diff $(BUILDTESTDIR)/6783039/stdout $(BUILDTESTDIR)/6783039/out.txt
+	mkdir $(BUILDTESTDIR)/6783039/super
 	$(JDKJAVA) -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar com.sun.javatest.diff.Main \
-		-o $(BUILDDIR)/6783039/super -super $(BUILDDIR)/6783039/
-	if [ `find $(BUILDDIR)/6783039/super -name \*.html | wc -l` != 9 ]; then \
+		-o $(BUILDTESTDIR)/6783039/super -super $(BUILDTESTDIR)/6783039/
+	if [ `find $(BUILDTESTDIR)/6783039/super -name \*.html | wc -l` != 9 ]; then \
 		echo "super output not as expected" ; exit 1 ; \
 	fi
 	echo $@ passed at `date` > $@
 
-TESTS.jtdiff += $(BUILDDIR)/T6783039.ok
+TESTS.jtdiff += $(BUILDTESTDIR)/T6783039.ok

--- a/test/6783087/T6783087.gmk
+++ b/test/6783087/T6783087.gmk
@@ -26,23 +26,23 @@
 #----------------------------------------------------------------------
 
 # 6783087: jtreg follows symlinks when cleaning a directory
-$(BUILDDIR)/T6783087.ok: \
+$(BUILDTESTDIR)/T6783087.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar
-	$(RM) $(BUILDDIR)/6783087/
-	$(MKDIR) -p $(BUILDDIR)/6783087/work/scratch
-	$(MKDIR) $(BUILDDIR)/6783087/doNotDelete
-	touch $(BUILDDIR)/6783087/doNotDelete.txt $(BUILDDIR)/6783087/doNotDelete/doNotDelete.txt
-	ln -s `pwd`/$(BUILDDIR)/6783087/doNotDelete $(BUILDDIR)/6783087/work/scratch/doNotDelete
-	ln -s `pwd`/$(BUILDDIR)/6783087/doNotDelete.txt $(BUILDDIR)/6783087/work/scratch/doNotDelete.txt
+	$(RM) $(BUILDTESTDIR)/6783087/
+	$(MKDIR) -p $(BUILDTESTDIR)/6783087/work/scratch
+	$(MKDIR) $(BUILDTESTDIR)/6783087/doNotDelete
+	touch $(BUILDTESTDIR)/6783087/doNotDelete.txt $(BUILDTESTDIR)/6783087/doNotDelete/doNotDelete.txt
+	ln -s `pwd`/$(BUILDTESTDIR)/6783087/doNotDelete $(BUILDTESTDIR)/6783087/work/scratch/doNotDelete
+	ln -s `pwd`/$(BUILDTESTDIR)/6783087/doNotDelete.txt $(BUILDTESTDIR)/6783087/work/scratch/doNotDelete.txt
 	$(JDKJAVA) -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		-w $(BUILDDIR)/6783087/work/ -r $(BUILDDIR)/6783087/report/ \
+		-w $(BUILDTESTDIR)/6783087/work/ -r $(BUILDTESTDIR)/6783087/report/ \
 		$(TESTDIR)/share/simple/Pass.java
-	find $(BUILDDIR)/6783087/
-	if [ ! -f $(BUILDDIR)/6783087/doNotDelete.txt -o ! -f $(BUILDDIR)/6783087/doNotDelete/doNotDelete.txt ]; then \
+	find $(BUILDTESTDIR)/6783087/
+	if [ ! -f $(BUILDTESTDIR)/6783087/doNotDelete.txt -o ! -f $(BUILDTESTDIR)/6783087/doNotDelete/doNotDelete.txt ]; then \
 		echo "files deleted incorrectly" ; exit 1 ; \
 	fi
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6783087.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6783087.ok
 

--- a/test/6799634/T6799634.gmk
+++ b/test/6799634/T6799634.gmk
@@ -27,13 +27,13 @@
 
 # 6799634: Allow annotation processing of class files in jtreg directives
 
-$(BUILDDIR)/T6799634.ok: \
+$(BUILDTESTDIR)/T6799634.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		-w $(BUILDDIR)/6799634/work/ -r $(BUILDDIR)/6799634/report/ \
+		-w $(BUILDTESTDIR)/6799634/work/ -r $(BUILDTESTDIR)/6799634/report/ \
 		$(TESTDIR)/6799634
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6799634.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6799634.ok
 

--- a/test/6809055/T6809055.gmk
+++ b/test/6809055/T6809055.gmk
@@ -26,13 +26,13 @@
 #----------------------------------------------------------------------
 
 # 6809055: Set test.src and test.classes information for @compile tasks
-$(BUILDDIR)/T6809055.ok: \
+$(BUILDTESTDIR)/T6809055.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		-w $(BUILDDIR)/6809055/work/ -r $(BUILDDIR)/6809055/report/ \
+		-w $(BUILDTESTDIR)/6809055/work/ -r $(BUILDTESTDIR)/6809055/report/ \
 		$(TESTDIR)/6809055
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6809055.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6809055.ok
 

--- a/test/6811371.gmk
+++ b/test/6811371.gmk
@@ -26,11 +26,11 @@
 #----------------------------------------------------------------------
 
 # 6811371: recategorize -e option as a general option instead of a JDK one
-$(BUILDDIR)/T6811371.ok: \
+$(BUILDTESTDIR)/T6811371.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(JDKJAVA) -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar -help -e | grep "General Options"
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T6811371.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T6811371.ok
 

--- a/test/7113596/T7113596.gmk
+++ b/test/7113596/T7113596.gmk
@@ -25,14 +25,14 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/T7113596.ok: \
+$(BUILDTESTDIR)/T7113596.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(LN) -s $(JDKHOME) $(@:%.ok=%)/jdk
 	cd $(@:%.ok=%) && $(JDKJAVA) -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-jdk:jdk \
-		../$(TESTDIR)/7113596
+		../../$(TESTDIR)/7113596
 	for i in COMPILEJAVA TESTJAVA ; do \
 	    value=`$(GREP) $$i= $(@:%.ok=%)/JTwork/Test.jtr | $(SED) -e 's/[^=]*=//' | head -n 1` ; \
 	    case $$value in \
@@ -46,6 +46,6 @@ $(BUILDDIR)/T7113596.ok: \
 	echo "test passed at `date`" > $@
 
 ifneq ($(OS_NAME), windows)
-TESTS.jtreg += $(BUILDDIR)/T7113596.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T7113596.ok
 endif
 

--- a/test/7900112/T7900112.gmk
+++ b/test/7900112/T7900112.gmk
@@ -26,16 +26,16 @@
 #----------------------------------------------------------------------
 
 # 7900112: don't print unnecessary stack traces
-$(BUILDDIR)/T7900112.ok: \
+$(BUILDTESTDIR)/T7900112.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JDK6HOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		-w $(BUILDDIR)/7900112/work/ -r $(BUILDDIR)/7900112/report/ \
+		-w $(@:%.ok=%)/work/ -r $(@:%.ok=%)/report/ \
 		$(TESTDIR)/7900112 > $(@:%.ok=%/jt.log) 2>&1; \
-        $(GREP) 'java.lang.Exception: thrown exception is success' $(BUILDDIR)/7900112/work/TestExpected.jtr > /dev/null ; rc=$$?; \
+        $(GREP) 'java.lang.Exception: thrown exception is success' $(@:%.ok=%)/work/TestExpected.jtr > /dev/null ; rc=$$?; \
         if [ "$$rc" = 0 ]; then echo "Unexpected stacktrace for successful test in TestExpected.jtr" ; exit 1 ; fi
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T7900112.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T7900112.ok
 

--- a/test/7900130/T7900130.gmk
+++ b/test/7900130/T7900130.gmk
@@ -27,16 +27,16 @@
 
 # 7900130: Exception in TestNG DataSource does not result in a reported test failure
 # Test should fail due to exception in @DataSource
-$(BUILDDIR)/T7900130.ok: \
+$(BUILDTESTDIR)/T7900130.ok: \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		-w $(BUILDDIR)/7900130/work/ -r $(BUILDDIR)/7900130/report/ \
+		-w $(@:%.ok=%)/work/ -r $(@:%.ok=%)/report/ \
 		$(TESTDIR)/7900130 > $(@:%.ok=%/jt.log) 2>&1
-	$(GREP) 'TestArguments.test_data("Thing1", "", 4, true, 2.0)' $(BUILDDIR)/7900130/work/TestArguments.jtr > /dev/null
-	$(GREP) 'TestArguments.test_data("Thing2", null, 8, false, 6.0)' $(BUILDDIR)/7900130/work/TestArguments.jtr > /dev/null
+	$(GREP) 'TestArguments.test_data("Thing1", "", 4, true, 2.0)' $(@:%.ok=%)/work/TestArguments.jtr > /dev/null
+	$(GREP) 'TestArguments.test_data("Thing2", null, 8, false, 6.0)' $(@:%.ok=%)/work/TestArguments.jtr > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T7900130.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T7900130.ok
 

--- a/test/7900165/T7900165.gmk
+++ b/test/7900165/T7900165.gmk
@@ -27,15 +27,15 @@
 
 # 7900165: Exception in TestNG DataSource does not result in a reported test failure
 # Test should fail due to exception in @DataSource
-$(BUILDDIR)/T7900165.ok: \
+$(BUILDTESTDIR)/T7900165.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-		-w $(BUILDDIR)/7900165/work/ -r $(BUILDDIR)/7900165/report/ \
+		-w $(@:%.ok=%)/work/ -r $(@:%.ok=%)/report/ \
 		$(TESTDIR)/7900165 > $(@:%.ok=%/jt.log) 2>&1 ; rc=$$? ; \
         if [ "$$rc" != 2 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/T7900165.ok
+TESTS.jtreg += $(BUILDTESTDIR)/T7900165.ok
 

--- a/test/LockCheck.gmk
+++ b/test/LockCheck.gmk
@@ -28,7 +28,7 @@
 # check for leftover TestResultCache lock files.
 # leftover files may indicate a bug in the cache or its robustness
 
-$(BUILDDIR)/lockCheck.ok: 
+$(BUILDTESTDIR)/lockCheck.ok:
 	@ ( \
 	lckfiles=`$(FIND) $(TOPDIR)/build -name ResultCache.jtw.lck -print` ; \
 	if [ ! -z "$$lckfiles" ] ; then \
@@ -41,4 +41,4 @@ $(BUILDDIR)/lockCheck.ok:
 	)
 	echo $@ passed at `date` > $@
 
-FINAL_TESTS += $(BUILDDIR)/lockCheck.ok
+FINAL_TESTS += $(BUILDTESTDIR)/lockCheck.ok

--- a/test/Properties/PropertyTests.gmk
+++ b/test/Properties/PropertyTests.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/PropertyTest_agentvm.ok: \
+$(BUILDTESTDIR)/PropertyTest_agentvm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
@@ -35,7 +35,7 @@ $(BUILDDIR)/PropertyTest_agentvm.ok: \
 		$(TESTDIR)/Properties
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/PropertyTest_othervm.ok: \
+$(BUILDTESTDIR)/PropertyTest_othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
@@ -46,6 +46,6 @@ $(BUILDDIR)/PropertyTest_othervm.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/PropertyTest_agentvm.ok \
-	$(BUILDDIR)/PropertyTest_othervm.ok
+	$(BUILDTESTDIR)/PropertyTest_agentvm.ok \
+	$(BUILDTESTDIR)/PropertyTest_othervm.ok
 

--- a/test/SecurityManager/SecurityManagerTests.gmk
+++ b/test/SecurityManager/SecurityManagerTests.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/GoodSecurityManagerTest.ok: \
+$(BUILDTESTDIR)/GoodSecurityManagerTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
@@ -36,11 +36,11 @@ $(BUILDDIR)/GoodSecurityManagerTest.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/GoodSecurityManagerTest.ok
+	$(BUILDTESTDIR)/GoodSecurityManagerTest.ok
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/BadSecurityManagerTest.ok: \
+$(BUILDTESTDIR)/BadSecurityManagerTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/
@@ -54,11 +54,11 @@ $(BUILDDIR)/BadSecurityManagerTest.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BadSecurityManagerTest.ok
+	$(BUILDTESTDIR)/BadSecurityManagerTest.ok
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/SecurityManagerTest_agentvm_forbid.ok: \
+$(BUILDTESTDIR)/SecurityManagerTest_agentvm_forbid.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/
@@ -73,11 +73,11 @@ $(BUILDDIR)/SecurityManagerTest_agentvm_forbid.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/SecurityManagerTest_agentvm_forbid.ok
+	$(BUILDTESTDIR)/SecurityManagerTest_agentvm_forbid.ok
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/SecurityManagerTest_othervm.ok: \
+$(BUILDTESTDIR)/SecurityManagerTest_othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
@@ -88,21 +88,21 @@ $(BUILDDIR)/SecurityManagerTest_othervm.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/SecurityManagerTest_othervm.ok
+	$(BUILDTESTDIR)/SecurityManagerTest_othervm.ok
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/SecurityManagerTest_8.ok \
-$(BUILDDIR)/SecurityManagerTest_14.ok \
-$(BUILDDIR)/SecurityManagerTest_18.ok: \
+$(BUILDTESTDIR)/SecurityManagerTest_8.ok \
+$(BUILDTESTDIR)/SecurityManagerTest_14.ok \
+$(BUILDTESTDIR)/SecurityManagerTest_18.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
-		-jdk:$(JDK$(@:$(BUILDDIR)/SecurityManagerTest_%.ok=%)HOME) \
+		-jdk:$(JDK$(@:$(BUILDTESTDIR)/SecurityManagerTest_%.ok=%)HOME) \
 		-agentvm \
 		$(TESTDIR)/SecurityManager/ShowSecurityManager.java
-	case "$(@:$(BUILDDIR)/SecurityManagerTest_%.ok=%)" in \
+	case "$(@:$(BUILDTESTDIR)/SecurityManagerTest_%.ok=%)" in \
 		18 ) $(GREP) "SM=null" \
 			$(@:%.ok=%)/work/ShowSecurityManager.jtr ;; \
 		*  ) $(GREP) "SM=com.sun.javatest.regtest.agent.RegressionSecurityManager" \
@@ -116,15 +116,15 @@ $(BUILDDIR)/SecurityManagerTest_18.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/SecurityManagerTest_8.ok
+	$(BUILDTESTDIR)/SecurityManagerTest_8.ok
 endif
 
 ifdef JDK14HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/SecurityManagerTest_14.ok
+	$(BUILDTESTDIR)/SecurityManagerTest_14.ok
 endif
 
 ifdef JDK18HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/SecurityManagerTest_18.ok
+	$(BUILDTESTDIR)/SecurityManagerTest_18.ok
 endif

--- a/test/TestWhiteSpaceFiles.gmk
+++ b/test/TestWhiteSpaceFiles.gmk
@@ -25,28 +25,28 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestWhiteSpaceFiles.ok: \
+$(BUILDTESTDIR)/TestWhiteSpaceFiles.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
-	$(RM) $(BUILDDIR)/tmp/$(@F:%.ok=%)
-	$(MKDIR) -p $(BUILDDIR)/tmp/$(@F:%.ok=%)
-	ln -s $(JDKHOME) $(BUILDDIR)/tmp/$(@F:%.ok=%)/"j2se home"
-	ln -s $(shell cd $(JTREG_IMAGEDIR); pwd) $(BUILDDIR)/tmp/$(@F:%.ok=%)/"jtreg home"
-	$(BUILDDIR)/tmp/$(@F:%.ok=%)/"jtreg home"/bin/jtreg $(JTREG_OPTS) \
+	$(RM) $(BUILDTESTDIR)/tmp/$(@F:%.ok=%)
+	$(MKDIR) -p $(BUILDTESTDIR)/tmp/$(@F:%.ok=%)
+	ln -s $(JDKHOME) $(BUILDTESTDIR)/tmp/$(@F:%.ok=%)/"j2se home"
+	ln -s $(shell cd $(JTREG_IMAGEDIR); pwd) $(BUILDTESTDIR)/tmp/$(@F:%.ok=%)/"jtreg home"
+	$(BUILDTESTDIR)/tmp/$(@F:%.ok=%)/"jtreg home"/bin/jtreg $(JTREG_OPTS) \
 		-w $(@:%.ok=%/ovm/work) \
 		-r $(@:%.ok=%/ovm/report) \
-		-jdk:$(BUILDDIR)/tmp/$(@F:%.ok=%)/"j2se home" \
+		-jdk:$(BUILDTESTDIR)/tmp/$(@F:%.ok=%)/"j2se home" \
 		$(TESTDIR)/share/simple/Pass.java
-	$(BUILDDIR)/tmp/$(@F:%.ok=%)/"jtreg home"/bin/jtreg $(JTREG_OPTS) \
+	$(BUILDTESTDIR)/tmp/$(@F:%.ok=%)/"jtreg home"/bin/jtreg $(JTREG_OPTS) \
 		-avm \
 		-w $(@:%.ok=%/avm/work) \
 		-r $(@:%.ok=%/avm/report) \
-		-jdk:$(BUILDDIR)/tmp/$(@F:%.ok=%)/"j2se home" \
+		-jdk:$(BUILDTESTDIR)/tmp/$(@F:%.ok=%)/"j2se home" \
 		$(TESTDIR)/share/simple/Pass.java
 	echo "test passed at `date`" > $@
 
 ifneq ($(OS_NAME), windows)
-TESTS.jtreg += $(BUILDDIR)/TestWhiteSpaceFiles.ok
+TESTS.jtreg += $(BUILDTESTDIR)/TestWhiteSpaceFiles.ok
 endif
 

--- a/test/absLib/TestAbsLib.gmk
+++ b/test/absLib/TestAbsLib.gmk
@@ -27,7 +27,7 @@
 #
 # Verify @library tag works for absolute paths (i.e. rel to TEST.ROOT dir).
 
-$(BUILDDIR)/TestAbsLib.ok: \
+$(BUILDTESTDIR)/TestAbsLib.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
@@ -38,5 +38,5 @@ $(BUILDDIR)/TestAbsLib.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/TestAbsLib.ok
+	$(BUILDTESTDIR)/TestAbsLib.ok
 

--- a/test/addmods/AddModulesTest.gmk
+++ b/test/addmods/AddModulesTest.gmk
@@ -27,7 +27,7 @@
 
 ifdef JDK9HOME
 
-$(BUILDDIR)/AddModulesTest.ok: \
+$(BUILDTESTDIR)/AddModulesTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -38,7 +38,7 @@ $(BUILDDIR)/AddModulesTest.ok: \
 			> $(@:%.ok=%/jt.log) 2>&1
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/AddModulesTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/AddModulesTest.ok
 
 endif
 

--- a/test/agentout/AgentOut.gmk
+++ b/test/agentout/AgentOut.gmk
@@ -23,8 +23,8 @@
 # questions.
 #
 
-$(BUILDDIR)/AgentOut.agentvm.ok \
-$(BUILDDIR)/AgentOut.othervm.ok: \
+$(BUILDTESTDIR)/AgentOut.agentvm.ok \
+$(BUILDTESTDIR)/AgentOut.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -32,41 +32,41 @@ $(BUILDDIR)/AgentOut.othervm.ok: \
 	JT_JAVA=$(JDKHOME) \
 		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
-		$(@:$(BUILDDIR)/AgentOut.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/AgentOut.%.ok=-%) \
 		$(TESTDIR)/agentout
 	$(MKDIR) $(@:%.ok=%)/logs
 	- JT_JAVA=$(JDKHOME) \
 		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work \
-		$(@:$(BUILDDIR)/AgentOut.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/AgentOut.%.ok=-%) \
 		-show:System.out \
 		$(TESTDIR)/agentout/CompileTest.java \
 		    > $(@:%.ok=%)/logs/CompileTest-System.out.log
 	- JT_JAVA=$(JDKHOME) \
 		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work \
-		$(@:$(BUILDDIR)/AgentOut.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/AgentOut.%.ok=-%) \
 		-show:System.err \
 		$(TESTDIR)/agentout/CompileTest.java \
 		    > $(@:%.ok=%)/logs/CompileTest-System.err.log
 	- JT_JAVA=$(JDKHOME) \
 		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work \
-		$(@:$(BUILDDIR)/AgentOut.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/AgentOut.%.ok=-%) \
 		-show:direct \
 		$(TESTDIR)/agentout/CompileTest.java \
 		    > $(@:%.ok=%)/logs/CompileTest-direct.log
 	- JT_JAVA=$(JDKHOME) \
 		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work \
-		$(@:$(BUILDDIR)/AgentOut.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/AgentOut.%.ok=-%) \
 		-show:System.out \
 		$(TESTDIR)/agentout/MainTest.java \
 		    > $(@:%.ok=%)/logs/MainTest-System.out.log
 	- JT_JAVA=$(JDKHOME) \
 		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work \
-		$(@:$(BUILDDIR)/AgentOut.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/AgentOut.%.ok=-%) \
 		-show:System.err \
 		$(TESTDIR)/agentout/MainTest.java \
 		    > $(@:%.ok=%)/logs/MainTest-System.err.log
@@ -79,22 +79,22 @@ $(BUILDDIR)/AgentOut.othervm.ok: \
 		> `dirname $$i`-filtered/`basename $$i` ; \
 	done
 	# merge direct and stderr from agent CompileTest to match stderr from othervm CompileTest
-	$(CAT) $(BUILDDIR)/AgentOut.agentvm/logs-filtered/CompileTest-direct.log \
-		$(BUILDDIR)/AgentOut.agentvm/logs-filtered/CompileTest-System.err.log \
-		> $(BUILDDIR)/AgentOut.agentvm/logs-filtered/tmp.log
-	$(MV) $(BUILDDIR)/AgentOut.agentvm/logs-filtered/tmp.log \
-		$(BUILDDIR)/AgentOut.agentvm/logs-filtered/CompileTest-System.err.log
-	$(CAT) < $(DEV_NULL) > $(BUILDDIR)/AgentOut.agentvm/logs-filtered/CompileTest-direct.log
+	$(CAT) $(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered/CompileTest-direct.log \
+		$(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered/CompileTest-System.err.log \
+		> $(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered/tmp.log
+	$(MV) $(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered/tmp.log \
+		$(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered/CompileTest-System.err.log
+	$(CAT) < $(DEV_NULL) > $(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered/CompileTest-direct.log
 	#
 	echo "run at `date`" > $@
 
-$(BUILDDIR)/AgentOut.ok: \
-	    $(BUILDDIR)/AgentOut.agentvm.ok \
-	    $(BUILDDIR)/AgentOut.othervm.ok
+$(BUILDTESTDIR)/AgentOut.ok: \
+	    $(BUILDTESTDIR)/AgentOut.agentvm.ok \
+	    $(BUILDTESTDIR)/AgentOut.othervm.ok
 	$(DIFF) -r \
-		$(BUILDDIR)/AgentOut.agentvm/logs-filtered \
-		$(BUILDDIR)/AgentOut.othervm/logs-filtered
+		$(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered \
+		$(BUILDTESTDIR)/AgentOut.othervm/logs-filtered
 	echo "passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/AgentOut.ok \
+	$(BUILDTESTDIR)/AgentOut.ok \

--- a/test/autovm/AutoVMTests.gmk
+++ b/test/autovm/AutoVMTests.gmk
@@ -27,25 +27,25 @@
 
 AUTOVM_FILES := $(shell find $(TESTDIR)/autovm -type f )
 		
-$(BUILDDIR)/autovm.ok: $(AUTOVM_FILES) \
+$(BUILDTESTDIR)/autovm.ok: $(AUTOVM_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	for ts in none agentvm othervm; do \
-	    $(MKDIR) -p $(BUILDDIR)/autovm/tests/default.$$ts ; \
-	    rsync --recursive --delete $(TESTDIR)/autovm/ $(BUILDDIR)/autovm/tests/default.$$ts/ ; \
+	    $(MKDIR) -p $(BUILDTESTDIR)/autovm/tests/default.$$ts ; \
+	    rsync --recursive --delete $(TESTDIR)/autovm/ $(BUILDTESTDIR)/autovm/tests/default.$$ts/ ; \
 	    if [ $$ts != none ]; then \
-		echo "defaultExecMode=$$ts" >> $(BUILDDIR)/autovm/tests/default.$$ts/TEST.ROOT ; \
+		echo "defaultExecMode=$$ts" >> $(BUILDTESTDIR)/autovm/tests/default.$$ts/TEST.ROOT ; \
 	    fi \
 	done ; \
 	for mode in none agentvm othervm ; do for ts in none agentvm othervm ; do \
 	    $(JDKJAVA) -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-jdk:$(JDKHOME) \
-		-w $(BUILDDIR)/autovm/jtreg/mode.$$mode/ts.$$ts/work \
-		-r $(BUILDDIR)/autovm/jtreg/mode.$$mode/ts.$$ts/report \
+		-w $(BUILDTESTDIR)/autovm/jtreg/mode.$$mode/ts.$$ts/work \
+		-r $(BUILDTESTDIR)/autovm/jtreg/mode.$$mode/ts.$$ts/report \
 		`if [ $$mode != none ]; then echo "-$$mode" ; fi` \
-		$(BUILDDIR)/autovm/tests/default.$$ts ; \
+		$(BUILDTESTDIR)/autovm/tests/default.$$ts ; \
 	done ; done ; \
-	cd $(BUILDDIR)/autovm/jtreg ; find mode.*/ts.*/work -name \*.jtr | \
+	cd $(BUILDTESTDIR)/autovm/jtreg ; find mode.*/ts.*/work -name \*.jtr | \
 	    grep -v Shell | while read file ; do \
 	    	echo $$file `grep '^Mode:' $$file | sort -u` ; \
 		found=`grep '^Mode:' $$file | sed -e 's/ \[.*\]$$//'` ; \
@@ -66,5 +66,5 @@ $(BUILDDIR)/autovm.ok: $(AUTOVM_FILES) \
 	    done
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/autovm.ok
+TESTS.jtreg += $(BUILDTESTDIR)/autovm.ok
 

--- a/test/badgroups/BadGroups.gmk
+++ b/test/badgroups/BadGroups.gmk
@@ -26,24 +26,24 @@
 #----------------------------------------------------------------------
 
 
-$(BUILDDIR)/BadGroups_badname.ok: \
+$(BUILDTESTDIR)/BadGroups_badname.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%) 
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(TESTDIR)/badgroups/$(@:$(BUILDDIR)/BadGroups_%.ok=%) \
+		$(TESTDIR)/badgroups/$(@:$(BUILDTESTDIR)/BadGroups_%.ok=%) \
                 > $(@:%.ok=%)/jt.log 2>&1 ; \
             status=$$? ; echo status=$$status ; \
             if [ "$$status" != "0" ]; then echo "unexpected exit: $$status" ; exit 1; fi
 	$(GREP) "TEST.groups: group a/b: invalid name for group" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/BadGroups_badname.ok
+TESTS.jtreg += $(BUILDTESTDIR)/BadGroups_badname.ok
 
 
-$(BUILDDIR)/BadGroups_badname51.ok: \
+$(BUILDTESTDIR)/BadGroups_badname51.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%) 
@@ -52,7 +52,7 @@ $(BUILDDIR)/BadGroups_badname51.ok: \
 		-J-DOVERRIDE-jtreg-Build=b01 \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(TESTDIR)/badgroups/$(@:$(BUILDDIR)/BadGroups_%.ok=%) \
+		$(TESTDIR)/badgroups/$(@:$(BUILDTESTDIR)/BadGroups_%.ok=%) \
                 > $(@:%.ok=%)/jt.log 2>&1 ; \
             status=$$? ; echo status=$$status ; \
             if [ "$$status" != "5" ]; then echo "unexpected exit: $$status" ; exit 1; fi
@@ -60,4 +60,4 @@ $(BUILDDIR)/BadGroups_badname51.ok: \
 	$(GREP) "Error: One or more groups are invalid" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/BadGroups_badname.ok
+TESTS.jtreg += $(BUILDTESTDIR)/BadGroups_badname.ok

--- a/test/badlibs/BadLibsTest.gmk
+++ b/test/badlibs/BadLibsTest.gmk
@@ -25,7 +25,7 @@
 
 #-------------------------------------------------------------------------------
 #
-$(BUILDDIR)/BadLibsTest.ok: \
+$(BUILDTESTDIR)/BadLibsTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -43,11 +43,11 @@ $(BUILDDIR)/BadLibsTest.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BadLibsTest.ok
+	$(BUILDTESTDIR)/BadLibsTest.ok
 
 #-------------------------------------------------------------------------------
 #
-$(BUILDDIR)/BadLibsTest.retain.ok: \
+$(BUILDTESTDIR)/BadLibsTest.retain.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -66,4 +66,4 @@ $(BUILDDIR)/BadLibsTest.retain.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BadLibsTest.retain.ok
+	$(BUILDTESTDIR)/BadLibsTest.retain.ok

--- a/test/badtests/BadTests.gmk
+++ b/test/badtests/BadTests.gmk
@@ -30,7 +30,7 @@
 # 1. Intentional
 # 2. Inappropriate use of exit
 #
-$(BUILDDIR)/BadTests.othervm.ok: \
+$(BUILDTESTDIR)/BadTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -55,7 +55,7 @@ $(BUILDDIR)/BadTests.othervm.ok: \
 #  -agentvm              17,1,2 (as below)
 #  -agentvm -retain:none 16,1,3 (because a test will fail in cleanup)
 #
-$(BUILDDIR)/BadTests.agentvm.ok: \
+$(BUILDTESTDIR)/BadTests.agentvm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -74,6 +74,6 @@ $(BUILDDIR)/BadTests.agentvm.ok: \
 
 ifneq ($(OS_NAME), windows)
 TESTS.jtreg += \
-	$(BUILDDIR)/BadTests.othervm.ok \
-	$(BUILDDIR)/BadTests.agentvm.ok
+	$(BUILDTESTDIR)/BadTests.othervm.ok \
+	$(BUILDTESTDIR)/BadTests.agentvm.ok
 endif

--- a/test/basic/Basic.gmk
+++ b/test/basic/Basic.gmk
@@ -30,11 +30,11 @@
 BASIC.files := $(shell find $(TESTDIR)/share/basic -type f)
 
 
-$(BUILDDIR)/Basic.check.ok: \
+$(BUILDTESTDIR)/Basic.check.ok: \
                 $(ALL_JTREG_JARS) \
-		$(BUILDDIR)/i18n.com.sun.javatest.regtest.config.ok \
-		$(BUILDDIR)/i18n.com.sun.javatest.regtest.report.ok \
-		$(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok \
+		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.config.ok \
+		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.report.ok \
+		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.tool.ok \
 	        $(BASIC.files)
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%/work/scratch) $(@:%.ok=%/report)
@@ -51,7 +51,7 @@ $(BUILDDIR)/Basic.check.ok: \
 	echo $@ passed at `date` > $@
 
 INITIAL_TESTS += \
-	$(BUILDDIR)/Basic.check.ok
+	$(BUILDTESTDIR)/Basic.check.ok
 
 #----------------------------------------------------------------------
 
@@ -63,18 +63,18 @@ else
   BASIC_TESTS := $(abspath $(TESTDIR)/share/basic)
 endif
 
-$(BUILDDIR)/Basic.othervm.ok \
-$(BUILDDIR)/Basic.agentvm.ok: \
+$(BUILDTESTDIR)/Basic.othervm.ok \
+$(BUILDTESTDIR)/Basic.agentvm.ok: \
                 $(ALL_JTREG_JARS) \
 		$(TESTDIR)/basic/Basic.java \
-		$(BUILDDIR)/i18n.com.sun.javatest.regtest.config.ok \
-		$(BUILDDIR)/i18n.com.sun.javatest.regtest.report.ok \
-		$(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok \
+		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.config.ok \
+		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.report.ok \
+		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.tool.ok \
 	        $(BASIC.files)
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
-	$(MKDIR) -p $(@:%.ok=%/work/scratch) $(@:%.ok=%/report) $(BUILDDIR)/basic/classes
+	$(MKDIR) -p $(@:%.ok=%/work/scratch) $(@:%.ok=%/report) $(BUILDTESTDIR)/basic/classes
 	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
-		$(JDKJAVAC) -Xlint -Werror -encoding ISO8859-1 -d $(BUILDDIR)/basic/classes $(TESTDIR)/basic/Basic.java
+		$(JDKJAVAC) -Xlint -Werror -encoding ISO8859-1 -d $(BUILDTESTDIR)/basic/classes $(TESTDIR)/basic/Basic.java
 	cd $(@:%.ok=%/work/scratch) ; \
 	    $(JDKJAVA) \
 		-cp "../../../basic/classes$(PS)$(ABS_JTREG_IMAGEJARDIR)/jtreg.jar" \
@@ -90,14 +90,14 @@ $(BUILDDIR)/Basic.agentvm.ok: \
 		    ../../work \
 		    $(JDKHOME) \
 		    $(ENVVARS) \
-		    $(@:$(BUILDDIR)/Basic.%.ok=-%) \
+		    $(@:$(BUILDTESTDIR)/Basic.%.ok=-%) \
 		> ../../log 2>&1 \
 	    || (cat ../../log ; exit 1)
 	echo $@ passed at `date` > $@
 
 ifndef HEADLESS
 INITIAL_TESTS += \
-	$(BUILDDIR)/Basic.othervm.ok \
-	$(BUILDDIR)/Basic.agentvm.ok
+	$(BUILDTESTDIR)/Basic.othervm.ok \
+	$(BUILDTESTDIR)/Basic.agentvm.ok
 endif
 

--- a/test/basic/ReportOnlyTest.gmk
+++ b/test/basic/ReportOnlyTest.gmk
@@ -26,15 +26,15 @@
 #----------------------------------------------------------------------
 
 # for full JavaTest gui, add "-gui" to jtreg call
-$(BUILDDIR)/ReportOnlyTest.ok: $(BUILDDIR)/Basic.othervm.ok \
+$(BUILDTESTDIR)/ReportOnlyTest.ok: $(BUILDTESTDIR)/Basic.othervm.ok \
 		   $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		   $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		   $(JTREG_IMAGEDIR)/bin/jtreg
 	JAVA_HOME=$(JDKHOME) CLASSPATH=$(ABSCLASSDIR) \
 	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-reportOnly  -automatic -v \
-		-workDir:$(BUILDDIR)/Basic.othervm/work \
-		-reportDir:$(BUILDDIR)/$(@:%.ok=%) \
+		-workDir:$(BUILDTESTDIR)/Basic.othervm/work \
+		-reportDir:$(BUILDTESTDIR)/$(@:%.ok=%) \
 		$(TESTDIR)/share/basic \
 			> $(@:%.ok=%.jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -42,6 +42,6 @@ $(BUILDDIR)/ReportOnlyTest.ok: $(BUILDDIR)/Basic.othervm.ok \
 	echo $@ passed at `date` > $@
 
 ifndef HEADLESS
-TESTS.jtreg += $(BUILDDIR)/ReportOnlyTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/ReportOnlyTest.ok
 endif
 

--- a/test/bootclasspath/BootClassPathTest.gmk
+++ b/test/bootclasspath/BootClassPathTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/BootClassPathTest.ok: \
+$(BUILDTESTDIR)/BootClassPathTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/lib/testng.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
@@ -38,6 +38,6 @@ $(BUILDDIR)/BootClassPathTest.ok: \
 	echo "test passed at `date`" > $@
 
 ifdef JDK8HOME
-TESTS.jtreg += $(BUILDDIR)/BootClassPathTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/BootClassPathTest.ok
 endif
 

--- a/test/bugidtests/BugIdTests.gmk
+++ b/test/bugidtests/BugIdTests.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/BugIdTests.ok: \
+$(BUILDTESTDIR)/BugIdTests.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -44,18 +44,18 @@ $(BUILDDIR)/BugIdTests.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BugIdTests.ok
+	$(BUILDTESTDIR)/BugIdTests.ok
 
 
-$(BUILDDIR)/BugIdTests.1001111.ok \
-$(BUILDDIR)/BugIdTests.1002222.ok: \
+$(BUILDTESTDIR)/BugIdTests.1001111.ok \
+$(BUILDTESTDIR)/BugIdTests.1002222.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		-bug:$(@:$(BUILDDIR)/BugIdTests.%.ok=%) \
+		-bug:$(@:$(BUILDTESTDIR)/BugIdTests.%.ok=%) \
 		$(TESTDIR)/bugidtests \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -67,18 +67,18 @@ $(BUILDDIR)/BugIdTests.1002222.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BugIdTests.1001111.ok \
-	$(BUILDDIR)/BugIdTests.1002222.ok
+	$(BUILDTESTDIR)/BugIdTests.1001111.ok \
+	$(BUILDTESTDIR)/BugIdTests.1002222.ok
 
-$(BUILDDIR)/BugIdTests.1003333.ok \
-$(BUILDDIR)/BugIdTests.1004444.ok: \
+$(BUILDTESTDIR)/BugIdTests.1003333.ok \
+$(BUILDTESTDIR)/BugIdTests.1004444.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		-bug:$(@:$(BUILDDIR)/BugIdTests.%.ok=%) \
+		-bug:$(@:$(BUILDTESTDIR)/BugIdTests.%.ok=%) \
 		$(TESTDIR)/bugidtests \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -90,6 +90,6 @@ $(BUILDDIR)/BugIdTests.1004444.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BugIdTests.1003333.ok \
-	$(BUILDDIR)/BugIdTests.1004444.ok
+	$(BUILDTESTDIR)/BugIdTests.1003333.ok \
+	$(BUILDTESTDIR)/BugIdTests.1004444.ok
 

--- a/test/build-wildcards/buildWildcards.gmk
+++ b/test/build-wildcards/buildWildcards.gmk
@@ -24,7 +24,7 @@
 #
 
 
-$(BUILDDIR)/BuildWildcards.ok: \
+$(BUILDTESTDIR)/BuildWildcards.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -36,4 +36,4 @@ $(BUILDDIR)/BuildWildcards.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BuildWildcards.ok
+	$(BUILDTESTDIR)/BuildWildcards.ok

--- a/test/buildPatternTest/BuildPatternTest.gmk
+++ b/test/buildPatternTest/BuildPatternTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/BuildPatternTest.ok: \
+$(BUILDTESTDIR)/BuildPatternTest.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/buildPatternTest/BuildPatternTest.java
 	$(MKDIR) -p $(@:%.ok=%/classes)
@@ -37,4 +37,4 @@ $(BUILDDIR)/BuildPatternTest.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/BuildPatternTest.ok
+	$(BUILDTESTDIR)/BuildPatternTest.ok

--- a/test/buildTag/BuildTagTest.gmk
+++ b/test/buildTag/BuildTagTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/BuildTagTest.ok: \
+$(BUILDTESTDIR)/BuildTagTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -38,4 +38,4 @@ $(BUILDDIR)/BuildTagTest.ok: \
 	$(GREP) -s 'Test results: passed: 4; error: 3' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/BuildTagTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/BuildTagTest.ok

--- a/test/cachingFilter/CachingFilterTest.gmk
+++ b/test/cachingFilter/CachingFilterTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/CachingFilter_NoExclude.ok: \
+$(BUILDTESTDIR)/CachingFilter_NoExclude.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -36,9 +36,9 @@ $(BUILDDIR)/CachingFilter_NoExclude.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/CachingFilter_NoExclude.ok
+	$(BUILDTESTDIR)/CachingFilter_NoExclude.ok
 
-$(BUILDDIR)/CachingFilter_Exclude.ok: \
+$(BUILDTESTDIR)/CachingFilter_Exclude.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -52,4 +52,4 @@ $(BUILDDIR)/CachingFilter_Exclude.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/CachingFilter_Exclude.ok
+	$(BUILDTESTDIR)/CachingFilter_Exclude.ok

--- a/test/classDirs/ClassDirsTest.gmk
+++ b/test/classDirs/ClassDirsTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/ClassDirsTest.ok: \
+$(BUILDTESTDIR)/ClassDirsTest.ok: \
 	    $(TESTDIR)/classDirs/ClassDirsTest.java \
             $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
@@ -39,4 +39,4 @@ $(BUILDDIR)/ClassDirsTest.ok: \
 	echo $@ passed at `date` > $@
 
 
-TESTS.jtreg += $(BUILDDIR)/ClassDirsTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/ClassDirsTest.ok

--- a/test/classIsolation/ClassIsolationTest.gmk
+++ b/test/classIsolation/ClassIsolationTest.gmk
@@ -29,7 +29,7 @@ UCD_FILES := $(shell find $(TESTDIR)/classIsolation -type f )
 # When enabled in jtreg 4.2 b08 or later, class files are placed in an unshared test-specific directory
 # See Locations constructor, local variable useUniqueClassDir
 
-$(BUILDDIR)/ClassIsolation.disable.b07.ok: $(UCD_FILES) \
+$(BUILDTESTDIR)/ClassIsolation.disable.b07.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
@@ -50,7 +50,7 @@ $(BUILDDIR)/ClassIsolation.disable.b07.ok: $(UCD_FILES) \
 	echo "test passed at `date`" > $@
 	
 
-$(BUILDDIR)/ClassIsolation.disable.b08.ok: $(UCD_FILES) \
+$(BUILDTESTDIR)/ClassIsolation.disable.b08.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
@@ -70,7 +70,7 @@ $(BUILDDIR)/ClassIsolation.disable.b08.ok: $(UCD_FILES) \
 	fi
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ClassIsolation.default.b08.ok: $(UCD_FILES) \
+$(BUILDTESTDIR)/ClassIsolation.default.b08.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
@@ -90,7 +90,7 @@ $(BUILDDIR)/ClassIsolation.default.b08.ok: $(UCD_FILES) \
 	fi
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ClassIsolation.enable.b08.ok: $(UCD_FILES) \
+$(BUILDTESTDIR)/ClassIsolation.enable.b08.ok: $(UCD_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%)
@@ -111,9 +111,9 @@ $(BUILDDIR)/ClassIsolation.enable.b08.ok: $(UCD_FILES) \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ClassIsolation.disable.b07.ok \
-	$(BUILDDIR)/ClassIsolation.disable.b08.ok \
-	$(BUILDDIR)/ClassIsolation.default.b08.ok \
-	$(BUILDDIR)/ClassIsolation.enable.b08.ok 
+	$(BUILDTESTDIR)/ClassIsolation.disable.b07.ok \
+	$(BUILDTESTDIR)/ClassIsolation.disable.b08.ok \
+	$(BUILDTESTDIR)/ClassIsolation.default.b08.ok \
+	$(BUILDTESTDIR)/ClassIsolation.enable.b08.ok
 
 

--- a/test/cleanup/CleanupTest.gmk
+++ b/test/cleanup/CleanupTest.gmk
@@ -30,8 +30,8 @@
 # In agentvm and othervm mode, jtreg should successfully run each test
 # by moving to a new scratch directory when it can't clear the previous one.
 
-$(BUILDDIR)/CleanupTests.agentvm.ok \
-$(BUILDDIR)/CleanupTests.othervm.ok: \
+$(BUILDTESTDIR)/CleanupTests.agentvm.ok \
+$(BUILDTESTDIR)/CleanupTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -40,7 +40,7 @@ $(BUILDDIR)/CleanupTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupTests.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupTests.%.ok=-%) \
 		$(TESTDIR)/cleanup \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -57,8 +57,8 @@ $(BUILDDIR)/CleanupTests.othervm.ok: \
 # run each test by moving to a new scratch directory when it can't clear 
 # the previous one.
 
-$(BUILDDIR)/CleanupTests.agentvm.conc.ok \
-$(BUILDDIR)/CleanupTests.othervm.conc.ok: \
+$(BUILDTESTDIR)/CleanupTests.agentvm.conc.ok \
+$(BUILDTESTDIR)/CleanupTests.othervm.conc.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -67,7 +67,7 @@ $(BUILDDIR)/CleanupTests.othervm.conc.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupTests.%.conc.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupTests.%.conc.ok=-%) \
 		-conc:2 \
 		$(TESTDIR)/cleanup \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
@@ -83,7 +83,7 @@ $(BUILDDIR)/CleanupTests.othervm.conc.ok: \
 # In agent mode with -retain, the tests all pass
 # even if the selected files cannot be retained
 
-$(BUILDDIR)/CleanupTests.agentvm.retain.ok: \
+$(BUILDTESTDIR)/CleanupTests.agentvm.retain.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -92,7 +92,7 @@ $(BUILDDIR)/CleanupTests.agentvm.retain.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupTests.%.retain.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupTests.%.retain.ok=-%) \
 		-retain:readonly.txt \
 		$(TESTDIR)/cleanup \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
@@ -109,7 +109,7 @@ $(BUILDDIR)/CleanupTests.agentvm.retain.ok: \
 # problem tests are written directly to the correct location 
 # and do not need to be moved.
 
-$(BUILDDIR)/CleanupTests.othervm.retain.ok: \
+$(BUILDTESTDIR)/CleanupTests.othervm.retain.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -118,7 +118,7 @@ $(BUILDDIR)/CleanupTests.othervm.retain.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupTests.%.retain.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupTests.%.retain.ok=-%) \
 		-retain:readonly.txt \
 		$(TESTDIR)/cleanup \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
@@ -133,10 +133,10 @@ $(BUILDDIR)/CleanupTests.othervm.retain.ok: \
 
 ifneq ($(OS_NAME), windows)
 TESTS.jtreg += \
-	$(BUILDDIR)/CleanupTests.agentvm.ok \
-	$(BUILDDIR)/CleanupTests.agentvm.conc.ok \
-	$(BUILDDIR)/CleanupTests.agentvm.retain.ok \
-	$(BUILDDIR)/CleanupTests.othervm.ok \
-	$(BUILDDIR)/CleanupTests.othervm.conc.ok \
-	$(BUILDDIR)/CleanupTests.othervm.retain.ok
+	$(BUILDTESTDIR)/CleanupTests.agentvm.ok \
+	$(BUILDTESTDIR)/CleanupTests.agentvm.conc.ok \
+	$(BUILDTESTDIR)/CleanupTests.agentvm.retain.ok \
+	$(BUILDTESTDIR)/CleanupTests.othervm.ok \
+	$(BUILDTESTDIR)/CleanupTests.othervm.conc.ok \
+	$(BUILDTESTDIR)/CleanupTests.othervm.retain.ok
 endif

--- a/test/cleanupDirs/CleanupDirsTest.gmk
+++ b/test/cleanupDirs/CleanupDirsTest.gmk
@@ -30,8 +30,8 @@
 # In agentvm and othervm mode, jtreg should successfully run each test
 # by moving to a new scratch directory when it can't clear the previous one.
 
-$(BUILDDIR)/CleanupDirsTests.agentvm.ok \
-$(BUILDDIR)/CleanupDirsTests.othervm.ok: \
+$(BUILDTESTDIR)/CleanupDirsTests.agentvm.ok \
+$(BUILDTESTDIR)/CleanupDirsTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -40,7 +40,7 @@ $(BUILDDIR)/CleanupDirsTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupDirsTests.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupDirsTests.%.ok=-%) \
 		$(TESTDIR)/cleanupDirs \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -61,8 +61,8 @@ $(BUILDDIR)/CleanupDirsTests.othervm.ok: \
 # test executed last in each scratch directory. Therefore, we just count
 # and check the number of scratch directories that were created.
 
-$(BUILDDIR)/CleanupDirsTests.agentvm.conc.ok \
-$(BUILDDIR)/CleanupDirsTests.othervm.conc.ok: \
+$(BUILDTESTDIR)/CleanupDirsTests.agentvm.conc.ok \
+$(BUILDTESTDIR)/CleanupDirsTests.othervm.conc.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -71,7 +71,7 @@ $(BUILDDIR)/CleanupDirsTests.othervm.conc.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupDirsTests.%.conc.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupDirsTests.%.conc.ok=-%) \
 		-conc:2 \
 		$(TESTDIR)/cleanupDirs \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
@@ -87,7 +87,7 @@ $(BUILDDIR)/CleanupDirsTests.othervm.conc.ok: \
 # In agent mode with -retain, the tests all return error
 # because the selected files cannot be retained
 
-$(BUILDDIR)/CleanupDirsTests.agentvm.retain.ok: \
+$(BUILDTESTDIR)/CleanupDirsTests.agentvm.retain.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -96,7 +96,7 @@ $(BUILDDIR)/CleanupDirsTests.agentvm.retain.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupDirsTests.%.retain.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupDirsTests.%.retain.ok=-%) \
 		-retain:readonly.txt \
 		$(TESTDIR)/cleanupDirs \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
@@ -113,7 +113,7 @@ $(BUILDDIR)/CleanupDirsTests.agentvm.retain.ok: \
 # problem tests are written directly to the correct location 
 # and do not need to be moved.
 
-$(BUILDDIR)/CleanupDirsTests.othervm.retain.ok: \
+$(BUILDTESTDIR)/CleanupDirsTests.othervm.retain.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -122,7 +122,7 @@ $(BUILDDIR)/CleanupDirsTests.othervm.retain.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/CleanupDirsTests.%.retain.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CleanupDirsTests.%.retain.ok=-%) \
 		-retain:readonly.txt \
 		$(TESTDIR)/cleanupDirs \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
@@ -137,10 +137,10 @@ $(BUILDDIR)/CleanupDirsTests.othervm.retain.ok: \
 
 ifneq ($(OS_NAME), windows)
 TESTS.jtreg += \
-	$(BUILDDIR)/CleanupDirsTests.agentvm.ok \
-	$(BUILDDIR)/CleanupDirsTests.agentvm.conc.ok \
-	$(BUILDDIR)/CleanupDirsTests.agentvm.retain.ok \
-	$(BUILDDIR)/CleanupDirsTests.othervm.ok \
-	$(BUILDDIR)/CleanupDirsTests.othervm.conc.ok \
-	$(BUILDDIR)/CleanupDirsTests.othervm.retain.ok
+	$(BUILDTESTDIR)/CleanupDirsTests.agentvm.ok \
+	$(BUILDTESTDIR)/CleanupDirsTests.agentvm.conc.ok \
+	$(BUILDTESTDIR)/CleanupDirsTests.agentvm.retain.ok \
+	$(BUILDTESTDIR)/CleanupDirsTests.othervm.ok \
+	$(BUILDTESTDIR)/CleanupDirsTests.othervm.conc.ok \
+	$(BUILDTESTDIR)/CleanupDirsTests.othervm.retain.ok
 endif

--- a/test/compileArgFileTest/CompileArgFileTest.gmk
+++ b/test/compileArgFileTest/CompileArgFileTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/CompileArgFileTest.ok: \
+$(BUILDTESTDIR)/CompileArgFileTest.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/classes
@@ -40,4 +40,4 @@ $(BUILDDIR)/CompileArgFileTest.ok: \
 	$(GREP) -s '^Test results: passed: [0-9]*$$' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/CompileArgFileTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/CompileArgFileTest.ok

--- a/test/compilejdk/CompileTests.gmk
+++ b/test/compilejdk/CompileTests.gmk
@@ -26,8 +26,8 @@
 #----------------------------------------------------------------------
 
 # Test @compile with -compilejdk; use not-a-jdk for -testjdk
-$(BUILDDIR)/CompileTest.1.agentvm.ok \
-$(BUILDDIR)/CompileTest.1.othervm.ok: \
+$(BUILDTESTDIR)/CompileTest.1.agentvm.ok \
+$(BUILDTESTDIR)/CompileTest.1.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
 	    $(BUILDDIR)/not-a-jdk/bin/java
@@ -38,15 +38,15 @@ $(BUILDDIR)/CompileTest.1.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-compilejdk:$(JDK5HOME) \
 		-jdk:$(BUILDDIR)/not-a-jdk \
-		$(@:$(BUILDDIR)/CompileTest.1.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CompileTest.1.%.ok=-%) \
 		$(TESTDIR)/compilejdk/CompileTest.java
 	grep $(JDK5HOME) $(@:%.ok=%)/work/CompileTest.jtr
 	if grep $(JDKHOME) $(@:%.ok=%)/work/CompileTest.jtr ; then exit 1; fi
 	echo "test passed at `date`" > $@
 
 # Precompile test classes, then test @run main with -testjdk, use not-a-jdk for -compilejdk
-$(BUILDDIR)/CompileTest.2.agentvm.ok \
-$(BUILDDIR)/CompileTest.2.othervm.ok: \
+$(BUILDTESTDIR)/CompileTest.2.agentvm.ok \
+$(BUILDTESTDIR)/CompileTest.2.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
 	    $(BUILDDIR)/not-a-jdk/bin/java
@@ -55,7 +55,7 @@ $(BUILDDIR)/CompileTest.2.othervm.ok: \
 	JT_JAVA=$(JDKHOME) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK5HOME) \
-		$(@:$(BUILDDIR)/CompileTest.2.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CompileTest.2.%.ok=-%) \
 		$(TESTDIR)/compilejdk/ExecuteTest.java
 	JTREG_SHOWAGENT=true JTREG_SHOWCMD=true \
 	JT_JAVA=$(JDKHOME) \
@@ -63,15 +63,15 @@ $(BUILDDIR)/CompileTest.2.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-compilejdk:$(BUILDDIR)/not-a-jdk \
 		-jdk:$(JDK5HOME) \
-		$(@:$(BUILDDIR)/CompileTest.2.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CompileTest.2.%.ok=-%) \
 		$(TESTDIR)/compilejdk/ExecuteTest.java
 	grep $(JDK5HOME) $(@:%.ok=%)/work/ExecuteTest.jtr
 	if grep $(JDKHOME) $(@:%.ok=%)/work/ExecuteTest.jtr ; then exit 1; fi
 	echo "test passed at `date`" > $@
 
 # Test compilation on JDK, execution on just-java (JRE lookalike)
-$(BUILDDIR)/CompileTest.3.agentvm.ok \
-$(BUILDDIR)/CompileTest.3.othervm.ok: \
+$(BUILDTESTDIR)/CompileTest.3.agentvm.ok \
+$(BUILDTESTDIR)/CompileTest.3.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
 	    $(BUILDDIR)/just-java/bin/java
@@ -82,14 +82,14 @@ $(BUILDDIR)/CompileTest.3.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-compilejdk:$(JDK5HOME) \
 		-jdk:$(BUILDDIR)/just-java \
-		$(@:$(BUILDDIR)/CompileTest.3.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CompileTest.3.%.ok=-%) \
 		$(TESTDIR)/compilejdk/ExecuteTest.java
 	echo "test passed at `date`" > $@
 
 # Test compilation on one version of JDK, execution on another;
 # Verify tools.jar is on classpath for both
-$(BUILDDIR)/CompileTest.4.agentvm.ok \
-$(BUILDDIR)/CompileTest.4.othervm.ok: \
+$(BUILDTESTDIR)/CompileTest.4.agentvm.ok \
+$(BUILDTESTDIR)/CompileTest.4.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -99,12 +99,12 @@ $(BUILDDIR)/CompileTest.4.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-compilejdk:$(JDK5HOME) \
 		-jdk:$(JDK6HOME) \
-		$(@:$(BUILDDIR)/CompileTest.4.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/CompileTest.4.%.ok=-%) \
 		$(TESTDIR)/compilejdk/ToolsJarTest.java
 	echo "test passed at `date`" > $@
 
 # Verify shell test gets COMPILEJAVA set as well as TESTJAVA
-$(BUILDDIR)/CompileTest.5.ok: \
+$(BUILDTESTDIR)/CompileTest.5.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -139,14 +139,14 @@ $(BUILDDIR)/just-java/bin/java:
 ifneq ($(OS_NAME), windows)
 ifdef JDK5HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/CompileTest.1.agentvm.ok \
-	$(BUILDDIR)/CompileTest.1.othervm.ok \
-	$(BUILDDIR)/CompileTest.2.agentvm.ok \
-	$(BUILDDIR)/CompileTest.2.othervm.ok \
-	$(BUILDDIR)/CompileTest.3.agentvm.ok \
-	$(BUILDDIR)/CompileTest.3.othervm.ok \
-	$(BUILDDIR)/CompileTest.4.agentvm.ok \
-	$(BUILDDIR)/CompileTest.4.othervm.ok \
-	$(BUILDDIR)/CompileTest.5.ok
+	$(BUILDTESTDIR)/CompileTest.1.agentvm.ok \
+	$(BUILDTESTDIR)/CompileTest.1.othervm.ok \
+	$(BUILDTESTDIR)/CompileTest.2.agentvm.ok \
+	$(BUILDTESTDIR)/CompileTest.2.othervm.ok \
+	$(BUILDTESTDIR)/CompileTest.3.agentvm.ok \
+	$(BUILDTESTDIR)/CompileTest.3.othervm.ok \
+	$(BUILDTESTDIR)/CompileTest.4.agentvm.ok \
+	$(BUILDTESTDIR)/CompileTest.4.othervm.ok \
+	$(BUILDTESTDIR)/CompileTest.5.ok
 endif
 endif

--- a/test/cpappend/CPAppendTests.gmk
+++ b/test/cpappend/CPAppendTests.gmk
@@ -25,19 +25,19 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/CPAppend/classes/p/Lib.class: \
+$(BUILDTESTDIR)/CPAppend/classes/p/Lib.class: \
 	$(TESTDIR)/cpappend/lib/p/Lib.java
-	$(MKDIR) -p $(BUILDDIR)/CPAppend/classes
-	$(JDKJAVAC) -d $(BUILDDIR)/CPAppend/classes \
+	$(MKDIR) -p $(BUILDTESTDIR)/CPAppend/classes
+	$(JDKJAVAC) -d $(BUILDTESTDIR)/CPAppend/classes \
 		-Xlint -Werror \
 		$(TESTDIR)/cpappend/lib/p/Lib.java
 
 # Control test for -cpa -- verify test fails if option not provided
 #
-$(BUILDDIR)/CPAppend/neg.ok: \
+$(BUILDTESTDIR)/CPAppend/neg.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
-	    $(BUILDDIR)/CPAppend/classes/p/Lib.class
+	    $(BUILDTESTDIR)/CPAppend/classes/p/Lib.class
 	    $(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
@@ -51,34 +51,34 @@ $(BUILDDIR)/CPAppend/neg.ok: \
 
 # Run test in -othervm mode
 #
-$(BUILDDIR)/CPAppend/othervm.ok: \
+$(BUILDTESTDIR)/CPAppend/othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
-	    $(BUILDDIR)/CPAppend/classes/p/Lib.class
+	    $(BUILDTESTDIR)/CPAppend/classes/p/Lib.class
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-othervm \
-		-cpa:$(BUILDDIR)/CPAppend/classes \
+		-cpa:$(BUILDTESTDIR)/CPAppend/classes \
 		$(TESTDIR)/cpappend/test
 	echo "test passed at `date`" > $@
 
 # Run test in -agentvm mode
 #
-$(BUILDDIR)/CPAppend/agentvm.ok: \
+$(BUILDTESTDIR)/CPAppend/agentvm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
-	    $(BUILDDIR)/CPAppend/classes/p/Lib.class
+	    $(BUILDTESTDIR)/CPAppend/classes/p/Lib.class
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-agentvm \
-		-cpa:$(BUILDDIR)/CPAppend/classes \
+		-cpa:$(BUILDTESTDIR)/CPAppend/classes \
 		$(TESTDIR)/cpappend/test
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/CPAppend/neg.ok \
-	$(BUILDDIR)/CPAppend/othervm.ok \
-	$(BUILDDIR)/CPAppend/agentvm.ok
+	$(BUILDTESTDIR)/CPAppend/neg.ok \
+	$(BUILDTESTDIR)/CPAppend/othervm.ok \
+	$(BUILDTESTDIR)/CPAppend/agentvm.ok
 

--- a/test/ctrl/ControlTest.gmk
+++ b/test/ctrl/ControlTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/ControlTest.ok: \
+$(BUILDTESTDIR)/ControlTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -38,5 +38,5 @@ $(BUILDDIR)/ControlTest.ok: \
         fi
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/ControlTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/ControlTest.ok
 

--- a/test/debug/DebugTest.gmk
+++ b/test/debug/DebugTest.gmk
@@ -29,7 +29,7 @@
 # different in the two modes. Ideally, the rerun sections should be
 # updated to be more equivalent.
 
-$(BUILDDIR)/DebugTest.othervm.ok: \
+$(BUILDTESTDIR)/DebugTest.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -46,10 +46,10 @@ $(BUILDDIR)/DebugTest.othervm.ok: \
 	fi
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/DebugTest.othervm.ok
+TESTS.jtreg += $(BUILDTESTDIR)/DebugTest.othervm.ok
 
 
-$(BUILDDIR)/DebugTest.agentvm.ok: \
+$(BUILDTESTDIR)/DebugTest.agentvm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -70,6 +70,6 @@ $(BUILDDIR)/DebugTest.agentvm.ok: \
 	fi
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/DebugTest.agentvm.ok
+TESTS.jtreg += $(BUILDTESTDIR)/DebugTest.agentvm.ok
 
 

--- a/test/docs.gmk
+++ b/test/docs.gmk
@@ -23,12 +23,12 @@
 # questions.
 #
 
-$(BUILDDIR)/tidy-docs.ok: \
+$(BUILDTESTDIR)/tidy-docs.ok: \
                 $(JTREG_IMAGEDIR)/doc/jtreg/tag-spec.html
 	if [ ! -x $(TIDY) ]; then exit 0; fi ; \
 	$(TIDY) -e --gnu-emacs true -q $<
 	echo "docs checked at `date`" > $@
 
 INITIAL_TESTS += \
-	$(BUILDDIR)/tidy-docs.ok
+	$(BUILDTESTDIR)/tidy-docs.ok
 

--- a/test/dupTests/DupTest.gmk
+++ b/test/dupTests/DupTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/DupTest.ok: \
+$(BUILDTESTDIR)/DupTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -35,5 +35,5 @@ $(BUILDDIR)/DupTest.ok: \
         if [ "$$rc" != 5 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/DupTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/DupTest.ok
 

--- a/test/empty/EmptyTest.gmk
+++ b/test/empty/EmptyTest.gmk
@@ -26,7 +26,7 @@
 # No Args:  
 #   not allowed, exit code 1, Error: No tests selected
 #
-$(BUILDDIR)/EmptyTest_NoArgs.ok: \
+$(BUILDTESTDIR)/EmptyTest_NoArgs.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -39,14 +39,14 @@ $(BUILDDIR)/EmptyTest_NoArgs.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_NoArgs.ok
+	$(BUILDTESTDIR)/EmptyTest_NoArgs.ok
 
 #-------------------------------------------------------------------------------
 
 # Empty Group:  
 #   allowed, exit code 0; Test results: No tests selected
 #
-$(BUILDDIR)/EmptyTest_EmptyGroup.ok: \
+$(BUILDTESTDIR)/EmptyTest_EmptyGroup.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -60,14 +60,14 @@ $(BUILDDIR)/EmptyTest_EmptyGroup.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_EmptyGroup.ok
+	$(BUILDTESTDIR)/EmptyTest_EmptyGroup.ok
 
 #-------------------------------------------------------------------------------
 
 # Empty Folder:
 #   not allowed, exit code 1; Test results: No tests selected
 #
-$(BUILDDIR)/EmptyTest_EmptyFolder.ok: \
+$(BUILDTESTDIR)/EmptyTest_EmptyFolder.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -82,14 +82,14 @@ $(BUILDDIR)/EmptyTest_EmptyFolder.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_EmptyFolder.ok
+	$(BUILDTESTDIR)/EmptyTest_EmptyFolder.ok
 
 #-------------------------------------------------------------------------------
 
 # Empty File:
 #   not allowed, exit code 5; Error: Not a test or directory containing tests: empty/Empty.java
 #
-$(BUILDDIR)/EmptyTest_EmptyFile.ok: \
+$(BUILDTESTDIR)/EmptyTest_EmptyFile.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -104,14 +104,14 @@ $(BUILDDIR)/EmptyTest_EmptyFile.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_EmptyFile.ok
+	$(BUILDTESTDIR)/EmptyTest_EmptyFile.ok
 
 #-------------------------------------------------------------------------------
 
 # Empty Group and a Test:  
 #   allowed, exit code 0; Test results: passed: 1
 #
-$(BUILDDIR)/EmptyTest_EmptyGroup_Test.ok: \
+$(BUILDTESTDIR)/EmptyTest_EmptyGroup_Test.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -125,14 +125,14 @@ $(BUILDDIR)/EmptyTest_EmptyGroup_Test.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_EmptyGroup_Test.ok
+	$(BUILDTESTDIR)/EmptyTest_EmptyGroup_Test.ok
 
 #-------------------------------------------------------------------------------
 
 # Empty Group and an empty folder:
 #   not allowed, exit code 1; Test results: No tests selected
 #
-$(BUILDDIR)/EmptyTest_EmptyGroup_EmptyFolder.ok: \
+$(BUILDTESTDIR)/EmptyTest_EmptyGroup_EmptyFolder.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -147,14 +147,14 @@ $(BUILDDIR)/EmptyTest_EmptyGroup_EmptyFolder.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_EmptyGroup_EmptyFolder.ok
+	$(BUILDTESTDIR)/EmptyTest_EmptyGroup_EmptyFolder.ok
 
 #-------------------------------------------------------------------------------
 
 # Multiple Empty Group in same test suite:  
 #   allowed, exit code 0; Test results: No tests selected
 #
-$(BUILDDIR)/EmptyTest_MultiEmptyGroup_1.ok: \
+$(BUILDTESTDIR)/EmptyTest_MultiEmptyGroup_1.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -168,14 +168,14 @@ $(BUILDDIR)/EmptyTest_MultiEmptyGroup_1.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_MultiEmptyGroup_1.ok
+	$(BUILDTESTDIR)/EmptyTest_MultiEmptyGroup_1.ok
 
 #-------------------------------------------------------------------------------
 
 # Multiple Empty Group in separate test suites:  
 #   allowed, exit code 0; Test results: No tests selected
 #
-$(BUILDDIR)/EmptyTest_MultiEmptyGroup_2.ok: \
+$(BUILDTESTDIR)/EmptyTest_MultiEmptyGroup_2.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -189,5 +189,5 @@ $(BUILDDIR)/EmptyTest_MultiEmptyGroup_2.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/EmptyTest_MultiEmptyGroup_2.ok
+	$(BUILDTESTDIR)/EmptyTest_MultiEmptyGroup_2.ok
 

--- a/test/env/EnvTest.gmk
+++ b/test/env/EnvTest.gmk
@@ -25,7 +25,7 @@
 
 ENV.files := $(shell find $(TESTDIR)/env -type f)
 
-$(BUILDDIR)/EnvTest.simple.ok: $(ENV.files) \
+$(BUILDTESTDIR)/EnvTest.simple.ok: $(ENV.files) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -49,7 +49,7 @@ $(BUILDDIR)/EnvTest.simple.ok: $(ENV.files) \
 	    ( cat $(@:%.ok=%/jt.log) ; exit 1 )
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/EnvTest.full.ok: $(ENV.files) \
+$(BUILDTESTDIR)/EnvTest.full.ok: $(ENV.files) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -83,8 +83,8 @@ ifdef JDK6HOME
 ifdef JDK7HOME
 ifndef HEADLESS
 TESTS.jtreg += \
-	$(BUILDDIR)/EnvTest.simple.ok \
-	$(BUILDDIR)/EnvTest.full.ok
+	$(BUILDTESTDIR)/EnvTest.simple.ok \
+	$(BUILDTESTDIR)/EnvTest.full.ok
 endif
 endif
 endif

--- a/test/exclude/ExcludeTest.gmk
+++ b/test/exclude/ExcludeTest.gmk
@@ -25,8 +25,8 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/exclude.othervm.ok \
-$(BUILDDIR)/exclude.agentvm.ok: \
+$(BUILDTESTDIR)/exclude.othervm.ok \
+$(BUILDTESTDIR)/exclude.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -38,7 +38,7 @@ $(BUILDDIR)/exclude.agentvm.ok: \
 		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
-		$(@:$(BUILDDIR)/exclude.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/exclude.%.ok=-%) \
 		-exclude:$(TESTDIR)/exclude/ProblemList.txt \
 		$(TESTDIR)/exclude \
 		> $(@:%.ok=%/log 2>&1) \
@@ -46,5 +46,5 @@ $(BUILDDIR)/exclude.agentvm.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/exclude.othervm.ok \
-	$(BUILDDIR)/exclude.agentvm.ok
+	$(BUILDTESTDIR)/exclude.othervm.ok \
+	$(BUILDTESTDIR)/exclude.agentvm.ok

--- a/test/exclusive/ExclusiveAccessTest.gmk
+++ b/test/exclusive/ExclusiveAccessTest.gmk
@@ -23,13 +23,13 @@
 # questions.
 #
 
-$(BUILDDIR)/ExclusiveAccessTest.ref:
+$(BUILDTESTDIR)/ExclusiveAccessTest.ref:
 	( for t in 1 2 3 4 ; do for i in 1 2 3 4 5 ; do echo "Test: $$i" ; done ; done ) > $@
 
-$(BUILDDIR)/ExclusiveAccessTest.single.ok: \
+$(BUILDTESTDIR)/ExclusiveAccessTest.single.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg \
-	$(BUILDDIR)/ExclusiveAccessTest.ref
+	$(BUILDTESTDIR)/ExclusiveAccessTest.ref
 	$(RM) $(@:%.ok=%) && $(MKDIR) $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
@@ -39,13 +39,13 @@ $(BUILDDIR)/ExclusiveAccessTest.single.ok: \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
 	$(GREP) -s 'Test results: passed: 4' $(@:%.ok=%/jt.log)  > /dev/null
-	$(DIFF) $(BUILDDIR)/ExclusiveAccessTest.ref $(@:%.ok=%)/Test.log
+	$(DIFF) $(BUILDTESTDIR)/ExclusiveAccessTest.ref $(@:%.ok=%)/Test.log
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ExclusiveAccessTest.multi.ok: \
+$(BUILDTESTDIR)/ExclusiveAccessTest.multi.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg \
-	$(BUILDDIR)/ExclusiveAccessTest.ref
+	$(BUILDTESTDIR)/ExclusiveAccessTest.ref
 	$(RM) $(@:%.ok=%) && $(MKDIR) $(@:%.ok=%)
 	for i in 1 2 3 4 ; do \
 	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
@@ -59,4 +59,4 @@ $(BUILDDIR)/ExclusiveAccessTest.multi.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExclusiveAccessTest.single.ok
+	$(BUILDTESTDIR)/ExclusiveAccessTest.single.ok

--- a/test/exitCodes/ExitCodeTest.gmk
+++ b/test/exitCodes/ExitCodeTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/ExitCodeTest.OK.ok: \
+$(BUILDTESTDIR)/ExitCodeTest.OK.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -35,7 +35,7 @@ $(BUILDDIR)/ExitCodeTest.OK.ok: \
         if [ "$$rc" != 0 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ExitCodeTest.NoTest.ok: \
+$(BUILDTESTDIR)/ExitCodeTest.NoTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -48,7 +48,7 @@ $(BUILDDIR)/ExitCodeTest.NoTest.ok: \
         if [ "$$rc" != 1 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ExitCodeTest.Fail.ok: \
+$(BUILDTESTDIR)/ExitCodeTest.Fail.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -60,7 +60,7 @@ $(BUILDDIR)/ExitCodeTest.Fail.ok: \
         if [ "$$rc" != 2 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ExitCodeTest.Error.ok: \
+$(BUILDTESTDIR)/ExitCodeTest.Error.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -72,7 +72,7 @@ $(BUILDDIR)/ExitCodeTest.Error.ok: \
         if [ "$$rc" != 3 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ExitCodeTest.BadArgs.ok: \
+$(BUILDTESTDIR)/ExitCodeTest.BadArgs.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -85,7 +85,7 @@ $(BUILDDIR)/ExitCodeTest.BadArgs.ok: \
         if [ "$$rc" != 4 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/ExitCodeTest.Fault.ok: \
+$(BUILDTESTDIR)/ExitCodeTest.Fault.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -98,9 +98,9 @@ $(BUILDDIR)/ExitCodeTest.Fault.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExitCodeTest.OK.ok \
-	$(BUILDDIR)/ExitCodeTest.NoTest.ok \
-	$(BUILDDIR)/ExitCodeTest.Fail.ok \
-	$(BUILDDIR)/ExitCodeTest.Error.ok \
-	$(BUILDDIR)/ExitCodeTest.BadArgs.ok \
-	$(BUILDDIR)/ExitCodeTest.Fault.ok
+	$(BUILDTESTDIR)/ExitCodeTest.OK.ok \
+	$(BUILDTESTDIR)/ExitCodeTest.NoTest.ok \
+	$(BUILDTESTDIR)/ExitCodeTest.Fail.ok \
+	$(BUILDTESTDIR)/ExitCodeTest.Error.ok \
+	$(BUILDTESTDIR)/ExitCodeTest.BadArgs.ok \
+	$(BUILDTESTDIR)/ExitCodeTest.Fault.ok

--- a/test/explicitIds/ExplicitIds.gmk
+++ b/test/explicitIds/ExplicitIds.gmk
@@ -23,8 +23,8 @@
 # questions.
 #
 
-$(BUILDDIR)/ExplicitIds.agentvm.ok \
-$(BUILDDIR)/ExplicitIds.othervm.ok: \
+$(BUILDTESTDIR)/ExplicitIds.agentvm.ok \
+$(BUILDTESTDIR)/ExplicitIds.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -32,7 +32,7 @@ $(BUILDDIR)/ExplicitIds.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/ExplicitIds.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/ExplicitIds.%.ok=-%) \
 		$(TESTDIR)/explicitIds \
 			> $(@:%.ok=%/jt.log)  2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -48,5 +48,5 @@ $(BUILDDIR)/ExplicitIds.othervm.ok: \
 
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExplicitIds.agentvm.ok \
-	$(BUILDDIR)/ExplicitIds.othervm.ok
+	$(BUILDTESTDIR)/ExplicitIds.agentvm.ok \
+	$(BUILDTESTDIR)/ExplicitIds.othervm.ok

--- a/test/extlib/ExtLibTest.gmk
+++ b/test/extlib/ExtLibTest.gmk
@@ -24,7 +24,7 @@
 #
 
 
-$(BUILDDIR)/ExtLibTest.ok: \
+$(BUILDTESTDIR)/ExtLibTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -37,5 +37,5 @@ $(BUILDDIR)/ExtLibTest.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExtLibTest.ok
+	$(BUILDTESTDIR)/ExtLibTest.ok
 

--- a/test/extra-props/ExtraPropDefnsTest.gmk
+++ b/test/extra-props/ExtraPropDefnsTest.gmk
@@ -25,7 +25,7 @@
 
 #-------------------------------------------------------------------------------
 #
-$(BUILDDIR)/ExtraPropDefnsTest.valid.ok: \
+$(BUILDTESTDIR)/ExtraPropDefnsTest.valid.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -38,11 +38,11 @@ $(BUILDDIR)/ExtraPropDefnsTest.valid.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExtraPropDefnsTest.valid.ok
+	$(BUILDTESTDIR)/ExtraPropDefnsTest.valid.ok
 
 #-------------------------------------------------------------------------------
 #
-$(BUILDDIR)/ExtraPropDefnsTest.valid.libs.ok: \
+$(BUILDTESTDIR)/ExtraPropDefnsTest.valid.libs.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -55,11 +55,11 @@ $(BUILDDIR)/ExtraPropDefnsTest.valid.libs.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExtraPropDefnsTest.valid.libs.ok
+	$(BUILDTESTDIR)/ExtraPropDefnsTest.valid.libs.ok
 
 #-------------------------------------------------------------------------------
 #
-$(BUILDDIR)/ExtraPropDefnsTest.bad-compile.ok: \
+$(BUILDTESTDIR)/ExtraPropDefnsTest.bad-compile.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -73,11 +73,11 @@ $(BUILDDIR)/ExtraPropDefnsTest.bad-compile.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExtraPropDefnsTest.bad-compile.ok
+	$(BUILDTESTDIR)/ExtraPropDefnsTest.bad-compile.ok
 
 #-------------------------------------------------------------------------------
 #
-$(BUILDDIR)/ExtraPropDefnsTest.bad-execute.ok: \
+$(BUILDTESTDIR)/ExtraPropDefnsTest.bad-execute.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -91,11 +91,11 @@ $(BUILDDIR)/ExtraPropDefnsTest.bad-execute.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExtraPropDefnsTest.bad-execute.ok
+	$(BUILDTESTDIR)/ExtraPropDefnsTest.bad-execute.ok
 
 #-------------------------------------------------------------------------------
 #
-$(BUILDDIR)/ExtraPropDefnsTest.error.ok: \
+$(BUILDTESTDIR)/ExtraPropDefnsTest.error.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -111,4 +111,4 @@ $(BUILDDIR)/ExtraPropDefnsTest.error.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ExtraPropDefnsTest.error.ok
+	$(BUILDTESTDIR)/ExtraPropDefnsTest.error.ok

--- a/test/fixup/FixupTest.gmk
+++ b/test/fixup/FixupTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/fixupSingle.ok: \
+$(BUILDTESTDIR)/fixupSingle.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -41,11 +41,11 @@ $(BUILDDIR)/fixupSingle.ok: \
 	if [ -n "$$g" ]; then echo "Error: Unexpected references:" ; echo "$$g" ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/fixupSingle.ok
+TESTS.jtreg += $(BUILDTESTDIR)/fixupSingle.ok
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/fixupMulti.ok: \
+$(BUILDTESTDIR)/fixupMulti.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -62,4 +62,4 @@ $(BUILDDIR)/fixupMulti.ok: \
 	if [ -n "$$g" ]; then echo "Error: Unexpected references:" ; echo "$$g" ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/fixupMulti.ok
+TESTS.jtreg += $(BUILDTESTDIR)/fixupMulti.ok

--- a/test/groups/GroupTest.gmk
+++ b/test/groups/GroupTest.gmk
@@ -29,19 +29,19 @@ GroupTest.GROUPS := $(shell $(GREP) -h '=' \
 	$(TESTDIR)/groups/TEST.group* | \
 	$(AWK) '{print $$1}' | $(SORT) -unk 1.2 )
 
-$(BUILDDIR)/GroupTest.ok: $(GroupTest.GROUPS:%=$(BUILDDIR)/GroupTest.%.ok)
+$(BUILDTESTDIR)/GroupTest.ok: $(GroupTest.GROUPS:%=$(BUILDTESTDIR)/GroupTest.%.ok)
 	echo $@ passed at `date` > $@
 
-$(GroupTest.GROUPS:%=$(BUILDDIR)/GroupTest.%.ok): \
+$(GroupTest.GROUPS:%=$(BUILDTESTDIR)/GroupTest.%.ok): \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%) 
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(TESTDIR)/groups:$(@:$(BUILDDIR)/GroupTest.%.ok=%) ; \
+		$(TESTDIR)/groups:$(@:$(BUILDTESTDIR)/GroupTest.%.ok=%) ; \
             status=$$? ; echo status=$$status ; \
-            case "$(@:$(BUILDDIR)/GroupTest.%.ok=%)" in \
+            case "$(@:$(BUILDTESTDIR)/GroupTest.%.ok=%)" in \
 		g6 )  expect=1 ;; \
 		g10|g11|g12 ) expect=5 ;; \
                 * ) expect=0 ;; \
@@ -49,9 +49,9 @@ $(GroupTest.GROUPS:%=$(BUILDDIR)/GroupTest.%.ok): \
             if [ "$$status" != "$$expect" ]; then echo "unexpected exit: $$status" ; exit 1; fi
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/GroupTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/GroupTest.ok
 
-$(BUILDDIR)/ShowGroupTest.ok: \
+$(BUILDTESTDIR)/ShowGroupTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%) 
@@ -67,4 +67,4 @@ $(BUILDDIR)/ShowGroupTest.ok: \
 	$(DIFF) $(@:%.ok=%)/g3.expect $(@:%.ok=%)/g3.found
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/ShowGroupTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/ShowGroupTest.ok

--- a/test/i18n/i18n.com.sun.javatest.diff.gmk
+++ b/test/i18n/i18n.com.sun.javatest.diff.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/i18n.com.sun.javatest.diff.ok: \
+$(BUILDTESTDIR)/i18n.com.sun.javatest.diff.ok: \
 		$(JAVAFILES.com.sun.javatest.diff) \
 		$(JAVADIR)/com/sun/javatest/diff/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.diff.ok \
@@ -38,4 +38,4 @@ $(BUILDDIR)/i18n.com.sun.javatest.diff.ok: \
 	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/diff $(@:%.ok=%/i18n-log.txt)
 	echo $@ passed at `date` > $@
 
-TESTS.jtdiff += $(BUILDDIR)/i18n.com.sun.javatest.diff.ok
+TESTS.jtdiff += $(BUILDTESTDIR)/i18n.com.sun.javatest.diff.ok

--- a/test/i18n/i18n.com.sun.javatest.regtest.gmk
+++ b/test/i18n/i18n.com.sun.javatest.regtest.gmk
@@ -24,7 +24,7 @@
 #
 
 
-$(BUILDDIR)/i18n.com.sun.javatest.regtest.config.ok: \
+$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.config.ok: \
 		$(JAVADIR)/com/sun/javatest/regtest/config/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
@@ -32,7 +32,7 @@ $(BUILDDIR)/i18n.com.sun.javatest.regtest.config.ok: \
 	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/regtest/config
 	echo $@ passed at `date` > $@
 
-$(BUILDDIR)/i18n.com.sun.javatest.regtest.report.ok: \
+$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.report.ok: \
 		$(JAVADIR)/com/sun/javatest/regtest/report/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
@@ -40,7 +40,7 @@ $(BUILDDIR)/i18n.com.sun.javatest.regtest.report.ok: \
 	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/regtest/report
 	echo $@ passed at `date` > $@
 
-$(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok: \
+$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.tool.ok: \
 		$(JAVADIR)/com/sun/javatest/regtest/tool/i18n.properties \
 		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok \
 		$(TESTDIR)/i18n/checkI18NProps.sh
@@ -54,12 +54,12 @@ $(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok: \
 
 # convenience target
 i18n.com.sun.javatest.regtest: \
-    $(BUILDDIR)/i18n.com.sun.javatest.regtest.config.ok \
-    $(BUILDDIR)/i18n.com.sun.javatest.regtest.report.ok \
-    $(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok
+    $(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.config.ok \
+    $(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.report.ok \
+    $(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.tool.ok
 
 INITIAL_TESTS += \
-    $(BUILDDIR)/i18n.com.sun.javatest.regtest.config.ok \
-    $(BUILDDIR)/i18n.com.sun.javatest.regtest.report.ok \
-    $(BUILDDIR)/i18n.com.sun.javatest.regtest.tool.ok
+    $(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.config.ok \
+    $(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.report.ok \
+    $(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.tool.ok
 

--- a/test/ignoreTag/IgnoreTagTest.gmk
+++ b/test/ignoreTag/IgnoreTagTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/IgnoreTagTest.default.ok: \
+$(BUILDTESTDIR)/IgnoreTagTest.default.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -38,9 +38,9 @@ $(BUILDDIR)/IgnoreTagTest.default.ok: \
 	$(GREP) -s 'Test results: passed: 1; error: 4' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/IgnoreTagTest.default.ok
+TESTS.jtreg += $(BUILDTESTDIR)/IgnoreTagTest.default.ok
 
-$(BUILDDIR)/IgnoreTagTest.run.ok: \
+$(BUILDTESTDIR)/IgnoreTagTest.run.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -54,9 +54,9 @@ $(BUILDDIR)/IgnoreTagTest.run.ok: \
 	$(GREP) -s 'Test results: passed: 5' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/IgnoreTagTest.run.ok
+TESTS.jtreg += $(BUILDTESTDIR)/IgnoreTagTest.run.ok
 
-$(BUILDDIR)/IgnoreTagTest.quiet.ok: \
+$(BUILDTESTDIR)/IgnoreTagTest.quiet.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -70,5 +70,5 @@ $(BUILDDIR)/IgnoreTagTest.quiet.ok: \
 	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/IgnoreTagTest.quiet.ok
+TESTS.jtreg += $(BUILDTESTDIR)/IgnoreTagTest.quiet.ok
 

--- a/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
+++ b/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
@@ -25,8 +25,8 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/ignoresymbolfile.othervm.ok \
-$(BUILDDIR)/ignoresymbolfile.agentvm.ok: \
+$(BUILDTESTDIR)/ignoresymbolfile.othervm.ok \
+$(BUILDTESTDIR)/ignoresymbolfile.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -39,7 +39,7 @@ $(BUILDDIR)/ignoresymbolfile.agentvm.ok: \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
-		$(@:$(BUILDDIR)/ignoresymbolfile.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/ignoresymbolfile.%.ok=-%) \
 		$(TESTDIR)/ignoresymbolfile \
 		> $(@:%.ok=%/log 2>&1) \
 	    || (cat $(@:%.ok=%/log) ; exit 1)
@@ -47,6 +47,6 @@ $(BUILDDIR)/ignoresymbolfile.agentvm.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/ignoresymbolfile.othervm.ok \
-	$(BUILDDIR)/ignoresymbolfile.agentvm.ok
+	$(BUILDTESTDIR)/ignoresymbolfile.othervm.ok \
+	$(BUILDTESTDIR)/ignoresymbolfile.agentvm.ok
 endif

--- a/test/interrupt/RunInterrupt.gmk
+++ b/test/interrupt/RunInterrupt.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/InterruptTest.ok: \
+$(BUILDTESTDIR)/InterruptTest.ok: \
 	    $(TESTDIR)/interrupt/InterruptTest.java \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -41,5 +41,5 @@ $(BUILDDIR)/InterruptTest.ok: \
 	echo "test passed at `date`" > $@
 
 # This is a manual GUI test. Do not run it by default.
-# TESTS.jtreg += $(BUILDDIR)/InterruptTest.ok
+# TESTS.jtreg += $(BUILDTESTDIR)/InterruptTest.ok
 

--- a/test/javac/JavacTests.gmk
+++ b/test/javac/JavacTests.gmk
@@ -27,8 +27,8 @@
 #
 # Verify javac etc available on path for @run main in all modes.
 
-$(BUILDDIR)/javac/othervm.ok \
-$(BUILDDIR)/javac/agentvm.ok: \
+$(BUILDTESTDIR)/javac/othervm.ok \
+$(BUILDTESTDIR)/javac/agentvm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	JTREG_SHOWAGENT=true JTREG_SHOWCMD=true \
@@ -36,14 +36,14 @@ $(BUILDDIR)/javac/agentvm.ok: \
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
-		$(@:$(BUILDDIR)/javac/%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/javac/%.ok=-%) \
 		$(TESTDIR)/javac
 	echo "test passed at `date`" > $@
 
 # test requires access to javac internals, so needs @modules tag to run on JDK 9 or later
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/javac/othervm.ok \
-	$(BUILDDIR)/javac/agentvm.ok
+	$(BUILDTESTDIR)/javac/othervm.ok \
+	$(BUILDTESTDIR)/javac/agentvm.ok
 endif
 

--- a/test/javacVMOptions/JavacVMOptions.gmk
+++ b/test/javacVMOptions/JavacVMOptions.gmk
@@ -23,8 +23,8 @@
 # questions.
 #
 
-$(BUILDDIR)/JavacVMOptions.agentvm.ok \
-$(BUILDDIR)/JavacVMOptions.othervm.ok: \
+$(BUILDTESTDIR)/JavacVMOptions.agentvm.ok \
+$(BUILDTESTDIR)/JavacVMOptions.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -32,7 +32,7 @@ $(BUILDDIR)/JavacVMOptions.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/JavacVMOptions.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/JavacVMOptions.%.ok=-%) \
 		$(TESTDIR)/javacVMOptions \
 			> $(@:%.ok=%/jt.log)
 	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.log)  > /dev/null
@@ -41,5 +41,5 @@ $(BUILDDIR)/JavacVMOptions.othervm.ok: \
 
 
 TESTS.jtreg += \
-	$(BUILDDIR)/JavacVMOptions.agentvm.ok \
-	$(BUILDDIR)/JavacVMOptions.othervm.ok
+	$(BUILDTESTDIR)/JavacVMOptions.agentvm.ok \
+	$(BUILDTESTDIR)/JavacVMOptions.othervm.ok

--- a/test/jdk11/JDK11Test.gmk
+++ b/test/jdk11/JDK11Test.gmk
@@ -27,7 +27,7 @@
 
 # Test compilation and execution using JDK 1.1
 # Only othervm supported -- jtreg can't run agentvm on 1.1
-$(BUILDDIR)/JDK11Test.1.ok: \
+$(BUILDTESTDIR)/JDK11Test.1.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -40,7 +40,7 @@ $(BUILDDIR)/JDK11Test.1.ok: \
 	echo "test passed at `date`" > $@
 
 # Test split compilation using JDK 1.1
-$(BUILDDIR)/JDK11Test.2.ok: \
+$(BUILDTESTDIR)/JDK11Test.2.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -56,8 +56,8 @@ $(BUILDDIR)/JDK11Test.2.ok: \
 ifdef JDK1_1HOME
 ifdef JDK6HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/JDK11Test.1.ok \
-	$(BUILDDIR)/JDK11Test.2.ok
+	$(BUILDTESTDIR)/JDK11Test.1.ok \
+	$(BUILDTESTDIR)/JDK11Test.2.ok
 endif
 endif
 

--- a/test/jdkModulesTest/JDKModulesTest.gmk
+++ b/test/jdkModulesTest/JDKModulesTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/JDKModulesTest.ok: \
+$(BUILDTESTDIR)/JDKModulesTest.ok: \
 	    $(TESTDIR)/jdkModulesTest/JDKModulesTest.java \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -44,6 +44,6 @@ $(BUILDDIR)/JDKModulesTest.ok: \
 		JDKModulesTest 
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/JDKModulesTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/JDKModulesTest.ok
 
 

--- a/test/jdkOptsTest/JDKOptsTest.gmk
+++ b/test/jdkOptsTest/JDKOptsTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/JDKOptsTest.ok: \
+$(BUILDTESTDIR)/JDKOptsTest.ok: \
 	    $(TESTDIR)/jdkOptsTest/JDKOptsTest.java \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -40,5 +40,5 @@ $(BUILDDIR)/JDKOptsTest.ok: \
 	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" -Djava.io.tmpdir=$(@:%.ok=%)/tmp JDKOptsTest 
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/JDKOptsTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/JDKOptsTest.ok
 

--- a/test/jdkVersion/JDKVersionTest.gmk
+++ b/test/jdkVersion/JDKVersionTest.gmk
@@ -28,7 +28,7 @@
 
 # test running jtreg using classes in build/classes
 
-$(BUILDDIR)/TestJDKVersion.classes.ok: \
+$(BUILDTESTDIR)/TestJDKVersion.classes.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar 
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKJAVA) -cp $(CLASSDIR):$(JTREG_IMAGEDIR)/lib/javatest.jar com.sun.javatest.regtest.Main \
@@ -43,7 +43,7 @@ $(BUILDDIR)/TestJDKVersion.classes.ok: \
 
 # test running jtreg using classes in jtreg.jar on classpath
 
-$(BUILDDIR)/TestJDKVersion.jar.ok: \
+$(BUILDTESTDIR)/TestJDKVersion.jar.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar 
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKJAVA) -cp $(JTREG_IMAGEJARDIR)/jtreg.jar:$(JTREG_IMAGEDIR)/lib/javatest.jar com.sun.javatest.regtest.Main \
@@ -56,6 +56,6 @@ $(BUILDDIR)/TestJDKVersion.jar.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/TestJDKVersion.classes.ok \
-	$(BUILDDIR)/TestJDKVersion.jar.ok
+	$(BUILDTESTDIR)/TestJDKVersion.classes.ok \
+	$(BUILDTESTDIR)/TestJDKVersion.jar.ok
 

--- a/test/junitTrace/JUnitTrace.gmk
+++ b/test/junitTrace/JUnitTrace.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/JUnitTrace.ok: \
+$(BUILDTESTDIR)/JUnitTrace.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -43,5 +43,5 @@ $(BUILDDIR)/JUnitTrace.ok: \
 	fi
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/JUnitTrace.ok
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitTrace.ok
 

--- a/test/keywords/testKeywords.gmk
+++ b/test/keywords/testKeywords.gmk
@@ -26,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestKeywords.good.ok: \
+$(BUILDTESTDIR)/TestKeywords.good.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -39,7 +39,7 @@ $(BUILDDIR)/TestKeywords.good.ok: \
 	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-$(BUILDDIR)/TestKeywords.badProps.ok: \
+$(BUILDTESTDIR)/TestKeywords.badProps.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -53,7 +53,7 @@ $(BUILDDIR)/TestKeywords.badProps.ok: \
 	$(GREP) -s "Error: .*/test/keywords/badProps/badProps/TEST.properties: bad keyword 'bad%word': invalid character: %" $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-$(BUILDDIR)/TestKeywords.badTest.ok: \
+$(BUILDTESTDIR)/TestKeywords.badTest.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -71,8 +71,8 @@ $(BUILDDIR)/TestKeywords.badTest.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/TestKeywords.good.ok \
-	$(BUILDDIR)/TestKeywords.badProps.ok \
-	$(BUILDDIR)/TestKeywords.badTest.ok
+	$(BUILDTESTDIR)/TestKeywords.good.ok \
+	$(BUILDTESTDIR)/TestKeywords.badProps.ok \
+	$(BUILDTESTDIR)/TestKeywords.badTest.ok
 endif
 

--- a/test/libBuildArgs/LibBuildArgsTest.gmk
+++ b/test/libBuildArgs/LibBuildArgsTest.gmk
@@ -26,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/LibBuildArgsTest.good.ok: \
+$(BUILDTESTDIR)/LibBuildArgsTest.good.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -40,7 +40,7 @@ $(BUILDDIR)/LibBuildArgsTest.good.ok: \
 	    || (cat $(@:%.ok=%/log) ; exit 1)
 	echo $@ passed at `date` > $@
 
-$(BUILDDIR)/LibBuildArgsTest.bad.ok: \
+$(BUILDTESTDIR)/LibBuildArgsTest.bad.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -56,5 +56,5 @@ $(BUILDDIR)/LibBuildArgsTest.bad.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/LibBuildArgsTest.good.ok \
-	$(BUILDDIR)/LibBuildArgsTest.bad.ok
+	$(BUILDTESTDIR)/LibBuildArgsTest.good.ok \
+	$(BUILDTESTDIR)/LibBuildArgsTest.bad.ok

--- a/test/libdirs/LibDirsTest.gmk
+++ b/test/libdirs/LibDirsTest.gmk
@@ -26,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/LibDirsTest.ok: \
+$(BUILDTESTDIR)/LibDirsTest.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -52,4 +52,4 @@ $(BUILDDIR)/LibDirsTest.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/LibDirsTest.ok
+	$(BUILDTESTDIR)/LibDirsTest.ok

--- a/test/match/MatchTest.gmk
+++ b/test/match/MatchTest.gmk
@@ -25,8 +25,8 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/match.othervm.ok \
-$(BUILDDIR)/match.agentvm.ok: \
+$(BUILDTESTDIR)/match.othervm.ok \
+$(BUILDTESTDIR)/match.agentvm.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -38,7 +38,7 @@ $(BUILDDIR)/match.agentvm.ok: \
 		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
-		$(@:$(BUILDDIR)/match.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/match.%.ok=-%) \
 		-match:$(TESTDIR)/match/ProblemList.txt \
 		$(TESTDIR)/match \
 		> $(@:%.ok=%/log 2>&1) \
@@ -46,5 +46,5 @@ $(BUILDDIR)/match.agentvm.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/match.othervm.ok \
-	$(BUILDDIR)/match.agentvm.ok
+	$(BUILDTESTDIR)/match.othervm.ok \
+	$(BUILDTESTDIR)/match.agentvm.ok

--- a/test/maxOutputSize/MaxOutputSize.gmk
+++ b/test/maxOutputSize/MaxOutputSize.gmk
@@ -39,7 +39,7 @@ define check-not-found
     fi 
 endef
 
-$(BUILDDIR)/MaxOutputSize.ok: \
+$(BUILDTESTDIR)/MaxOutputSize.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -58,5 +58,5 @@ $(BUILDDIR)/MaxOutputSize.ok: \
 	echo "test passed at `date`" > $@
 
 # disabled, waiting for JT Harness update
-#TESTS.jtreg += $(BUILDDIR)/MaxOutputSize.ok
+#TESTS.jtreg += $(BUILDTESTDIR)/MaxOutputSize.ok
 

--- a/test/modlibs/ModLibsTest.gmk
+++ b/test/modlibs/ModLibsTest.gmk
@@ -26,8 +26,8 @@
 MODLIBS_TEST_FILES := \
 	$(shell $(FIND) $(TESTDIR)/modlibs -type f )
 
-$(BUILDDIR)/ModLibsTest.othervm.ok \
-$(BUILDDIR)/ModLibsTest.agentvm.ok: \
+$(BUILDTESTDIR)/ModLibsTest.othervm.ok \
+$(BUILDTESTDIR)/ModLibsTest.agentvm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
             $(MODLIBS_TEST_FILES)
@@ -36,7 +36,7 @@ $(BUILDDIR)/ModLibsTest.agentvm.ok: \
 		-J-Djavatest.regtest.allowTrailingBuild=true \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \
-		$(@:$(BUILDDIR)/ModLibsTest.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/ModLibsTest.%.ok=-%) \
 		$(TESTDIR)/modlibs
 	( cd $(@:%.ok=%)/work ; $(FIND) . -name \*.class ) | \
 		$(SORT) > $(@:%.ok=%)/found-classes.txt
@@ -47,7 +47,7 @@ $(BUILDDIR)/ModLibsTest.agentvm.ok: \
 
 ifdef JDK9HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/ModLibsTest.othervm.ok \
-	$(BUILDDIR)/ModLibsTest.agentvm.ok
+	$(BUILDTESTDIR)/ModLibsTest.othervm.ok \
+	$(BUILDTESTDIR)/ModLibsTest.agentvm.ok
 endif
 

--- a/test/moduleOpens/ModuleOpensTest.gmk
+++ b/test/moduleOpens/ModuleOpensTest.gmk
@@ -23,8 +23,8 @@
 # questions.
 #
 
-$(BUILDDIR)/ModuleOpensTest.agentvm.ok \
-$(BUILDDIR)/ModuleOpensTest.othervm.ok: \
+$(BUILDTESTDIR)/ModuleOpensTest.agentvm.ok \
+$(BUILDTESTDIR)/ModuleOpensTest.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -34,7 +34,7 @@ $(BUILDDIR)/ModuleOpensTest.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \
 		-vmoption:-Dsun.reflect.enableStrictMode=true \
-		$(@:$(BUILDDIR)/ModuleOpensTest.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/ModuleOpensTest.%.ok=-%) \
 		$(TESTDIR)/moduleOpens \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -45,8 +45,8 @@ $(BUILDDIR)/ModuleOpensTest.othervm.ok: \
 ifdef JDK9HOME
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ModuleOpensTest.agentvm.ok \
-	$(BUILDDIR)/ModuleOpensTest.othervm.ok
+	$(BUILDTESTDIR)/ModuleOpensTest.agentvm.ok \
+	$(BUILDTESTDIR)/ModuleOpensTest.othervm.ok
 
 endif #JDK9HOME
 

--- a/test/modules/ModulesTest.gmk
+++ b/test/modules/ModulesTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/ModulesTest_NoLimitMods.ok: \
+$(BUILDTESTDIR)/ModulesTest_NoLimitMods.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/classes
@@ -47,21 +47,21 @@ $(BUILDDIR)/ModulesTest_NoLimitMods.ok: \
 	fi
 	echo $@ passed at `date` > $@
 
-$(BUILDDIR)/ModulesTest_LimitMods_java.base.ok \
-$(BUILDDIR)/ModulesTest_LimitMods_java.se.ok: \
+$(BUILDTESTDIR)/ModulesTest_LimitMods_java.base.ok \
+$(BUILDTESTDIR)/ModulesTest_LimitMods_java.se.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/classes
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \
-		-javaoptions:"--limit-modules $(@:$(BUILDDIR)/ModulesTest_LimitMods_%.ok=%)" \
+		-javaoptions:"--limit-modules $(@:$(BUILDTESTDIR)/ModulesTest_LimitMods_%.ok=%)" \
 		$(TESTDIR)/modules \
 			> $(@:%.ok=%/jt.log) 2>&1 
 	$(GREP) '^Test results: passed: 2$$' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-$(BUILDDIR)/ModulesTest_IgnoreAtModules.ok: \
+$(BUILDTESTDIR)/ModulesTest_IgnoreAtModules.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)/classes
@@ -82,16 +82,16 @@ $(BUILDDIR)/ModulesTest_IgnoreAtModules.ok: \
 ifdef JDK9HOME
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ModulesTest_NoLimitMods.ok \
-	$(BUILDDIR)/ModulesTest_LimitMods_java.base.ok \
-	$(BUILDDIR)/ModulesTest_LimitMods_java.se.ok \
+	$(BUILDTESTDIR)/ModulesTest_NoLimitMods.ok \
+	$(BUILDTESTDIR)/ModulesTest_LimitMods_java.base.ok \
+	$(BUILDTESTDIR)/ModulesTest_LimitMods_java.se.ok \
 
 endif #JDK9HOME
 
 ifdef JDK8HOME
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ModulesTest_IgnoreAtModules.ok \
+	$(BUILDTESTDIR)/ModulesTest_IgnoreAtModules.ok \
 
 endif #JDK8HOME
 

--- a/test/multirun/MultiRunTest.gmk
+++ b/test/multirun/MultiRunTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/multirun.ok: \
+$(BUILDTESTDIR)/multirun.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -61,7 +61,7 @@ $(BUILDDIR)/multirun.ok: \
 			> $(@:%.ok=%/jt.a_b1_b2.log) 2>&1
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/multirun.noreport.ok: \
+$(BUILDTESTDIR)/multirun.noreport.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -76,5 +76,5 @@ $(BUILDDIR)/multirun.noreport.ok: \
 			> $(@:%.ok=%/jt.a_b1.log) 2>&1
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/multirun.ok $(BUILDDIR)/multirun.noreport.ok
+TESTS.jtreg += $(BUILDTESTDIR)/multirun.ok $(BUILDTESTDIR)/multirun.noreport.ok
 

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -28,8 +28,8 @@
 
 NATIVEPATH := $(shell cd $(BUILDDIR); pwd)
 
-$(BUILDDIR)/TestNativePath.agentvm.ok \
-$(BUILDDIR)/TestNativePath.othervm.ok: \
+$(BUILDTESTDIR)/TestNativePath.agentvm.ok \
+$(BUILDTESTDIR)/TestNativePath.othervm.ok: \
                 $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -38,24 +38,24 @@ $(BUILDDIR)/TestNativePath.othervm.ok: \
 		-jdk:$(JDKHOME) \
 		-nativepath:$(NATIVEPATH) \
 		-vmoption:-Dcorrect.nativepath=$(NATIVEPATH) \
-		-w:$(BUILDDIR)/nativepath.othervm/work \
-		-r:$(BUILDDIR)/nativepath.othervm/report \
+		-w:$(BUILDTESTDIR)/nativepath.othervm/work \
+		-r:$(BUILDTESTDIR)/nativepath.othervm/report \
 		-verbose:fail \
-		$(@:$(BUILDDIR)/TestNativePath.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/TestNativePath.%.ok=-%) \
 		$(TESTDIR)/nativepath/NativesOK.java
 
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-w:$(BUILDDIR)/nativepath.othervm2/work \
-		-r:$(BUILDDIR)/nativepath.othervm2/report \
+		-w:$(BUILDTESTDIR)/nativepath.othervm2/work \
+		-r:$(BUILDTESTDIR)/nativepath.othervm2/report \
 		-verbose:fail \
-		$(@:$(BUILDDIR)/TestNativePath.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/TestNativePath.%.ok=-%) \
 		$(TESTDIR)/nativepath/NativesEmpty.java
 
 	echo "$@ test passed at `date`" > $@
 
 
-$(BUILDDIR)/TestNativePath.ok: \
+$(BUILDTESTDIR)/TestNativePath.ok: \
                 $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -82,8 +82,8 @@ $(BUILDDIR)/TestNativePath.ok: \
         # should yield an error
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-w:$(BUILDDIR)/nativepath.othervm2/work \
-		-r:$(BUILDDIR)/nativepath.othervm2/report \
+		-w:$(BUILDTESTDIR)/nativepath.othervm2/work \
+		-r:$(BUILDTESTDIR)/nativepath.othervm2/report \
 		-verbose:fail \
 		$(TESTDIR)/nativepath/NativesOK.java \
 		2>&1 | grep -q "Use -nativepath to specify the location of native code"
@@ -91,8 +91,8 @@ $(BUILDDIR)/TestNativePath.ok: \
         # Exclude all tests with native code
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-w:$(BUILDDIR)/nativepath.othervm2/work \
-		-r:$(BUILDDIR)/nativepath.othervm2/report \
+		-w:$(BUILDTESTDIR)/nativepath.othervm2/work \
+		-r:$(BUILDTESTDIR)/nativepath.othervm2/report \
                 -k:!native \
 		-verbose:fail \
 		$(TESTDIR)/nativepath/NativesOK.java \
@@ -103,15 +103,15 @@ $(BUILDDIR)/TestNativePath.ok: \
 		-jdk:$(JDKHOME) \
 		-nativepath:$(NATIVEPATH) \
 		-e:CORRECTNATIVEPATH=$(NATIVEPATH) \
-		-w:$(BUILDDIR)/nativepath.shell/work \
-		-r:$(BUILDDIR)/nativepath.shell/report \
+		-w:$(BUILDTESTDIR)/nativepath.shell/work \
+		-r:$(BUILDTESTDIR)/nativepath.shell/report \
 		-verbose:fail \
 		$(TESTDIR)/nativepath/NativesOKShell.sh
 
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-w:$(BUILDDIR)/nativepath.shell/work \
-		-r:$(BUILDDIR)/nativepath.shell/report \
+		-w:$(BUILDTESTDIR)/nativepath.shell/work \
+		-r:$(BUILDTESTDIR)/nativepath.shell/report \
 		-verbose:fail \
 		$(TESTDIR)/nativepath/NativesEmptyShell.sh
 
@@ -119,12 +119,12 @@ $(BUILDDIR)/TestNativePath.ok: \
 
 
 TESTS.jtreg += \
-    $(BUILDDIR)/TestNativePath.ok \
-    $(BUILDDIR)/TestNativePath.agentvm.ok \
-    $(BUILDDIR)/TestNativePath.othervm.ok
+    $(BUILDTESTDIR)/TestNativePath.ok \
+    $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
+    $(BUILDTESTDIR)/TestNativePath.othervm.ok
 
 testnativepath: \
-    $(BUILDDIR)/TestNativePath.ok \
-    $(BUILDDIR)/TestNativePath.agentvm.ok \
-    $(BUILDDIR)/TestNativePath.othervm.ok
+    $(BUILDTESTDIR)/TestNativePath.ok \
+    $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
+    $(BUILDTESTDIR)/TestNativePath.othervm.ok
 

--- a/test/normalizeStatus/NormalizeStatusTest.gmk
+++ b/test/normalizeStatus/NormalizeStatusTest.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 # 7900029: newline in exception message will corrupt jtreg summary.txt output
-$(BUILDDIR)/NormalizeStatusTest.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/NormalizeStatusTest.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(TESTDIR)/normalizeStatus/Test.java \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -42,5 +42,5 @@ $(BUILDDIR)/NormalizeStatusTest.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		< $(@:%.ok=%)/report/text/summary.txt
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/NormalizeStatusTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/NormalizeStatusTest.ok
 

--- a/test/openfiles/OpenFileTests.gmk
+++ b/test/openfiles/OpenFileTests.gmk
@@ -40,8 +40,8 @@
 # In agentvm and othervm mode, jtreg should successfully run each test
 # by moving to a new scratch directory when it can't clear the previous one.
 
-$(BUILDDIR)/OpenFileTests.agentvm.ok \
-$(BUILDDIR)/OpenFileTests.othervm.ok: \
+$(BUILDTESTDIR)/OpenFileTests.agentvm.ok \
+$(BUILDTESTDIR)/OpenFileTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -49,7 +49,7 @@ $(BUILDDIR)/OpenFileTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/OpenFileTests.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/OpenFileTests.%.ok=-%) \
 		$(TESTDIR)/openfiles \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -61,8 +61,8 @@ $(BUILDDIR)/OpenFileTests.othervm.ok: \
 # In agent mode with -retain, the tests all return error
 # because the selected files cannot be retained
 
-$(BUILDDIR)/OpenFileTests.agentvm.retain.ok \
-$(BUILDDIR)/OpenFileTests.othervm.retain.ok: \
+$(BUILDTESTDIR)/OpenFileTests.agentvm.retain.ok \
+$(BUILDTESTDIR)/OpenFileTests.othervm.retain.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -70,7 +70,7 @@ $(BUILDDIR)/OpenFileTests.othervm.retain.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/OpenFileTests.%.retain.ok=-%) \
+		$(@:$(BUILDTESTDIR)/OpenFileTests.%.retain.ok=-%) \
 		-retain:none \
 		$(TESTDIR)/openfiles \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
@@ -81,8 +81,8 @@ $(BUILDDIR)/OpenFileTests.othervm.retain.ok: \
 
 ifneq ($(OS_NAME), windows) # TEMP
 TESTS.jtreg += \
-	$(BUILDDIR)/OpenFileTests.agentvm.ok \
-	$(BUILDDIR)/OpenFileTests.agentvm.retain.ok \
-	$(BUILDDIR)/OpenFileTests.othervm.ok \
-	$(BUILDDIR)/OpenFileTests.othervm.retain.ok
+	$(BUILDTESTDIR)/OpenFileTests.agentvm.ok \
+	$(BUILDTESTDIR)/OpenFileTests.agentvm.retain.ok \
+	$(BUILDTESTDIR)/OpenFileTests.othervm.ok \
+	$(BUILDTESTDIR)/OpenFileTests.othervm.retain.ok
 endif

--- a/test/optionDecoder/OptionDecoderTest.gmk
+++ b/test/optionDecoder/OptionDecoderTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/OptionDecoderTest.ok: \
+$(BUILDTESTDIR)/OptionDecoderTest.ok: \
 	    $(TESTDIR)/optionDecoder/OptionDecoderTest.java \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -38,5 +38,5 @@ $(BUILDDIR)/OptionDecoderTest.ok: \
 	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" OptionDecoderTest 
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/OptionDecoderTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/OptionDecoderTest.ok
 

--- a/test/osTest/OSTest.gmk
+++ b/test/osTest/OSTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/OSTest.ok: \
+$(BUILDTESTDIR)/OSTest.ok: \
 	    $(TESTDIR)/osTest/OSTest.java \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -39,5 +39,5 @@ $(BUILDDIR)/OSTest.ok: \
 	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" OSTest
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/OSTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/OSTest.ok
 

--- a/test/pkgInfo/PkgInfoTest.gmk
+++ b/test/pkgInfo/PkgInfoTest.gmk
@@ -25,7 +25,7 @@
 
 # Check that package-info is accepted in a build list
 
-$(BUILDDIR)/PkgInfoTest.ok: \
+$(BUILDTESTDIR)/PkgInfoTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -36,5 +36,5 @@ $(BUILDDIR)/PkgInfoTest.ok: \
 			> $(@:%.ok=%/jt.log)
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/PkgInfoTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/PkgInfoTest.ok
 

--- a/test/policy/PolicyTest.gmk
+++ b/test/policy/PolicyTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/PolicyTest.ok: \
+$(BUILDTESTDIR)/PolicyTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -44,5 +44,5 @@ $(BUILDDIR)/PolicyTest.ok: \
 	$(GREP) 'grant.*testng[^ ]*.jar' $(@:%.ok=%)/work/TestNG/simple.policy_new
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/PolicyTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/PolicyTest.ok
 

--- a/test/preview/PreviewTest.gmk
+++ b/test/preview/PreviewTest.gmk
@@ -27,7 +27,7 @@
 
 ifdef JDK14HOME
 
-$(BUILDDIR)/PreviewTest_good.ok: \
+$(BUILDTESTDIR)/PreviewTest_good.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -40,7 +40,7 @@ $(BUILDDIR)/PreviewTest_good.ok: \
 	$(GREP) -s 'Test results: passed: 5' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/PreviewTest_bad.ok: \
+$(BUILDTESTDIR)/PreviewTest_bad.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -54,7 +54,7 @@ $(BUILDDIR)/PreviewTest_bad.ok: \
 	$(GREP) -s 'Test results: failed: 3; error: 1' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/PreviewTest_good.ok
-TESTS.jtreg += $(BUILDDIR)/PreviewTest_bad.ok
+TESTS.jtreg += $(BUILDTESTDIR)/PreviewTest_good.ok
+TESTS.jtreg += $(BUILDTESTDIR)/PreviewTest_bad.ok
 
 endif

--- a/test/problemList/ProblemList.gmk
+++ b/test/problemList/ProblemList.gmk
@@ -36,7 +36,7 @@
 # Create a version of ProblemList.txt to test by editing those values
 # into a template.
 
-$(BUILDDIR)/ProblemList.ok: \
+$(BUILDTESTDIR)/ProblemList.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
@@ -71,5 +71,5 @@ $(BUILDDIR)/ProblemList.ok: \
 	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/2/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/ProblemList.ok
+TESTS.jtreg += $(BUILDTESTDIR)/ProblemList.ok
 

--- a/test/refIgnoreLines/RefIgnoreLines.gmk
+++ b/test/refIgnoreLines/RefIgnoreLines.gmk
@@ -27,7 +27,7 @@
 
 # control 1: no special options
 
-$(BUILDDIR)/RefIgnoreLines_std.ok: \
+$(BUILDTESTDIR)/RefIgnoreLines_std.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -39,16 +39,16 @@ $(BUILDDIR)/RefIgnoreLines_std.ok: \
 	echo "test passed at `date`" > $@
 
 ifdef JDK8HOME
-TESTS.jtreg += $(BUILDDIR)/RefIgnoreLines_std.ok
+TESTS.jtreg += $(BUILDTESTDIR)/RefIgnoreLines_std.ok
 endif
 
-testRefIgnoreLines: $(BUILDDIR)/RefIgnoreLines_std.ok
+testRefIgnoreLines: $(BUILDTESTDIR)/RefIgnoreLines_std.ok
 
 #------------------------------------------------------------
 #
 # control 2: set -Xmx directly
 
-$(BUILDDIR)/RefIgnoreLines_Xmx.ok: \
+$(BUILDTESTDIR)/RefIgnoreLines_Xmx.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -61,25 +61,25 @@ $(BUILDDIR)/RefIgnoreLines_Xmx.ok: \
 	echo "test passed at `date`" > $@
 
 ifdef JDK8HOME
-TESTS.jtreg += $(BUILDDIR)/RefIgnoreLines_Xmx.ok
+TESTS.jtreg += $(BUILDTESTDIR)/RefIgnoreLines_Xmx.ok
 endif
 
-testRefIgnoreLines: $(BUILDDIR)/RefIgnoreLines_Xmx.ok
+testRefIgnoreLines: $(BUILDTESTDIR)/RefIgnoreLines_Xmx.ok
 
 #------------------------------------------------------------
 #
 # test 1: set env var and use -e
 
-$(BUILDDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_1.ok \
-$(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok: \
+$(BUILDTESTDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_1.ok \
+$(BUILDTESTDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
-	$(@:$(BUILDDIR)/RefIgnoreLines_%_1.ok=%)=-Xmx100m \
+	$(@:$(BUILDTESTDIR)/RefIgnoreLines_%_1.ok=%)=-Xmx100m \
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
-		-e:$(@:$(BUILDDIR)/RefIgnoreLines_%_1.ok=%) \
+		-e:$(@:$(BUILDTESTDIR)/RefIgnoreLines_%_1.ok=%) \
 		$(TESTDIR)/refIgnoreLines \
 			> $(@:%.ok=%/jt.log)
 	$(GREP) 'Ignoring line: Picked up' $(@:%.ok=%)/work/Test.jtr
@@ -87,27 +87,27 @@ $(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_1.ok \
-	$(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok
+	$(BUILDTESTDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_1.ok \
+	$(BUILDTESTDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok
 endif
 
 testRefIgnoreLines: \
-	$(BUILDDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_1.ok \
-	$(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok
+	$(BUILDTESTDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_1.ok \
+	$(BUILDTESTDIR)/RefIgnoreLines__JAVA_OPTIONS_1.ok
 
 #------------------------------------------------------------
 #
 # test 2: use -e
 
-$(BUILDDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_2.ok \
-$(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok: \
+$(BUILDTESTDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_2.ok \
+$(BUILDTESTDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
-		-e:$(@:$(BUILDDIR)/RefIgnoreLines_%_2.ok=%)=-Xmx100m \
+		-e:$(@:$(BUILDTESTDIR)/RefIgnoreLines_%_2.ok=%)=-Xmx100m \
 		$(TESTDIR)/refIgnoreLines \
 			> $(@:%.ok=%/jt.log)
 	$(GREP) 'Ignoring line: Picked up' $(@:%.ok=%)/work/Test.jtr
@@ -116,11 +116,11 @@ $(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_2.ok \
-	$(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok
+	$(BUILDTESTDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_2.ok \
+	$(BUILDTESTDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok
 endif
 
 testRefIgnoreLines: \
-	$(BUILDDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_2.ok \
-	$(BUILDDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok
+	$(BUILDTESTDIR)/RefIgnoreLines_JAVA_TOOL_OPTIONS_2.ok \
+	$(BUILDTESTDIR)/RefIgnoreLines__JAVA_OPTIONS_2.ok
 

--- a/test/requires/RequiresTest.gmk
+++ b/test/requires/RequiresTest.gmk
@@ -24,7 +24,7 @@
 #
 
 
-$(BUILDDIR)/RequiresTest.ok: \
+$(BUILDTESTDIR)/RequiresTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -42,4 +42,4 @@ $(BUILDDIR)/RequiresTest.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/RequiresTest.ok
+	$(BUILDTESTDIR)/RequiresTest.ok

--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -23,14 +23,14 @@
 # questions.
 #
 
-$(BUILDDIR)/RerunTest.agentvm.ok \
-$(BUILDDIR)/RerunTest.othervm.ok:  JAVAOPTION =-javaoption:-Dmy.java.option=x
+$(BUILDTESTDIR)/RerunTest.agentvm.ok \
+$(BUILDTESTDIR)/RerunTest.othervm.ok:  JAVAOPTION =-javaoption:-Dmy.java.option=x
 
-$(BUILDDIR)/RerunTest.agentvm.ok \
-$(BUILDDIR)/RerunTest.othervm.ok:  JAVACOPTION=-javacoption:-XDmy.javac.option=x
+$(BUILDTESTDIR)/RerunTest.agentvm.ok \
+$(BUILDTESTDIR)/RerunTest.othervm.ok:  JAVACOPTION=-javacoption:-XDmy.javac.option=x
 
-$(BUILDDIR)/RerunTest.agentvm.ok \
-$(BUILDDIR)/RerunTest.othervm.ok: \
+$(BUILDTESTDIR)/RerunTest.agentvm.ok \
+$(BUILDTESTDIR)/RerunTest.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -44,12 +44,12 @@ $(BUILDDIR)/RerunTest.othervm.ok: \
 		-verbose:summary \
 		-e:MY_ENV_VAR=x -vmoption:-Dmy.vm.option=x $(JAVAOPTION) $(JAVACOPTION) \
                 -ignore:run \
-		$(@:$(BUILDDIR)/RerunTest.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/RerunTest.%.ok=-%) \
 		$(TESTDIR)/rerun  \
 			> $(@:%.ok=%/jt.log) 2>&1
 	$(GREP) -s 'Test results: passed: 10' $(@:%.ok=%/jt.log)  > /dev/null
 	for i in `cd $(TESTDIR)/rerun ; ls */*.sh */*.java` ; do \
-	    echo Checking $(@:$(BUILDDIR)/RerunTest.%.ok=%) $$i ; \
+	    echo Checking $(@:$(BUILDTESTDIR)/RerunTest.%.ok=%) $$i ; \
 	    mkdir -p `dirname $(@:%.ok=%)/out/$$i` ; \
 	    JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
 		-jdk:$(JDK8HOME) \
@@ -61,6 +61,7 @@ $(BUILDDIR)/RerunTest.othervm.ok: \
 		    -e 's|$(JDK8HOME)|%JDKHOME%|g' \
 		    -e "s|`cd $(JDK8HOME); pwd -P`|%JDKHOME%|g" \
 		    -e '/JTREG_JAVA=/d' \
+		    -e 's|$(BUILDTESTDIR)|%BUILDTEST%|g' \
 		    -e 's|$(BUILDDIR)|%BUILD%|g' \
 		    -e 's|$(ABSTOPDIR)|%WS%|g' \
 		    -e 's|junit-[A-Za-z0-9.-]*\.jar|junit.jar|g' \
@@ -69,7 +70,7 @@ $(BUILDDIR)/RerunTest.othervm.ok: \
 		    -e 's|%BUILD%.images.jtreg.lib.hamcrest[A-Za-z0-9.-]*\.jar.||g' \
 		    -e 's|%BUILD%.images.jtreg.lib.jcommander[A-Za-z0-9.-]*\.jar.||g' \
 		> $(@:%.ok=%)/out/$${i%.*}.out ; \
-	    diff -c $(TESTDIR)/rerun/$${i%.*}.$(@:$(BUILDDIR)/RerunTest.%.ok=%).out \
+	    diff -c $(TESTDIR)/rerun/$${i%.*}.$(@:$(BUILDTESTDIR)/RerunTest.%.ok=%).out \
 		$(@:%.ok=%)/out/$${i%.*}.out || exit 1 ; \
 	done
 	echo "test passed at `date`" > $@
@@ -78,8 +79,8 @@ ifdef JDK8HOME
 ifneq ($(OS_NAME), windows)
 ifndef HEADLESS
 TESTS.jtreg += \
-	$(BUILDDIR)/RerunTest.agentvm.ok \
-	$(BUILDDIR)/RerunTest.othervm.ok
+	$(BUILDTESTDIR)/RerunTest.agentvm.ok \
+	$(BUILDTESTDIR)/RerunTest.othervm.ok
 endif
 endif
 endif

--- a/test/rerun/std/AppletTest.agentvm.out
+++ b/test/rerun/std/AppletTest.agentvm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,17 +20,17 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d \
-        -J-Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d:%WS%/test/rerun/std \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d \
+        -J-Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d:%WS%/test/rerun/std \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d \
+        -d %BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/AppletTest.java
 
 ### Section applet
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -38,7 +38,7 @@ MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/java \
-        -classpath %BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+        -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
         -Dtest.vm.opts=-Dmy.vm.option=x \
@@ -53,8 +53,8 @@ TZ=GMT+0.00 \
         -Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d \
-        -Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/AppletTest.d:%WS%/test/rerun/std \
-        -mx128m com.sun.javatest.regtest.agent.AppletWrapper %BUILD%/RerunTest.agentvm/work/std/AppletTest.d/applet.0.jta
+        -Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d \
+        -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d:%WS%/test/rerun/std \
+        -mx128m com.sun.javatest.regtest.agent.AppletWrapper %BUILDTEST%/RerunTest.agentvm/work/std/AppletTest.d/applet.0.jta
 

--- a/test/rerun/std/AppletTest.othervm.out
+++ b/test/rerun/std/AppletTest.othervm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,16 +20,16 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/AppletTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/AppletTest.d \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.othervm/work/classes/std/AppletTest.d \
+        -d %BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.othervm/work/classes/std/AppletTest.d:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/AppletTest.java
 
 ### Section applet
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -37,7 +37,7 @@ MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
     %JDKHOME%/bin/java \
-        -classpath %BUILD%/RerunTest.othervm/work/classes/std/AppletTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+        -classpath %BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
         -Dtest.vm.opts=-Dmy.vm.option=x \
@@ -52,7 +52,7 @@ TZ=GMT+0.00 \
         -Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/AppletTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/AppletTest.d \
-        -mx128m com.sun.javatest.regtest.agent.AppletWrapper %BUILD%/RerunTest.othervm/work/std/AppletTest.d/applet.0.jta
+        -Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d \
+        -mx128m com.sun.javatest.regtest.agent.AppletWrapper %BUILDTEST%/RerunTest.othervm/work/std/AppletTest.d/applet.0.jta
 

--- a/test/rerun/std/BuildTest.agentvm.out
+++ b/test/rerun/std/BuildTest.agentvm.out
@@ -1,9 +1,9 @@
 ### Section clean
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
-rm -f %BUILD%/RerunTest.agentvm/work/classes/std/BuildTest.d/BuildTest.class
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
+rm -f %BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d/BuildTest.class
 
 ### Section compile
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -24,12 +24,12 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/BuildTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/BuildTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/BuildTest.d \
-        -J-Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/BuildTest.d:%WS%/test/rerun/std \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d \
+        -J-Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d:%WS%/test/rerun/std \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.agentvm/work/classes/std/BuildTest.d \
+        -d %BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.agentvm/work/classes/std/BuildTest.d:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/BuildTest.java
 

--- a/test/rerun/std/BuildTest.othervm.out
+++ b/test/rerun/std/BuildTest.othervm.out
@@ -1,9 +1,9 @@
 ### Section clean
-cd %BUILD%/RerunTest.othervm/work/scratch && \
-rm -f %BUILD%/RerunTest.othervm/work/classes/std/BuildTest.d/BuildTest.class
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
+rm -f %BUILDTEST%/RerunTest.othervm/work/classes/std/BuildTest.d/BuildTest.class
 
 ### Section compile
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -24,11 +24,11 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/BuildTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/BuildTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/BuildTest.d \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/BuildTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/BuildTest.d \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.othervm/work/classes/std/BuildTest.d \
+        -d %BUILDTEST%/RerunTest.othervm/work/classes/std/BuildTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.othervm/work/classes/std/BuildTest.d:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/BuildTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/BuildTest.java
 

--- a/test/rerun/std/CleanTest.agentvm.out
+++ b/test/rerun/std/CleanTest.agentvm.out
@@ -1,10 +1,10 @@
 ### Section clean
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
-rm -f %BUILD%/RerunTest.agentvm/work/classes/std/CleanTest.d/CleanTest.class
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
+rm -f %BUILDTEST%/RerunTest.agentvm/work/classes/std/CleanTest.d/CleanTest.class
 
 ### Section clean
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
-for f in %BUILD%/RerunTest.agentvm/work/classes/std/CleanTest.d/p/*; do
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
+for f in %BUILDTEST%/RerunTest.agentvm/work/classes/std/CleanTest.d/p/*; do
   if [ -f $f ]; then rm $f ; fi
 done
 

--- a/test/rerun/std/CleanTest.othervm.out
+++ b/test/rerun/std/CleanTest.othervm.out
@@ -1,10 +1,10 @@
 ### Section clean
-cd %BUILD%/RerunTest.othervm/work/scratch && \
-rm -f %BUILD%/RerunTest.othervm/work/classes/std/CleanTest.d/CleanTest.class
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
+rm -f %BUILDTEST%/RerunTest.othervm/work/classes/std/CleanTest.d/CleanTest.class
 
 ### Section clean
-cd %BUILD%/RerunTest.othervm/work/scratch && \
-for f in %BUILD%/RerunTest.othervm/work/classes/std/CleanTest.d/p/*; do
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
+for f in %BUILDTEST%/RerunTest.othervm/work/classes/std/CleanTest.d/p/*; do
   if [ -f $f ]; then rm $f ; fi
 done
 

--- a/test/rerun/std/CompileTest.agentvm.out
+++ b/test/rerun/std/CompileTest.agentvm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,11 +20,11 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/CompileTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/CompileTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/CompileTest.d \
-        -J-Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/CompileTest.d:%WS%/test/rerun/std \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/CompileTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/CompileTest.d \
+        -J-Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/CompileTest.d:%WS%/test/rerun/std \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.agentvm/work/classes/std/CompileTest.d \
+        -d %BUILDTEST%/RerunTest.agentvm/work/classes/std/CompileTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.agentvm/work/classes/std/CompileTest.d:%JDKHOME%/lib/tools.jar %WS%/test/rerun/std/CompileTest.java
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/CompileTest.d:%JDKHOME%/lib/tools.jar %WS%/test/rerun/std/CompileTest.java
 

--- a/test/rerun/std/CompileTest.othervm.out
+++ b/test/rerun/std/CompileTest.othervm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,10 +20,10 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/CompileTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/CompileTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/CompileTest.d \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/CompileTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/CompileTest.d \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.othervm/work/classes/std/CompileTest.d \
+        -d %BUILDTEST%/RerunTest.othervm/work/classes/std/CompileTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.othervm/work/classes/std/CompileTest.d:%JDKHOME%/lib/tools.jar %WS%/test/rerun/std/CompileTest.java
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/CompileTest.d:%JDKHOME%/lib/tools.jar %WS%/test/rerun/std/CompileTest.java
 

--- a/test/rerun/std/IgnoreTest.agentvm.out
+++ b/test/rerun/std/IgnoreTest.agentvm.out
@@ -1,4 +1,4 @@
 ### Section ignore
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 # @ignore:  (suppressed)
 

--- a/test/rerun/std/IgnoreTest.othervm.out
+++ b/test/rerun/std/IgnoreTest.othervm.out
@@ -1,4 +1,4 @@
 ### Section ignore
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 # @ignore:  (suppressed)
 

--- a/test/rerun/std/JUnitTest.agentvm.out
+++ b/test/rerun/std/JUnitTest.agentvm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,17 +20,17 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
-        -J-Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
+        -J-Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
+        -d %BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/JUnitTest.java
 
 ### Section junit
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -50,9 +50,9 @@ TZ=GMT+0.00 \
         -Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
-        -Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std \
-        -classpath %BUILD%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+        -Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d \
+        -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std \
+        -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         com.sun.javatest.regtest.agent.JUnitRunner std/JUnitTest.java JUnitTest
 

--- a/test/rerun/std/JUnitTest.othervm.out
+++ b/test/rerun/std/JUnitTest.othervm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,23 +20,23 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d \
+        -d %BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/JUnitTest.java
 
 ### Section junit
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
-CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
     %JDKHOME%/bin/java \
         -Dtest.vm.opts=-Dmy.vm.option=x \
         -Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
@@ -50,9 +50,9 @@ CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d:%WS%/test/rerun
         -Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/JUnitTest.d \
+        -Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d \
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
-        com.sun.javatest.regtest.agent.MainWrapper %BUILD%/RerunTest.othervm/work/std/JUnitTest.d/junit.0.jta std/JUnitTest.java JUnitTest
+        com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/std/JUnitTest.d/junit.0.jta std/JUnitTest.java JUnitTest
 

--- a/test/rerun/std/MainTest.agentvm.out
+++ b/test/rerun/std/MainTest.agentvm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,17 +20,17 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d \
-        -J-Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d \
+        -J-Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d \
+        -d %BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/MainTest.java
 
 ### Section main
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -50,9 +50,9 @@ TZ=GMT+0.00 \
         -Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d \
-        -Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std \
-        -classpath %BUILD%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+        -Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d \
+        -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std \
+        -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         MainTest
 

--- a/test/rerun/std/MainTest.othervm.out
+++ b/test/rerun/std/MainTest.othervm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,23 +20,23 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/MainTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/MainTest.d \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.othervm/work/classes/std/MainTest.d \
+        -d %BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.othervm/work/classes/std/MainTest.d:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/MainTest.java
 
 ### Section main
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
-CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/std/MainTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
     %JDKHOME%/bin/java \
         -Dtest.vm.opts=-Dmy.vm.option=x \
         -Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
@@ -50,9 +50,9 @@ CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/std/MainTest.d:%WS%/test/rerun/
         -Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/MainTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/MainTest.d \
+        -Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d \
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
-        com.sun.javatest.regtest.agent.MainWrapper %BUILD%/RerunTest.othervm/work/std/MainTest.d/main.0.jta
+        com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/std/MainTest.d/main.0.jta
 

--- a/test/rerun/std/ShellTest.agentvm.out
+++ b/test/rerun/std/ShellTest.agentvm.out
@@ -1,5 +1,5 @@
 ### Section shell
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -9,8 +9,8 @@ TZ=GMT+0.00 \
 TESTFILE=%WS%/test/rerun/std/ShellTest.sh \
 TESTSRC=%WS%/test/rerun/std \
 TESTSRCPATH=%WS%/test/rerun/std \
-TESTCLASSES=%BUILD%/RerunTest.agentvm/work/classes/std/ShellTest.d \
-TESTCLASSPATH=%BUILD%/RerunTest.agentvm/work/classes/std/ShellTest.d \
+TESTCLASSES=%BUILDTEST%/RerunTest.agentvm/work/classes/std/ShellTest.d \
+TESTCLASSPATH=%BUILDTEST%/RerunTest.agentvm/work/classes/std/ShellTest.d \
 COMPILEJAVA=%JDKHOME% \
 TESTJAVA=%JDKHOME% \
 TESTVMOPTS=-Dmy.vm.option=x \

--- a/test/rerun/std/ShellTest.othervm.out
+++ b/test/rerun/std/ShellTest.othervm.out
@@ -1,5 +1,5 @@
 ### Section shell
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -9,8 +9,8 @@ TZ=GMT+0.00 \
 TESTFILE=%WS%/test/rerun/std/ShellTest.sh \
 TESTSRC=%WS%/test/rerun/std \
 TESTSRCPATH=%WS%/test/rerun/std \
-TESTCLASSES=%BUILD%/RerunTest.othervm/work/classes/std/ShellTest.d \
-TESTCLASSPATH=%BUILD%/RerunTest.othervm/work/classes/std/ShellTest.d \
+TESTCLASSES=%BUILDTEST%/RerunTest.othervm/work/classes/std/ShellTest.d \
+TESTCLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/ShellTest.d \
 COMPILEJAVA=%JDKHOME% \
 TESTJAVA=%JDKHOME% \
 TESTVMOPTS=-Dmy.vm.option=x \

--- a/test/rerun/std/TestNGTest.agentvm.out
+++ b/test/rerun/std/TestNGTest.agentvm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,17 +20,17 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
-        -J-Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
+        -J-Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
+        -d %BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/TestNGTest.java
 
 ### Section testng
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -50,9 +50,9 @@ TZ=GMT+0.00 \
         -Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
-        -Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std \
-        -classpath %BUILD%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+        -Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d \
+        -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std \
+        -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         com.sun.javatest.regtest.agent.TestNGRunner std/TestNGTest.java false TestNGTest
 

--- a/test/rerun/std/TestNGTest.othervm.out
+++ b/test/rerun/std/TestNGTest.othervm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,23 +20,23 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
-        -J-Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d \
-        -J-Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d \
+        -d %BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d \
         -sourcepath %WS%/test/rerun/std \
-        -classpath %WS%/test/rerun/std:%BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/TestNGTest.java
 
 ### Section testng
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
-CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
     %JDKHOME%/bin/java \
         -Dtest.vm.opts=-Dmy.vm.option=x \
         -Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
@@ -50,9 +50,9 @@ CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d:%WS%/test/reru
         -Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
-        -Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d \
-        -Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/std/TestNGTest.d \
+        -Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d \
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
-        com.sun.javatest.regtest.agent.MainWrapper %BUILD%/RerunTest.othervm/work/std/TestNGTest.d/testng.0.jta std/TestNGTest.java false TestNGTest
+        com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/std/TestNGTest.d/testng.0.jta std/TestNGTest.java false TestNGTest
 

--- a/test/rerun/testng/TestNGTest.agentvm.out
+++ b/test/rerun/testng/TestNGTest.agentvm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,18 +20,18 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/testng \
         -J-Dtest.src.path=%WS%/test/rerun/testng \
-        -J-Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/testng \
-        -J-Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/testng \
-        -J-Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng \
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/testng \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/testng \
+        -J-Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng \
         -XDmy.javac.option=x \
-        -d %BUILD%/RerunTest.agentvm/work/classes/testng \
+        -d %BUILDTEST%/RerunTest.agentvm/work/classes/testng \
         -sourcepath %WS%/test/rerun/testng \
-        -classpath %WS%/test/rerun/testng:%BUILD%/RerunTest.agentvm/work/classes/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
+        -classpath %WS%/test/rerun/testng:%BUILDTEST%/RerunTest.agentvm/work/classes/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true \
         -implicit:none %WS%/test/rerun/testng/TestNGTest.java
 
 ### Section testng
-cd %BUILD%/RerunTest.agentvm/work/scratch && \
+cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -51,9 +51,9 @@ TZ=GMT+0.00 \
         -Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/testng \
         -Dtest.src.path=%WS%/test/rerun/testng \
-        -Dtest.classes=%BUILD%/RerunTest.agentvm/work/classes/testng \
-        -Dtest.class.path=%BUILD%/RerunTest.agentvm/work/classes/testng \
-        -Dtest.class.path.prefix=%BUILD%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng \
-        -classpath %BUILD%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+        -Dtest.classes=%BUILDTEST%/RerunTest.agentvm/work/classes/testng \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/testng \
+        -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng \
+        -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         com.sun.javatest.regtest.agent.TestNGRunner testng/TestNGTest.java false TestNGTest
 

--- a/test/rerun/testng/TestNGTest.othervm.out
+++ b/test/rerun/testng/TestNGTest.othervm.out
@@ -1,5 +1,5 @@
 ### Section compile
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
@@ -20,19 +20,19 @@ TZ=GMT+0.00 \
         -J-Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/testng \
         -J-Dtest.src.path=%WS%/test/rerun/testng \
-        -J-Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/testng \
-        -J-Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/testng \
-        @%BUILD%/RerunTest.othervm/work/testng/TestNGTest.d/compile.0.jta
+        -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/testng \
+        -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/testng \
+        @%BUILDTEST%/RerunTest.othervm/work/testng/TestNGTest.d/compile.0.jta
 
 ### Section testng
-cd %BUILD%/RerunTest.othervm/work/scratch && \
+cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
 TZ=GMT+0.00 \
-CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/testng:%WS%/test/rerun/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
+CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/testng:%WS%/test/rerun/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
     %JDKHOME%/bin/java \
         -Dtest.vm.opts=-Dmy.vm.option=x \
         -Dtest.tool.vm.opts=-J-Dmy.vm.option=x \
@@ -46,9 +46,9 @@ CLASSPATH=%BUILD%/RerunTest.othervm/work/classes/testng:%WS%/test/rerun/testng:%
         -Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/testng \
         -Dtest.src.path=%WS%/test/rerun/testng \
-        -Dtest.classes=%BUILD%/RerunTest.othervm/work/classes/testng \
-        -Dtest.class.path=%BUILD%/RerunTest.othervm/work/classes/testng \
+        -Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/testng \
+        -Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/testng \
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
-        com.sun.javatest.regtest.agent.MainWrapper %BUILD%/RerunTest.othervm/work/testng/TestNGTest.d/testng.1.jta testng/TestNGTest.java false TestNGTest
+        com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/testng/TestNGTest.d/testng.1.jta testng/TestNGTest.java false TestNGTest
 

--- a/test/rerun2/RerunTest2.gmk
+++ b/test/rerun2/RerunTest2.gmk
@@ -25,7 +25,7 @@
 
 # Tests use pre-module features, such as bootclasspath
 
-$(BUILDDIR)/RerunTest2.ok: \
+$(BUILDTESTDIR)/RerunTest2.ok: \
 	    $(TESTDIR)/rerun2/RerunTest2.java \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/lib/junit.jar \
@@ -42,13 +42,13 @@ $(BUILDDIR)/RerunTest2.ok: \
 		-classpath classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		RerunTest2 \
 		$(JDK8HOME) \
-		../$(TESTDIR)/rerun2/test
+		../../$(TESTDIR)/rerun2/test
 	echo "test passed at `date`" > $@
 
 ifdef JDK8HOME
 ifneq ($(OS_NAME), windows)
 TESTS.jtreg += \
-	$(BUILDDIR)/RerunTest2.ok
+	$(BUILDTESTDIR)/RerunTest2.ok
 endif
 endif
 

--- a/test/retain/TestRetainTest.gmk
+++ b/test/retain/TestRetainTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestRetainTest.ok:  \
+$(BUILDTESTDIR)/TestRetainTest.ok:  \
 		$(TESTDIR)/retain/RetainTest.java \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar
@@ -42,5 +42,5 @@ $(BUILDDIR)/TestRetainTest.ok:  \
 		> $(@:%.ok=%.log 2>&1) || (cat $(@:%.ok=%.log) ; exit 1)
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/TestRetainTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/TestRetainTest.ok
 

--- a/test/sanityTest/SanityTest.gmk
+++ b/test/sanityTest/SanityTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/TestSanityTest.ok:
+$(BUILDTESTDIR)/TestSanityTest.ok:
 	$(RM) $(@:%.ok=%)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(FIND) $(TOPDIR)/make $(TOPDIR)/test -name \*.gmk | \
@@ -40,4 +40,4 @@ $(BUILDDIR)/TestSanityTest.ok:
 
 # Test disabled following cleanup to `make sanity` in $(TOPDIR)/make/Makefile
 # See CODETOOLS-7903111
-# TESTS.jtreg += $(BUILDDIR)/TestSanityTest.ok
+# TESTS.jtreg += $(BUILDTESTDIR)/TestSanityTest.ok

--- a/test/secprov/SecurityProviderTest.gmk
+++ b/test/secprov/SecurityProviderTest.gmk
@@ -23,8 +23,8 @@
 # questions.
 #
 
-$(BUILDDIR)/SecProvTests.agentvm.ok \
-$(BUILDDIR)/SecProvTests.othervm.ok: \
+$(BUILDTESTDIR)/SecProvTests.agentvm.ok \
+$(BUILDTESTDIR)/SecProvTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(RM) $(@:%.ok=%) ; fi
@@ -32,11 +32,11 @@ $(BUILDDIR)/SecProvTests.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/SecProvTests.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/SecProvTests.%.ok=-%) \
 		$(TESTDIR)/secprov \
 			> $(@:%.ok=%/jt.log) 2>&1
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/SecProvTests.agentvm.ok \
-	$(BUILDDIR)/SecProvTests.othervm.ok
+	$(BUILDTESTDIR)/SecProvTests.agentvm.ok \
+	$(BUILDTESTDIR)/SecProvTests.othervm.ok

--- a/test/shell/testShell.gmk
+++ b/test/shell/testShell.gmk
@@ -26,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestShell.ok: \
+$(BUILDTESTDIR)/TestShell.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -42,6 +42,6 @@ $(BUILDDIR)/TestShell.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/TestShell.ok
+	$(BUILDTESTDIR)/TestShell.ok
 endif
 

--- a/test/skip/SkippedExceptionTest.gmk
+++ b/test/skip/SkippedExceptionTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/SkippedExceptionTest.agentvm.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/SkippedExceptionTest.agentvm.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -46,11 +46,11 @@ $(BUILDDIR)/SkippedExceptionTest.agentvm.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar 
 		< $(@:%.ok=%)/report/text/summary.txt > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/SkippedExceptionTest.agentvm.ok
+TESTS.jtreg += $(BUILDTESTDIR)/SkippedExceptionTest.agentvm.ok
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/SkippedExceptionTest.othervm.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/SkippedExceptionTest.othervm.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -71,5 +71,5 @@ $(BUILDDIR)/SkippedExceptionTest.othervm.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar 
 		< $(@:%.ok=%)/report/text/summary.txt > /dev/null
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/SkippedExceptionTest.othervm.ok
+TESTS.jtreg += $(BUILDTESTDIR)/SkippedExceptionTest.othervm.ok
 

--- a/test/smartActionArgs/SmartActionArgs.gmk
+++ b/test/smartActionArgs/SmartActionArgs.gmk
@@ -23,8 +23,8 @@
 # questions.
 #
 
-$(BUILDDIR)/SmartActionArgs.agentvm.ok \
-$(BUILDDIR)/SmartActionArgs.othervm.ok: \
+$(BUILDTESTDIR)/SmartActionArgs.agentvm.ok \
+$(BUILDTESTDIR)/SmartActionArgs.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -32,7 +32,7 @@ $(BUILDDIR)/SmartActionArgs.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/SmartActionArgs.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/SmartActionArgs.%.ok=-%) \
 		$(TESTDIR)/smartActionArgs \
 			> $(@:%.ok=%/jt.log)
 	$(GREP) -s 'Test results: passed: 6' $(@:%.ok=%/jt.log)  > /dev/null
@@ -41,5 +41,5 @@ $(BUILDDIR)/SmartActionArgs.othervm.ok: \
 
 
 TESTS.jtreg += \
-	$(BUILDDIR)/SmartActionArgs.agentvm.ok \
-	$(BUILDDIR)/SmartActionArgs.othervm.ok
+	$(BUILDTESTDIR)/SmartActionArgs.agentvm.ok \
+	$(BUILDTESTDIR)/SmartActionArgs.othervm.ok

--- a/test/statsTests/StatsTests.gmk
+++ b/test/statsTests/StatsTests.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/StatsTest.ok: \
+$(BUILDTESTDIR)/StatsTest.ok: \
 	    $(TESTDIR)/statsTests/StatsTest.java \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
@@ -39,10 +39,10 @@ $(BUILDDIR)/StatsTest.ok: \
 	echo "test passed at `date`" > $@
 
 ifneq ($(OS_NAME), windows)
-TESTS.jtreg += $(BUILDDIR)/StatsTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/StatsTest.ok
 endif
 
-$(BUILDDIR)/StatsTxt.1.ok: \
+$(BUILDTESTDIR)/StatsTxt.1.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -62,9 +62,9 @@ $(BUILDDIR)/StatsTxt.1.ok: \
 		$(@:%.ok=%/report/text/stats.txt)  > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/StatsTxt.1.ok
+TESTS.jtreg += $(BUILDTESTDIR)/StatsTxt.1.ok
 
-$(BUILDDIR)/StatsTxt.2.ok: \
+$(BUILDTESTDIR)/StatsTxt.2.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -86,5 +86,5 @@ $(BUILDDIR)/StatsTxt.2.ok: \
 		$(@:%.ok=%/report/text/stats.txt)  > /dev/null
 	echo "test passed at `date`" > $@
 		    			
-TESTS.jtreg += $(BUILDDIR)/StatsTxt.2.ok
+TESTS.jtreg += $(BUILDTESTDIR)/StatsTxt.2.ok
 

--- a/test/statusFilter/StatusFilterTest.gmk
+++ b/test/statusFilter/StatusFilterTest.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 
-$(BUILDDIR)/StatusFilter.ok: \
+$(BUILDTESTDIR)/StatusFilter.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -144,7 +144,7 @@ $(BUILDDIR)/StatusFilter.ok: \
 
 
 TESTS.jtreg += \
-    $(BUILDDIR)/StatusFilter.ok
+    $(BUILDTESTDIR)/StatusFilter.ok
 
 #----------------------------------------------------------------------
 

--- a/test/streams/StreamsTest.gmk
+++ b/test/streams/StreamsTest.gmk
@@ -23,8 +23,8 @@
 # questions.
 #
 
-$(BUILDDIR)/StreamsTest.agentvm.ok \
-$(BUILDDIR)/StreamsTest.othervm.ok: \
+$(BUILDTESTDIR)/StreamsTest.agentvm.ok \
+$(BUILDTESTDIR)/StreamsTest.othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	if [ -d $(@:%.ok=%) ]; then $(CHMOD) -R +w $(@:%.ok=%) && $(RM) $(@:%.ok=%) ; fi
@@ -32,7 +32,7 @@ $(BUILDDIR)/StreamsTest.othervm.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(@:$(BUILDDIR)/StreamsTest.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/StreamsTest.%.ok=-%) \
 		$(TESTDIR)/streams \
 			> $(@:%.ok=%/jt.log)
 	#
@@ -50,5 +50,5 @@ $(BUILDDIR)/StreamsTest.othervm.ok: \
 
 
 TESTS.jtreg += \
-	$(BUILDDIR)/StreamsTest.agentvm.ok \
-	$(BUILDDIR)/StreamsTest.othervm.ok
+	$(BUILDTESTDIR)/StreamsTest.agentvm.ok \
+	$(BUILDTESTDIR)/StreamsTest.othervm.ok

--- a/test/sysprops/SysPropsTest.gmk
+++ b/test/sysprops/SysPropsTest.gmk
@@ -25,8 +25,8 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/SysPropsTest_agentvm.ok \
-$(BUILDDIR)/SysPropsTest_othervm.ok: \
+$(BUILDTESTDIR)/SysPropsTest_agentvm.ok \
+$(BUILDTESTDIR)/SysPropsTest_othervm.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
@@ -38,5 +38,5 @@ $(BUILDDIR)/SysPropsTest_othervm.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/SysPropsTest_agentvm.ok \
-	$(BUILDDIR)/SysPropsTest_othervm.ok
+	$(BUILDTESTDIR)/SysPropsTest_agentvm.ok \
+	$(BUILDTESTDIR)/SysPropsTest_othervm.ok

--- a/test/testJavacExitCodes/JavacExitCodeTests.gmk
+++ b/test/testJavacExitCodes/JavacExitCodeTests.gmk
@@ -26,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/javacExitCodes.jdk5.othervm.ok: \
+$(BUILDTESTDIR)/javacExitCodes.jdk5.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -41,7 +41,7 @@ $(BUILDDIR)/javacExitCodes.jdk5.othervm.ok: \
 	$(GREP) -s 'Test results: passed: 4; failed: 4' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/javacExitCodes.jdk6.othervm.ok: \
+$(BUILDTESTDIR)/javacExitCodes.jdk6.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -57,10 +57,10 @@ $(BUILDDIR)/javacExitCodes.jdk6.othervm.ok: \
 	echo "test passed at `date`" > $@
 
 ifdef JDK5HOME
-TESTS.jtreg += $(BUILDDIR)/javacExitCodes.jdk5.othervm.ok 
+TESTS.jtreg += $(BUILDTESTDIR)/javacExitCodes.jdk5.othervm.ok
 endif
 
 ifdef JDK6HOME
-TESTS.jtreg += $(BUILDDIR)/javacExitCodes.jdk6.othervm.ok
+TESTS.jtreg += $(BUILDTESTDIR)/javacExitCodes.jdk6.othervm.ok
 endif
 

--- a/test/testRequiredVersion.gmk
+++ b/test/testRequiredVersion.gmk
@@ -26,39 +26,39 @@
 #----------------------------------------------------------------------
 
 
-$(BUILDDIR)/TestRequiredVersion.ok: \
+$(BUILDTESTDIR)/TestRequiredVersion.ok: \
                 $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 
   # test that a previous version is accepted
-	mkdir -p $(BUILDDIR)/requiredversion.previous/suite
-	echo "requiredVersion = 1.0 b01" > $(BUILDDIR)/requiredversion.previous/suite/TEST.ROOT
+	mkdir -p $(BUILDTESTDIR)/requiredversion.previous/suite
+	echo "requiredVersion = 1.0 b01" > $(BUILDTESTDIR)/requiredversion.previous/suite/TEST.ROOT
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-w:$(BUILDDIR)/requiredversion.previous/work \
-		-r:$(BUILDDIR)/requiredversion.previous/report \
+		-w:$(BUILDTESTDIR)/requiredversion.previous/work \
+		-r:$(BUILDTESTDIR)/requiredversion.previous/report \
 		-verbose:fail \
-		$(BUILDDIR)/requiredversion.previous/suite/ \
-		2>&1 | tee $(BUILDDIR)/requiredversion.previous/log.txt
-	grep -q "no tests selected" $(BUILDDIR)/requiredversion.previous/log.txt
+		$(BUILDTESTDIR)/requiredversion.previous/suite/ \
+		2>&1 | tee $(BUILDTESTDIR)/requiredversion.previous/log.txt
+	grep -q "no tests selected" $(BUILDTESTDIR)/requiredversion.previous/log.txt
 
   # test that a future version is not accepted
-	mkdir -p $(BUILDDIR)/requiredversion.future/suite
-	echo "requiredVersion = 99.9 b01" > $(BUILDDIR)/requiredversion.future/suite/TEST.ROOT
+	mkdir -p $(BUILDTESTDIR)/requiredversion.future/suite
+	echo "requiredVersion = 99.9 b01" > $(BUILDTESTDIR)/requiredversion.future/suite/TEST.ROOT
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-w:$(BUILDDIR)/requiredversion.future/work \
-		-r:$(BUILDDIR)/requiredversion.future/report \
+		-w:$(BUILDTESTDIR)/requiredversion.future/work \
+		-r:$(BUILDTESTDIR)/requiredversion.future/report \
 		-verbose:fail \
-		$(BUILDDIR)/requiredversion.future/suite/ \
-		2>&1 | tee $(BUILDDIR)/requiredversion.future/log.txt
-	grep -q "requires jtreg version 99.9 b01 or higher" $(BUILDDIR)/requiredversion.future/log.txt 
+		$(BUILDTESTDIR)/requiredversion.future/suite/ \
+		2>&1 | tee $(BUILDTESTDIR)/requiredversion.future/log.txt
+	grep -q "requires jtreg version 99.9 b01 or higher" $(BUILDTESTDIR)/requiredversion.future/log.txt
 
 	echo "$@ test passed at `date`" > $@
 
 TESTS.jtreg += \
-    $(BUILDDIR)/TestRequiredVersion.ok
+    $(BUILDTESTDIR)/TestRequiredVersion.ok
     
 testrequiredversion: \
-    $(BUILDDIR)/TestRequiredVersion.ok
+    $(BUILDTESTDIR)/TestRequiredVersion.ok

--- a/test/testng-junit/TestNGJUnitTest.gmk
+++ b/test/testng-junit/TestNGJUnitTest.gmk
@@ -26,8 +26,8 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestNGJUnitTest.agentvm.ok \
-$(BUILDDIR)/TestNGJUnitTest.othervm.ok: \
+$(BUILDTESTDIR)/TestNGJUnitTest.agentvm.ok \
+$(BUILDTESTDIR)/TestNGJUnitTest.othervm.ok: \
 		$(ALL_JTREG_JARS) \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
@@ -35,7 +35,7 @@ $(BUILDDIR)/TestNGJUnitTest.othervm.ok: \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
-		$(@:$(BUILDDIR)/TestNGJUnitTest.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/TestNGJUnitTest.%.ok=-%) \
 		$(TESTDIR)/testng-junit \
 		> $(@:%.ok=%/jt.log) 2>&1
 	$(GREP) -s 'Test results: passed: 2' $(@:%.ok=%/jt.log)  > /dev/null
@@ -45,7 +45,7 @@ $(BUILDDIR)/TestNGJUnitTest.othervm.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/TestNGJUnitTest.agentvm.ok \
-	$(BUILDDIR)/TestNGJUnitTest.othervm.ok
+	$(BUILDTESTDIR)/TestNGJUnitTest.agentvm.ok \
+	$(BUILDTESTDIR)/TestNGJUnitTest.othervm.ok
 endif
 

--- a/test/testng/TestNGLibTest.gmk
+++ b/test/testng/TestNGLibTest.gmk
@@ -26,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestNGLibTest.ok: \
+$(BUILDTESTDIR)/TestNGLibTest.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -41,5 +41,5 @@ $(BUILDDIR)/TestNGLibTest.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/TestNGLibTest.ok
+	$(BUILDTESTDIR)/TestNGLibTest.ok
 

--- a/test/testngLibs/TestNGLibsTest.gmk
+++ b/test/testngLibs/TestNGLibsTest.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestNGLibsTest.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/TestNGLibsTest.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%)
@@ -37,5 +37,5 @@ $(BUILDDIR)/TestNGLibsTest.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngLibs/tests
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDDIR)/TestNGLibsTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/TestNGLibsTest.ok
 

--- a/test/testprops/TestPropsTest.gmk
+++ b/test/testprops/TestPropsTest.gmk
@@ -26,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestPropsTest.ok: \
+$(BUILDTESTDIR)/TestPropsTest.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -41,5 +41,5 @@ $(BUILDDIR)/TestPropsTest.ok: \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += \
-	$(BUILDDIR)/TestPropsTest.ok
+	$(BUILDTESTDIR)/TestPropsTest.ok
 

--- a/test/threadCleanup/ThreadCleanupTest.gmk
+++ b/test/threadCleanup/ThreadCleanupTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/threadCleanupTest.ok: \
+$(BUILDTESTDIR)/threadCleanupTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -41,4 +41,4 @@ $(BUILDDIR)/threadCleanupTest.ok: \
 	$(GREP) -s 'Problem cleaning up the following threads:' $(@:%.ok=%)/work/Test_id1.jtr
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/threadCleanupTest.ok 
+TESTS.jtreg += $(BUILDTESTDIR)/threadCleanupTest.ok

--- a/test/timelimit/TimelimitTests.gmk
+++ b/test/timelimit/TimelimitTests.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/timelimit.none.ok: \
+$(BUILDTESTDIR)/timelimit.none.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -38,9 +38,9 @@ $(BUILDDIR)/timelimit.none.ok: \
 	$(GREP) -s 'Test results: passed: 3' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/timelimit.none.ok
+TESTS.jtreg += $(BUILDTESTDIR)/timelimit.none.ok
 
-$(BUILDDIR)/timelimit.150.ok: \
+$(BUILDTESTDIR)/timelimit.150.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -54,9 +54,9 @@ $(BUILDDIR)/timelimit.150.ok: \
 	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/timelimit.150.ok
+TESTS.jtreg += $(BUILDTESTDIR)/timelimit.150.ok
 
-$(BUILDDIR)/timelimit.300.ok: \
+$(BUILDTESTDIR)/timelimit.300.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -70,9 +70,9 @@ $(BUILDDIR)/timelimit.300.ok: \
 	$(GREP) -s 'Test results: passed: 2' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/timelimit.300.ok
+TESTS.jtreg += $(BUILDTESTDIR)/timelimit.300.ok
 
-$(BUILDDIR)/timelimit.500.ok: \
+$(BUILDTESTDIR)/timelimit.500.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -86,9 +86,9 @@ $(BUILDDIR)/timelimit.500.ok: \
 	$(GREP) -s 'Test results: passed: 3' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/timelimit.500.ok
+TESTS.jtreg += $(BUILDTESTDIR)/timelimit.500.ok
 
-$(BUILDDIR)/timelimit.bad.ok: \
+$(BUILDTESTDIR)/timelimit.bad.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -103,5 +103,5 @@ $(BUILDDIR)/timelimit.bad.ok: \
 	$(GREP) -s 'Error: Bad value for -timeLimit' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDDIR)/timelimit.bad.ok
+TESTS.jtreg += $(BUILDTESTDIR)/timelimit.bad.ok
 

--- a/test/timeoutHandler/TimeoutHandlerTimeoutTest.gmk
+++ b/test/timeoutHandler/TimeoutHandlerTimeoutTest.gmk
@@ -26,20 +26,20 @@
 # use target-specific variables to specify jtreg option 
 # and the resulting expected timeout
 
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.default.ok: OPTION=
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.default.ok: EXPECT=300
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.default.ok: OPTION=
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.default.ok: EXPECT=300
 
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok: OPTION=-timeoutHandlerTimeout:0
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok: EXPECT=0
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok: OPTION=-timeoutHandlerTimeout:0
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok: EXPECT=0
 
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.timeout.ok: OPTION=-timeoutHandlerTimeout:5
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.timeout.ok: EXPECT=5
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.timeout.ok: OPTION=-timeoutHandlerTimeout:5
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.timeout.ok: EXPECT=5
 
 # the tests
 
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.default.ok \
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok \
-$(BUILDDIR)/TimeoutHandlerTimeoutTest.timeout.ok: \
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.default.ok \
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok \
+$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.timeout.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
 	    $(TESTDIR)/timeoutHandler/TestTimeoutHandler.java
@@ -62,7 +62,7 @@ $(BUILDDIR)/TimeoutHandlerTimeoutTest.timeout.ok: \
 		
 
 TESTS.jtreg += \
-	$(BUILDDIR)/TimeoutHandlerTimeoutTest.default.ok \
-	$(BUILDDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok \
-	$(BUILDDIR)/TimeoutHandlerTimeoutTest.timeout.ok
+	$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.default.ok \
+	$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.noTimeout.ok \
+	$(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.timeout.ok
 

--- a/test/timeouthandlers/TimeoutHandlerTest.gmk
+++ b/test/timeouthandlers/TimeoutHandlerTest.gmk
@@ -29,8 +29,8 @@
 # Test that the default timeout handler in jtreg works
 #
 
-$(BUILDDIR)/TimeoutHandlerTestDefault.agentvm.ok \
-$(BUILDDIR)/TimeoutHandlerTestDefault.othervm.ok: \
+$(BUILDTESTDIR)/TimeoutHandlerTestDefault.agentvm.ok \
+$(BUILDTESTDIR)/TimeoutHandlerTestDefault.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -38,7 +38,7 @@ $(BUILDDIR)/TimeoutHandlerTestDefault.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		-va \
-		$(@:$(BUILDDIR)/TimeoutHandlerTestDefault.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/TimeoutHandlerTestDefault.%.ok=-%) \
 		$(TESTDIR)/timeouthandlers/TestJavaHang.java  \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -46,7 +46,7 @@ $(BUILDDIR)/TimeoutHandlerTestDefault.othervm.ok: \
 	$(GREP) -s 'Test results: error: 1' $(@:%.ok=%/jt.log) > /dev/null
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/TimeoutHandlerTestDefault.shell.ok: \
+$(BUILDTESTDIR)/TimeoutHandlerTestDefault.shell.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -63,16 +63,16 @@ $(BUILDDIR)/TimeoutHandlerTestDefault.shell.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.timeouthandler += \
-	$(BUILDDIR)/TimeoutHandlerTestDefault.agentvm.ok \
-	$(BUILDDIR)/TimeoutHandlerTestDefault.othervm.ok \
-	$(BUILDDIR)/TimeoutHandlerTestDefault.shell.ok
+	$(BUILDTESTDIR)/TimeoutHandlerTestDefault.agentvm.ok \
+	$(BUILDTESTDIR)/TimeoutHandlerTestDefault.othervm.ok \
+	$(BUILDTESTDIR)/TimeoutHandlerTestDefault.shell.ok
 
 #
 # Test that it is possible to supply an external timeout handler
 #
 
-$(BUILDDIR)/TimeoutHandlerTestExternal.agentvm.ok \
-$(BUILDDIR)/TimeoutHandlerTestExternal.othervm.ok: \
+$(BUILDTESTDIR)/TimeoutHandlerTestExternal.agentvm.ok \
+$(BUILDTESTDIR)/TimeoutHandlerTestExternal.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -85,7 +85,7 @@ $(BUILDDIR)/TimeoutHandlerTestExternal.othervm.ok: \
 		-va \
 		-timeoutHandler:MyHandler \
 		-timeoutHandlerDir:$(@:%.ok=%) \
-		$(@:$(BUILDDIR)/TimeoutHandlerTestExternal.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/TimeoutHandlerTestExternal.%.ok=-%) \
 		$(TESTDIR)/timeouthandlers/TestJavaHang.java  \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
@@ -93,7 +93,7 @@ $(BUILDDIR)/TimeoutHandlerTestExternal.othervm.ok: \
 	$(GREP) -s 'Test results: error: 1' $(@:%.ok=%/jt.log) > /dev/null
 	echo "test passed at `date`" > $@
 
-$(BUILDDIR)/TimeoutHandlerTestExternal.shell.ok: \
+$(BUILDTESTDIR)/TimeoutHandlerTestExternal.shell.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -115,9 +115,9 @@ $(BUILDDIR)/TimeoutHandlerTestExternal.shell.ok: \
 	echo "test passed at `date`" > $@
 
 TESTS.timeouthandler += \
-	$(BUILDDIR)/TimeoutHandlerTestExternal.agentvm.ok \
-	$(BUILDDIR)/TimeoutHandlerTestExternal.othervm.ok \
-	$(BUILDDIR)/TimeoutHandlerTestExternal.shell.ok
+	$(BUILDTESTDIR)/TimeoutHandlerTestExternal.agentvm.ok \
+	$(BUILDTESTDIR)/TimeoutHandlerTestExternal.othervm.ok \
+	$(BUILDTESTDIR)/TimeoutHandlerTestExternal.shell.ok
 
 ifdef JDK8HOME
 TESTS.jtreg += ${TESTS.timeouthandler}

--- a/test/timeouts/TimeoutTest.gmk
+++ b/test/timeouts/TimeoutTest.gmk
@@ -25,11 +25,11 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TimeoutTest.ok: \
+$(BUILDTESTDIR)/TimeoutTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(MAKE) -C $(TESTDIR)/timeouts/test \
-		TEST_OUTPUT_DIR=`pwd`/$(BUILDDIR)/$(@:%.ok=%) \
+		TEST_OUTPUT_DIR=`pwd`/$(BUILDTESTDIR)/$(@:%.ok=%) \
 		JT_JAVA=$(JDKHOME) \
 		TESTJAVA=$(JDKHOME) \
 		JTREG_HOME=`cd $(JTREG_IMAGEDIR); pwd`
@@ -37,7 +37,7 @@ $(BUILDDIR)/TimeoutTest.ok: \
 
 # This test is not included by default because it is by its nature so
 # slow to run.
-# TESTS.jtreg += $(BUILDDIR)/TimeoutTest.ok
+# TESTS.jtreg += $(BUILDTESTDIR)/TimeoutTest.ok
 
 #----------------------------------------------------------------------
 
@@ -64,8 +64,8 @@ $(BUILDDIR)/TimeoutTest.ok: \
 # pass: 2, failed: 1, error: 3
 
 
-$(BUILDDIR)/TimeoutTest.agentvm.ok \
-$(BUILDDIR)/TimeoutTest.othervm.ok: \
+$(BUILDTESTDIR)/TimeoutTest.agentvm.ok \
+$(BUILDTESTDIR)/TimeoutTest.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -73,11 +73,11 @@ $(BUILDDIR)/TimeoutTest.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK6HOME) \
 		-va \
-		$(@:$(BUILDDIR)/TimeoutTest.%.ok=-%) \
+		$(@:$(BUILDTESTDIR)/TimeoutTest.%.ok=-%) \
 		$(TESTDIR)/timeouts/test  \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	case $(@:$(BUILDDIR)/TimeoutTest.%.ok=%) in \
+	case $(@:$(BUILDTESTDIR)/TimeoutTest.%.ok=%) in \
 	    othervm ) expect="Test results: passed: 2; failed: 1; error: 3" ;; \
 	    agentvm ) expect="Test results: passed: 3; error: 3" ;; \
 	esac ; \
@@ -87,10 +87,10 @@ $(BUILDDIR)/TimeoutTest.othervm.ok: \
 # These tests are not included by default because by their nature they are so
 # slow to run.
 # TESTS.jtreg += \
-	$(BUILDDIR)/TimeoutTest.agentvm.ok \
-	$(BUILDDIR)/TimeoutTest.othervm.ok
+	$(BUILDTESTDIR)/TimeoutTest.agentvm.ok \
+	$(BUILDTESTDIR)/TimeoutTest.othervm.ok
 
 testtimeouts: \
-	$(BUILDDIR)/TimeoutTest.ok \
-	$(BUILDDIR)/TimeoutTest.agentvm.ok \
-	$(BUILDDIR)/TimeoutTest.othervm.ok
+	$(BUILDTESTDIR)/TimeoutTest.ok \
+	$(BUILDTESTDIR)/TimeoutTest.agentvm.ok \
+	$(BUILDTESTDIR)/TimeoutTest.othervm.ok

--- a/test/toolprovider/ToolProviderTest.gmk
+++ b/test/toolprovider/ToolProviderTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-$(BUILDDIR)/ToolProviderTest.ok: \
+$(BUILDTESTDIR)/ToolProviderTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(TESTDIR)/toolprovider/ToolProviderTest.java
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
@@ -36,4 +36,4 @@ $(BUILDDIR)/ToolProviderTest.ok: \
 
 
 TESTS.jtreg += \
-	$(BUILDDIR)/ToolProviderTest.ok
+	$(BUILDTESTDIR)/ToolProviderTest.ok

--- a/test/versionCheck/TestVersionCheck.gmk
+++ b/test/versionCheck/TestVersionCheck.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestVersionCheck.match.ok: \
+$(BUILDTESTDIR)/TestVersionCheck.match.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -46,12 +46,12 @@ $(BUILDDIR)/TestVersionCheck.match.ok: \
 
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/TestVersionCheck.match.ok
+	$(BUILDTESTDIR)/TestVersionCheck.match.ok
 endif
 
 #----------------------------------------------------------------------
 
-$(BUILDDIR)/TestVersionCheck.mismatch.ok: \
+$(BUILDTESTDIR)/TestVersionCheck.mismatch.ok: \
                 $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/lib/javatest.jar
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
@@ -75,7 +75,7 @@ $(BUILDDIR)/TestVersionCheck.mismatch.ok: \
 ifdef JDK7HOME
 ifdef JDK8HOME
 TESTS.jtreg += \
-	$(BUILDDIR)/TestVersionCheck.mismatch.ok
+	$(BUILDTESTDIR)/TestVersionCheck.mismatch.ok
 endif
 endif
 

--- a/test/vmopts/TestVMOpts.gmk
+++ b/test/vmopts/TestVMOpts.gmk
@@ -28,19 +28,19 @@
 #JTREG_OPTS += \
 #	-J-Djavatest.regtest.debugOptions=true
 
-$(BUILDDIR)/TestVMOpts.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/TestVMOpts.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDK8HOME) -Dfoo=bar -Xbootclasspath/p:baz \
-		-w:$(BUILDDIR)/jtreg/cmd.othervm/work \
-		-r:$(BUILDDIR)/jtreg/cmd.othervm/report \
+		-w:$(@:%.ok=%)/cmd.othervm/work \
+		-r:$(@:%.ok=%)/cmd.othervm/report \
 		-verbose:fail \
 		$(TESTDIR)/vmopts
 	echo "test passed at `date`" > $@
 
 ifdef JDK8HOME
-TESTS.jtreg += $(BUILDDIR)/TestVMOpts.ok
+TESTS.jtreg += $(BUILDTESTDIR)/TestVMOpts.ok
 endif
 
 


### PR DESCRIPTION
Please review a mostly test-only fix to move all the output generated by the many jtreg self-tests into a new $(BUILDDIR)/test subdirectory, defined by a new BUILDTESTDIR variable.

All but two of the edited files are "just" test updates, and most of those were done with search/replace in the IDE. That gave a first pass, with about 90% success rate.  The remaining edits were done by fixing tests up manually, either because they had become broken, or because there were still writing files outside the $(BUILDTESTDIR) directory.

Of the two files that were edited that were not in the main `test` directory, one is in Defs.gmk, to define the new BUILDTESTDIR variable, and the other is in Makefile to add some opportunistic new clean targets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903150](https://bugs.openjdk.java.net/browse/CODETOOLS-7903150): Restructure generated files for jtreg self-tests


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/jtreg pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/69.diff">https://git.openjdk.java.net/jtreg/pull/69.diff</a>

</details>
