### PR TITLE
CODETOOLS-7903171: Fix issues related to generating internal API documentation

### DIFF
--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -189,26 +189,26 @@ JAVATEST_SRCFILES= \
 endif
 
 $(JTREG_IMAGEDIR)/doc/api/index.html: \
-            $(JAVAFILES.com.sun.javatest.regtest-tools) \
-            $(JAVATEST_SRCFILES)
+	    $(JAVAFILES.com.sun.javatest.regtest-tools) \
+	    $(JAVATEST_SRCFILES)
 	$(JDKHOME)/bin/javadoc -d $(@D) \
-                -encoding iso-8859-1 \
+		-encoding ascii \
 		-sourcepath "$(JAVADIR)$(PS)$(JAVATEST_SRCDIR)" \
 		-classpath "$(JAVATEST_JAR)$(PS)$(JUNIT_JAR)$(PS)$(TESTNG_JAR)" \
 		com.sun.javatest.regtest \
-                $(JAVATEST_SRCFILES)
+		$(JAVATEST_SRCFILES)
 
 $(JTREG_IMAGEDIR)/doc/devapi/index.html: \
-            $(JAVAFILES.com.sun.javatest.regtest-tools) \
-            $(JAVATEST_SRCFILES)
+	    $(JAVAFILES.com.sun.javatest.regtest-tools) \
+	    $(JAVATEST_SRCFILES)
 	$(JDKHOME)/bin/javadoc -d $(@D) \
-                -encoding iso-8859-1 \
+		-encoding ascii \
 		-sourcepath "$(JAVADIR)$(PS)$(JAVATEST_SRCDIR)" \
-		-classpath "$(JAVATEST_JAR)$(PS)$(JUNIT_JAR)$(PS)$(TESTNG_JAR)" \
+		-classpath "$(JAVATEST_JAR)$(PS)$(JUNIT_CLASSPATH)$(PS)$(TESTNG_CLASSPATH)" \
 		-subpackages com.sun.javatest.regtest \
-                -tag "implNote:a:Implementation Note:" \
-                $(JAVATEST_SRCFILES)
-		
+		-tag "implNote:a:Implementation Note:" \
+		$(JAVATEST_SRCFILES)
+
 
 #----------------------------------------------------------------------
 #

--- a/src/share/classes/com/sun/javatest/regtest/agent/AStatus.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AStatus.java
@@ -27,7 +27,7 @@ package com.sun.javatest.regtest.agent;
 /**
  * A class to embody the result of a test: a status-code and a related message.
  *
- * This is a reduced copy of com.sun.javatest.Status, sufficient to the needs
+ * This is a reduced copy of {@code com.sun.javatest.Status}, sufficient to the needs
  * of returning test results from a test VM. In particular, it implements the
  * same protocol to transfer results across process boundaries, meaning the
  * encoding of the status type and reason.
@@ -166,7 +166,6 @@ public class AStatus
 
     /**
      * Convert a Status to a string.
-     * @see #parse
      */
     public String toString() {
         if (reason == null || reason.length() == 0)
@@ -285,23 +284,23 @@ public class AStatus
 
     /**
      * Exit codes used by Status.exit corresponding to
-     * PASSED, FAILED, ERROR, NOT_RUN.
+     * {@code PASSED}, {@code FAILED}, {@code ERROR}, {@code NOT_RUN}.
      * The only values that should normally be returned from a test
      * are the first three; the other value is provided for completeness.
-     * <font size=-1> Note: The assignment is historical and cannot easily be changed. </font>
+     * <small> Note: The assignment is historical and cannot easily be changed. </small>
      */
     public static final int[] exitCodes = { 95, 97, 98, 99 };
 
     /**
      * Encodes strings containing non-ascii characters, where all characters
-     * are replaced with with their Unicode code. Encoded string will have
+     * are replaced with their Unicode code. Encoded string will have
      * the certain prefix and suffix to be distinguished from non-encode one.
      * Strings of ASCII chars only are encoded into themselves.<br>
      * Example:
-     * <pre>
+     * <pre>{@code
      * System.out.println(Status.encode("X \u01AB")); //<Encoded>58 20 1AB </Encoded>
      * System.out.println(Status.encode("Abc1")); // Abc1
-     * </pre>
+     * }</pre>
      * @param str - string to encode
      * @return Encoded string or the same string if none non-ascii chars were found
      *

--- a/src/share/classes/com/sun/javatest/regtest/config/CachingTestFilter.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/CachingTestFilter.java
@@ -77,6 +77,7 @@ public abstract class CachingTestFilter extends TestFilter {
      *
      * @param td the test description
      * @return the value
+     * @throws Fault if any error occurred in the filter
      */
     protected abstract boolean getCacheableValue(TestDescription td) throws Fault;
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -272,9 +272,9 @@ public abstract class Action extends ActionHelper {
      *
      * The remaining entries in the policy file should remain the same.
      *
-     * @param fileName The absolute name of the original policy file.
-     * @return     A string indicating the absolute name of the modified policy
-     *             file.
+     * @param fileName the absolute name of the original policy file
+     * @param argFile  an additional file to be granted permissions
+     * @return     a string indicating the absolute name of the modified policy file
      * @throws TestRunException if a problem occurred adding this grant entry.
      */
     protected File addGrantEntries(File fileName, File argFile) throws TestRunException {

--- a/src/share/classes/com/sun/javatest/regtest/util/GraphUtils.java
+++ b/src/share/classes/com/sun/javatest/regtest/util/GraphUtils.java
@@ -87,7 +87,7 @@ public class GraphUtils {
      * @param <D> the type of a data object included in each node
      * @param <N> the subtype of {@code TarjanNode<D>}
      * @param nodes the nodes of the graph
-     * @return the set of strongly connected components, each represented by a set of {@coed TarjanNode} objects
+     * @return the set of strongly connected components, each represented by a set of {@code TarjanNode} objects
      */
     public static <D, N extends TarjanNode<D>> Set<? extends Set<? extends N>> tarjan(Iterable<? extends N> nodes) {
         Set<Set<N>> cycles = new LinkedHashSet<>();


### PR DESCRIPTION
Please review some trivial changes to update the makefiles and doc comments used to generate internal API documentation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903171](https://bugs.openjdk.java.net/browse/CODETOOLS-7903171): Fix issues related to generating internal API documentation


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.java.net/jtreg pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/79.diff">https://git.openjdk.java.net/jtreg/pull/79.diff</a>

</details>
