### PR TITLE
7903159: Make jtreg self-tests run on Windows/Cygwin

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -75,6 +75,7 @@ ifndef BUILDDIR
   BUILDDIR = $(TOPDIR)/build
 endif
 override BUILDDIR := $(call FullPath, $(BUILDDIR))
+override JDKHOME := $(call FullPath, $(JDKHOME))
 
 BUILDTESTDIR=$(BUILDDIR)/test
 

--- a/test/agentout/AgentOut.gmk
+++ b/test/agentout/AgentOut.gmk
@@ -73,7 +73,7 @@ $(BUILDTESTDIR)/AgentOut.othervm.ok: \
 	# remove noise lines
 	for i in $(@:%.ok=%)/logs/*.log ; do \
 	   $(MKDIR) -p `dirname $$i`-filtered ; \
-	   $(SED) -e '/^$$/d' -e '/^STATUS.*/d' -e '/^JavaTest.*/d' \
+	   $(SED) -e 's/\r$$//' -e '/^$$/d' -e '/^STATUS.*/d' -e '/^JavaTest.*/d' \
 			-e '/^###/d' -e '/.*warning.*/d' \
 		< $$i \
 		> `dirname $$i`-filtered/`basename $$i` ; \
@@ -91,7 +91,7 @@ $(BUILDTESTDIR)/AgentOut.othervm.ok: \
 $(BUILDTESTDIR)/AgentOut.ok: \
 	    $(BUILDTESTDIR)/AgentOut.agentvm.ok \
 	    $(BUILDTESTDIR)/AgentOut.othervm.ok
-	$(DIFF) -r \
+	$(DIFF) --strip-trailing-cr --recursive \
 		$(BUILDTESTDIR)/AgentOut.agentvm/logs-filtered \
 		$(BUILDTESTDIR)/AgentOut.othervm/logs-filtered
 	echo "passed at `date`" > $@

--- a/test/basic/Basic.gmk
+++ b/test/basic/Basic.gmk
@@ -77,7 +77,7 @@ $(BUILDTESTDIR)/Basic.agentvm.ok: \
 		$(JDKJAVAC) -Xlint -Werror -encoding ISO8859-1 -d $(BUILDTESTDIR)/basic/classes $(TESTDIR)/basic/Basic.java
 	cd $(@:%.ok=%/work/scratch) ; \
 	    $(JDKJAVA) \
-		-cp "../../../basic/classes$(PS)$(ABS_JTREG_IMAGEJARDIR)/jtreg.jar" \
+		-cp "../../../basic/classes$(PS)$(JTREG_IMAGEJARDIR)/jtreg.jar" \
 		-Ddebug.com.sun.javatest.TestResultTable=true \
 		-Ddebug.com.sun.javatest.TRT.TreeIterator=true \
 		-Ddebug.com.sun.javatest.TestRunner=true \

--- a/test/build-wildcards/tests/Test.java
+++ b/test/build-wildcards/tests/Test.java
@@ -74,7 +74,7 @@ public class Test {
             } else if (f.isFile() && f.getName().endsWith(".class")) {
                 String c = base.toURI().relativize(f.toURI()).getPath()
                     .replace(".class", "")
-                    .replace(File.separator, ".");
+                    .replace("/", ".");
                 classes.add(c);
             }
         }

--- a/test/buildPatternTest/BuildPatternTest.gmk
+++ b/test/buildPatternTest/BuildPatternTest.gmk
@@ -32,7 +32,7 @@ $(BUILDTESTDIR)/BuildPatternTest.ok: \
 		-Xlint -Werror \
 		$(TESTDIR)/buildPatternTest/BuildPatternTest.java
 	$(JDKJAVA) \
-		-cp $(@:%.ok=%/classes):$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		-cp "$(@:%.ok=%/classes)$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" \
 		com.sun.javatest.regtest.exec.BuildPatternTest
 	echo $@ passed at `date` > $@
 

--- a/test/classDirs/ClassDirsTest.gmk
+++ b/test/classDirs/ClassDirsTest.gmk
@@ -34,7 +34,7 @@ $(BUILDTESTDIR)/ClassDirsTest.ok: \
 		-Xlint -Werror \
 		$(TESTDIR)/classDirs/ClassDirsTest.java
 	cd $(@:%.ok=%); $(JDKJAVA) \
-		-classpath $(@:%.ok=%)/classes:$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		-classpath "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" \
 		ClassDirsTest
 	echo $@ passed at `date` > $@
 

--- a/test/compileArgFileTest/CompileArgFileTest.gmk
+++ b/test/compileArgFileTest/CompileArgFileTest.gmk
@@ -37,7 +37,7 @@ $(BUILDTESTDIR)/CompileArgFileTest.ok: \
 		-jdk:$(JDKHOME) \
 		$(@:%.ok=%)/tests \
 			> $(@:%.ok=%/jt.log) 2>&1 
-	$(GREP) -s '^Test results: passed: [0-9]*$$' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s '^Test results: passed: [0-9]*\s*$$' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/CompileArgFileTest.ok

--- a/test/exclude/ExcludeTest.gmk
+++ b/test/exclude/ExcludeTest.gmk
@@ -35,7 +35,7 @@ $(BUILDTESTDIR)/exclude.agentvm.ok: \
 		-Djavatest.regtest.showCmd=true \
 		-Djavatest.regtest.debugChild=true \
 		-Djavatest.regtest.traceAgent=true \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		$(@:$(BUILDTESTDIR)/exclude.%.ok=-%) \

--- a/test/groups/GroupTest.gmk
+++ b/test/groups/GroupTest.gmk
@@ -64,7 +64,7 @@ $(BUILDTESTDIR)/ShowGroupTest.ok: \
 	$(GREP) '^g3[0-9]' $(@:%.ok=%)/jt.log > $(@:%.ok=%)/g3.found
 	$(GREP) '^# g3[0-9]*' $(TESTDIR)/groups/TEST.groups3 \
 	        | $(SED) -e 's/# //' > $(@:%.ok=%)/g3.expect
-	$(DIFF) $(@:%.ok=%)/g3.expect $(@:%.ok=%)/g3.found
+	$(DIFF) --strip-trailing-cr $(@:%.ok=%)/g3.expect $(@:%.ok=%)/g3.found
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/ShowGroupTest.ok

--- a/test/i18n/checkI18NProps.sh
+++ b/test/i18n/checkI18NProps.sh
@@ -62,13 +62,13 @@ defdNotReqd=$baseDir/defined-not-required.txt
 \1.name/' ;
   grep 'new FileType' ${srcDir}/*.java | sed -e 's/.*new FileType("\([^"]*\)");.*/filetype\1/' -e 's/.*new FileType();.*/filetype.allFiles/'
   if [ ! -z "$dynProps" ]; then grep '^i18n:' $dynProps | awk '{print $2}' ; fi
-) | sort -u > $requiredProps
+) | sed 's/\r$//' | sort -u > $requiredProps
 
 # end
 
 sed -e '/^#/d' -e '/^[  ]/d' -e '/^[^=]*$/d' -e 's/^\([A-Za-z0-9/_.-]*\).*/\1/' ${srcDir}/i18n.properties  | sort -u > $definedProps
 
-diff $requiredProps $definedProps > $diffs
+diff --strip-trailing-cr $requiredProps $definedProps > $diffs
 
 grep '^<' $diffs | awk '{print $2}' > $reqdNotDefd
 if [ -s $reqdNotDefd ]; then

--- a/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
+++ b/test/ignoresymbolfile/IgnoreSymbolFileTest.gmk
@@ -35,7 +35,7 @@ $(BUILDTESTDIR)/ignoresymbolfile.agentvm.ok: \
 		-Djavatest.regtest.showCmd=true \
 		-Djavatest.regtest.debugChild=true \
 		-Djavatest.regtest.traceAgent=true \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-jdk:$(JDK8HOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \

--- a/test/jdkVersion/JDKVersionTest.gmk
+++ b/test/jdkVersion/JDKVersionTest.gmk
@@ -31,7 +31,7 @@
 $(BUILDTESTDIR)/TestJDKVersion.classes.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar 
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JDKJAVA) -cp $(CLASSDIR):$(JTREG_IMAGEDIR)/lib/javatest.jar com.sun.javatest.regtest.Main \
+	$(JDKJAVA) -cp "$(CLASSDIR)$(PS)$(JTREG_IMAGEDIR)/lib/javatest.jar" com.sun.javatest.regtest.Main \
 		-jdk:$(JDKHOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
@@ -46,7 +46,7 @@ $(BUILDTESTDIR)/TestJDKVersion.classes.ok: \
 $(BUILDTESTDIR)/TestJDKVersion.jar.ok: \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar 
 	$(MKDIR) -p $(@:%.ok=%)
-	$(JDKJAVA) -cp $(JTREG_IMAGEJARDIR)/jtreg.jar:$(JTREG_IMAGEDIR)/lib/javatest.jar com.sun.javatest.regtest.Main \
+	$(JDKJAVA) -cp "$(JTREG_IMAGEJARDIR)/jtreg.jar$(PS)$(JTREG_IMAGEDIR)/lib/javatest.jar" com.sun.javatest.regtest.Main \
 		-jdk:$(JDKHOME) \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \

--- a/test/match/MatchTest.gmk
+++ b/test/match/MatchTest.gmk
@@ -35,7 +35,7 @@ $(BUILDTESTDIR)/match.agentvm.ok: \
 		-Djavatest.regtest.showCmd=true \
 		-Djavatest.regtest.debugChild=true \
 		-Djavatest.regtest.traceAgent=true \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		$(@:$(BUILDTESTDIR)/match.%.ok=-%) \

--- a/test/nativepath/NativesOK.java
+++ b/test/nativepath/NativesOK.java
@@ -33,11 +33,13 @@ public class NativesOK {
     public static void main(String[] args) {
         String j_l_path = System.getProperty("java.library.path");
         String t_native = System.getProperty("test.nativepath");
+        String c_native = System.getProperty("correct.nativepath").replace("/", File.separator);
 
         System.out.println("java.library.path: " + j_l_path);
         System.out.println("test.nativepath: " + t_native);
+        System.out.println("correct.nativepath: " + c_native);
 
-        if (!t_native.equals(System.getProperty("correct.nativepath")))
+        if (!t_native.equals(c_native))
             throw new Error("System property 'test.nativepath' not set correctly");
         if (j_l_path == null)
             throw new Error("System property 'java.library.path' not set");

--- a/test/nativepath/NativesOKShell.sh
+++ b/test/nativepath/NativesOKShell.sh
@@ -26,6 +26,11 @@
 
 # @test
 
+if [[ "$(uname)" == *"CYGWIN"* ]]; then
+  TESTNATIVEPATH=$(echo $TESTNATIVEPATH | tr '/' '\\')
+  CORRECTNATIVEPATH=$(echo $CORRECTNATIVEPATH | tr '/' '\\')
+fi
+
 echo TESTNATIVEPATH=$TESTNATIVEPATH
 echo CORRECTNATIVEPATH=$CORRECTNATIVEPATH
 

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -26,7 +26,7 @@
 #----------------------------------------------------------------------
 
 
-NATIVEPATH := $(shell cd $(BUILDDIR); pwd)
+NATIVEPATH := $(call FullPath, $(shell cd $(BUILDDIR); pwd))
 
 $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
 $(BUILDTESTDIR)/TestNativePath.othervm.ok: \
@@ -74,7 +74,7 @@ $(BUILDTESTDIR)/TestNativePath.ok: \
 
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-nativepath:$(JTREG_IMAGEDIR)/bin/jtreg:$(JDK6HOME) \
+		-nativepath:"$(JTREG_IMAGEDIR)/bin/jtreg$(PS)$(JDK6HOME)" \
 		$(TESTDIR)/nativepath \
 		2>&1 | grep -q "The argument to -nativepath cannot be more than one path." 
 

--- a/test/requires/ExprTest.java
+++ b/test/requires/ExprTest.java
@@ -38,7 +38,7 @@
  * @requires 1G == 1024M
  * @requires 1M == 1024K
  * @requires file.separator == "/" | file.separator == "\\"
- * @requires line.separator == "\n" | file.separator == "\r\n"
+ * @requires line.separator == "\n" | line.separator == "\r\n"
  * @requires os.maxMemory > 1M
  * @requires os.maxSwap >= 0
  * @run main ExprTest

--- a/test/statsTests/StatsTests.gmk
+++ b/test/statsTests/StatsTests.gmk
@@ -56,9 +56,9 @@ $(BUILDTESTDIR)/StatsTxt.1.ok: \
 		$(TESTDIR)/share/basic/main   \
 			> $(@:%.ok=%/jt.log) 2>&1  || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^TEST-STATS: StatsTxt run=44 failed=32 excluded=0$$' \
+	$(GREP) -E -s '^TEST-STATS: StatsTxt run=44 failed=32 excluded=0\s?$$' \
 		$(@:%.ok=%/jt.log)  > /dev/null
-	$(GREP) -s '^TEST-STATS: StatsTxt run=44 failed=32 excluded=0$$' \
+	$(GREP) -E -s '^TEST-STATS: StatsTxt run=44 failed=32 excluded=0\s?$$' \
 		$(@:%.ok=%/report/text/stats.txt)  > /dev/null
 	echo "test passed at `date`" > $@
 
@@ -80,9 +80,9 @@ $(BUILDTESTDIR)/StatsTxt.2.ok: \
 		$(TESTDIR)/share/basic/ignore   \
 			> $(@:%.ok=%/jt.log) 2>&1  || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^TEST-STATS: StatsTxt passed=12 failed=32 ignored=2$$' \
+	$(GREP) -E -s '^TEST-STATS: StatsTxt passed=12 failed=32 ignored=2\s?$$' \
 		$(@:%.ok=%/jt.log)  > /dev/null
-	$(GREP) -s '^TEST-STATS: StatsTxt passed=12 failed=32 ignored=2$$' \
+	$(GREP) -E -s '^TEST-STATS: StatsTxt passed=12 failed=32 ignored=2\s?$$' \
 		$(@:%.ok=%/report/text/stats.txt)  > /dev/null
 	echo "test passed at `date`" > $@
 		    			

--- a/test/statusFilter/StatusFilterTest.gmk
+++ b/test/statusFilter/StatusFilterTest.gmk
@@ -59,7 +59,7 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter/p1 \
 		> $(@:%.ok=%/rerun-status-fail-report-default.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -E -s '^Test results: failed: 1\s+$$' $(@:%.ok=%/rerun-status-fail-report-default.log) > /dev/null
+	$(GREP) -E -s '^Test results: failed: 1\s?$$' $(@:%.ok=%/rerun-status-fail-report-default.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "5" ]; then echo "!! bad summary.txt" ; $(CAT) $(@:%.ok=%/report)/text/summary.txt; exit 1 ; fi
 	#

--- a/test/statusFilter/StatusFilterTest.gmk
+++ b/test/statusFilter/StatusFilterTest.gmk
@@ -34,7 +34,7 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 	#
 	@echo "*** run p1 tests with 1 failure; expect 4 pass 1 fail"
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-jdk:$(JDKHOME) \
@@ -43,13 +43,13 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter/p1 \
 		> $(@:%.ok=%/init.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^Test results: passed: 4; failed: 1$$' $(@:%.ok=%/init.log) > /dev/null
+	$(GREP) -E -s '^Test results: passed: 4; failed: 1\s?$$' $(@:%.ok=%/init.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "5" ]; then echo "!! bad summary.txt" ; $(CAT) $(@:%.ok=%/report)/text/summary.txt; exit 1 ; fi
 	#
 	@echo "*** rerun failed p1 tests, test fails again; expect 1 fail"
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-jdk:$(JDKHOME) \
@@ -59,13 +59,13 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter/p1 \
 		> $(@:%.ok=%/rerun-status-fail-report-default.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^Test results: failed: 1$$' $(@:%.ok=%/rerun-status-fail-report-default.log) > /dev/null
+	$(GREP) -E -s '^Test results: failed: 1\s+$$' $(@:%.ok=%/rerun-status-fail-report-default.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "5" ]; then echo "!! bad summary.txt" ; $(CAT) $(@:%.ok=%/report)/text/summary.txt; exit 1 ; fi
 	#
 	@echo "*** reportonly run; expect 4 pass 1 fail"
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-jdk:$(JDKHOME) \
@@ -74,13 +74,13 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter/p1 \
 		> $(@:%.ok=%/rerun-reportonly.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^Test results: passed: 4; failed: 1$$' $(@:%.ok=%/rerun-reportonly.log) > /dev/null
+	$(GREP) -E -s '^Test results: passed: 4; failed: 1\s?$$' $(@:%.ok=%/rerun-reportonly.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "5" ]; then echo "!! bad summary.txt" ; $(CAT) $(@:%.ok=%/report)/text/summary.txt; exit 1 ; fi
 	#
 	@echo "*** rerun failed p1 tests, test fails again; report all; expect 1 fail, all in report"
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-jdk:$(JDKHOME) \
@@ -91,13 +91,13 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter/p1 \
 		> $(@:%.ok=%/rerun-status-fail-report-all.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^Test results: failed: 1$$' $(@:%.ok=%/rerun-status-fail-report-all.log) > /dev/null
+	$(GREP) -E -s '^Test results: failed: 1\s?$$' $(@:%.ok=%/rerun-status-fail-report-all.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "10" ]; then echo bad summary.txt ; exit 1 ; fi
 	#
 	@echo "*** rerun failed p1 tests; report all; expect 1 pass, all in report"
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-jdk:$(JDKHOME) \
@@ -107,12 +107,12 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter/p1 \
 		> $(@:%.ok=%/rerun-2.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^Test results: passed: 1$$' $(@:%.ok=%/rerun-2.log) > /dev/null
+	$(GREP) -E -s '^Test results: passed: 1\s?$$' $(@:%.ok=%/rerun-2.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "10" ]; then echo bad summary.txt ; exit 1 ; fi
 	#
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-jdk:$(JDKHOME) \
@@ -121,12 +121,12 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter \
 		> $(@:%.ok=%/rerun-all-executed.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^Test results: passed: 8; error: 1$$' $(@:%.ok=%/rerun-all-executed.log) > /dev/null
+	$(GREP) -E -s '^Test results: passed: 8; error: 1\s?$$' $(@:%.ok=%/rerun-all-executed.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "9" ]; then echo bad summary.txt ; exit 1 ; fi
 	#
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-jdk:$(JDKHOME) \
@@ -136,7 +136,7 @@ $(BUILDTESTDIR)/StatusFilter.ok: \
 		$(TESTDIR)/statusFilter \
 		> $(@:%.ok=%/rerun-all.log 2>&1) || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s '^Test results: passed: 8; error: 1$$' $(@:%.ok=%/rerun-all.log) > /dev/null
+	$(GREP) -E -s '^Test results: passed: 8; error: 1\s?$$' $(@:%.ok=%/rerun-all.log) > /dev/null
 	lines=`$(CAT) $(@:%.ok=%/report)/text/summary.txt | $(WC) -l` ; \
 	if [ "$$lines" -ne "10" ]; then echo bad summary.txt ; exit 1 ; fi
 	#

--- a/test/testng/TestNGLibTest.gmk
+++ b/test/testng/TestNGLibTest.gmk
@@ -32,7 +32,7 @@ $(BUILDTESTDIR)/TestNGLibTest.ok: \
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		$(TESTDIR)/testng \

--- a/test/testprops/TestPropsTest.gmk
+++ b/test/testprops/TestPropsTest.gmk
@@ -32,7 +32,7 @@ $(BUILDTESTDIR)/TestPropsTest.ok: \
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		$(TESTDIR)/testprops \

--- a/test/versionCheck/TestVersionCheck.gmk
+++ b/test/versionCheck/TestVersionCheck.gmk
@@ -31,7 +31,7 @@ $(BUILDTESTDIR)/TestVersionCheck.match.ok: \
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-compileJDK:$(JDK8HOME) \
@@ -57,7 +57,7 @@ $(BUILDTESTDIR)/TestVersionCheck.mismatch.ok: \
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKHOME)/bin/java \
-		-jar $(ABS_JTREG_IMAGEJARDIR)/jtreg.jar \
+		-jar $(JTREG_IMAGEJARDIR)/jtreg.jar \
 		-w:$(@:%.ok=%/work) \
 		-r:$(@:%.ok=%/report) \
 		-compileJDK:$(JDK7HOME) \


### PR DESCRIPTION
Prior to this commit some of `jtreg`'s self-tests failed on Windows/Cygwin systems.

This commit fixes this mainly by adjusting assertions expecting Windows-style paths, `\r\n` line-breaks, and ignoring/normalizing other differences compared to Unix-based systems.

https://bugs.openjdk.java.net/browse/CODETOOLS-7903159

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903159](https://bugs.openjdk.java.net/browse/CODETOOLS-7903159): Make jtreg self-tests run on Windows/Cygwin


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.java.net/jtreg pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/74.diff">https://git.openjdk.java.net/jtreg/pull/74.diff</a>

</details>
