### PR TITLE
CODETOOLS-7903155: replace single use of `rsync` with `cp -R`

### DIFF
--- a/test/autovm/AutoVMTests.gmk
+++ b/test/autovm/AutoVMTests.gmk
@@ -31,8 +31,9 @@ $(BUILDTESTDIR)/autovm.ok: $(AUTOVM_FILES) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	for ts in none agentvm othervm; do \
+	    $(RM) $(BUILDTESTDIR)/autovm/tests/default.$$ts ; \
 	    $(MKDIR) -p $(BUILDTESTDIR)/autovm/tests/default.$$ts ; \
-	    rsync --recursive --delete $(TESTDIR)/autovm/ $(BUILDTESTDIR)/autovm/tests/default.$$ts/ ; \
+	    $(CP) -R $(TESTDIR)/autovm/* $(BUILDTESTDIR)/autovm/tests/default.$$ts ; \
 	    if [ $$ts != none ]; then \
 		echo "defaultExecMode=$$ts" >> $(BUILDTESTDIR)/autovm/tests/default.$$ts/TEST.ROOT ; \
 	    fi \


### PR DESCRIPTION
Please review a simple test-only fix to replace the one single use of `rsync` with equivalent  `rm ...` `cp -R`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903155](https://bugs.openjdk.java.net/browse/CODETOOLS-7903155): replace single use of `rsync` with `cp -R`


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.java.net/jtreg pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/73.diff">https://git.openjdk.java.net/jtreg/pull/73.diff</a>

</details>
