### PR TITLE
7903151: NPE when resolving @library from jtreg plugin

### DIFF
--- a/plugins/idea/README.md
+++ b/plugins/idea/README.md
@@ -38,7 +38,7 @@ This will download gradle and the required IntelliJ dependencies, will build the
 
 > Note: to build the plugin, the build script must point to a valid jtreg installation; see the property `jtregHome` in the `gradle.properties` file, and tweak accordingly.
 
-> Note: the property `intellijVersion` can be used to specify which IDE version should the plugin depend on (defaults to `2021.1`).
+> Note: the property `minBuild` can be used to specify which IDE version should the plugin depend. The value of this property should be a valid IntelliJ [release build number](https://www.jetbrains.com/intellij-repository/releases/) (defaults to `IC-211.7142.45`).
 
 Once the build is configured correctly, the plugin can even be tested in a sandbox environment, as follows:
 

--- a/plugins/idea/build.gradle
+++ b/plugins/idea/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = '2021.3.3'
+    version = minBuild
     plugins = ['java', 'AntSupport', 'TestNG-J']
 }
 

--- a/plugins/idea/build.gradle
+++ b/plugins/idea/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
+    version = '2021.3.3'
     plugins = ['java', 'AntSupport', 'TestNG-J']
 }
 

--- a/plugins/idea/gradle.properties
+++ b/plugins/idea/gradle.properties
@@ -1,7 +1,7 @@
 jtregHome = /path/to/jtreg
 minBuild = 211
-pluginVersion = 1.14
+pluginVersion = 1.15
 javaLevel = 11
 notes = <ul>\
-<li>Fix debugging support for 2021.3</li>\
+<li>Fix NPE when resolving @library tag</li>\
 </ul>

--- a/plugins/idea/gradle.properties
+++ b/plugins/idea/gradle.properties
@@ -1,5 +1,5 @@
 jtregHome = /path/to/jtreg
-minBuild = 211
+minBuild = minBuild = IC-211.7142.45
 pluginVersion = 1.15
 javaLevel = 11
 notes = <ul>\

--- a/plugins/idea/gradle.properties
+++ b/plugins/idea/gradle.properties
@@ -1,5 +1,5 @@
 jtregHome = /path/to/jtreg
-minBuild = minBuild = IC-211.7142.45
+minBuild = IC-211.7142.45
 pluginVersion = 1.15
 javaLevel = 11
 notes = <ul>\

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/util/JTRegUtils.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/util/JTRegUtils.java
@@ -241,8 +241,9 @@ public class JTRegUtils {
                                         LOG.debug("Nothing found relative to test suite root.");
                                         Properties testSuiteConfig = testSuiteConfigForRootFile(testRootFile);
                                         if (testSuiteConfig != null) {
-                                            String s = testSuiteConfig.getProperty("external.lib.roots").trim();
+                                            String s = testSuiteConfig.getProperty("external.lib.roots");
                                             if (s != null) {
+                                                s = s.trim();
                                                 LOG.debug("external.lib.roots = \"" + s + "\"");
                                                 // Note: jtreg tag specification for "external.lib.roots" talks about a
                                                 // search path with separate segments; however, all usages I see in our


### PR DESCRIPTION
This patch fixes a trivial NPE which occurs when the plugin is attempting to resolve an absolute library in a `@library` tag. If no library is found starting from TEST.ROOT, and if TEST.ROOT does not specify any alternate library root, the plugin fails with a NPE, as the code is eagerly trimming the property value "external.lib.roots", which might not exist.

The solution is simple, e.g. check for null before trimming.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903151](https://bugs.openjdk.java.net/browse/CODETOOLS-7903151): NPE when resolving @library from jtreg plugin


### Reviewers
 * [Daniel Jeliński](https://openjdk.java.net/census#djelinski) (@djelinski - no project role)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.java.net/jtreg pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/70.diff">https://git.openjdk.java.net/jtreg/pull/70.diff</a>

</details>
