### PR TITLE
7903166: jtreg crashes trying to compile .jasm with enablePreview=true

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -364,7 +364,7 @@ public class CompileAction extends Action {
             }
         }
 
-        if (insertPos != -1 && script.enablePreview() && !seenEnablePreview) {
+        if (runJavac && script.enablePreview() && !seenEnablePreview) {
             javacArgs.add(insertPos, "--enable-preview");
             if (!seenSourceOrRelease) {
                 int v = script.getTestJDKVersion().major;

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -364,7 +364,7 @@ public class CompileAction extends Action {
             }
         }
 
-        if (script.enablePreview() && !seenEnablePreview) {
+        if (insertPos != -1 && script.enablePreview() && !seenEnablePreview) {
             javacArgs.add(insertPos, "--enable-preview");
             if (!seenSourceOrRelease) {
                 int v = script.getTestJDKVersion().major;

--- a/test/preview/PreviewTest.gmk
+++ b/test/preview/PreviewTest.gmk
@@ -37,7 +37,7 @@ $(BUILDTESTDIR)/PreviewTest_good.ok: \
 		'-k:!bad' \
 		$(TESTDIR)/preview/  \
 			> $(@:%.ok=%/jt.log)
-	$(GREP) -s 'Test results: passed: 5' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: 6' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
 $(BUILDTESTDIR)/PreviewTest_bad.ok: \

--- a/test/preview/preview/JASMClass.jasm
+++ b/test/preview/preview/JASMClass.jasm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+public class JASMClass
+    version 58:0
+{
+
+    public static Method someMethod:"()I" stack 1 locals 0 {
+        iconst_4;
+        ireturn;
+    }
+
+} // end class JASMClass

--- a/test/preview/preview/JASMTest.java
+++ b/test/preview/preview/JASMTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @compile JASMClass.jasm
+ * @run main/othervm JASMTest
+ */
+
+// The main point of this test is to make sure dependant .jasm file is compiled correctly
+public class JASMTest {
+    public static void main(String... args) throws Exception {
+        if (JASMClass.someMethod() != 4) {
+            throw new Error("Unexpected return value from JASM method");
+        }
+    }
+}


### PR DESCRIPTION
The bug: [CODETOOLS-7903166](https://bugs.openjdk.java.net/browse/CODETOOLS-7903166)

A small fix targeting crashes that occurs when jtreg compiles non-javac files with enablePreview. Prior the fix, the code crashed trying to insert arguments into javacArgs list using negative index.

Testing: test/preview folder self-tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [CODETOOLS-7903166](https://bugs.openjdk.java.net/browse/CODETOOLS-7903166): jtreg crashes trying to compile .jasm with enablePreview=true


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.java.net/jtreg pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/77.diff">https://git.openjdk.java.net/jtreg/pull/77.diff</a>

</details>
