### PR TITLE
CODETOOLS-7903168: Update openjdk/jtreg repo to require 1 Reviewer

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -22,6 +22,7 @@ ignore-tabs=.*\.gmk|Makefile
 message=Merge
 
 [checks "reviewers"]
+reviewers=1
 ignore=duke
 
 [checks "committer"]


### PR DESCRIPTION
Please review a small change to require a "R"eviewer for changes to the jtreg repo

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903168](https://bugs.openjdk.java.net/browse/CODETOOLS-7903168): Update openjdk/jtreg repo to require 1 Reviewer


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.java.net/jtreg pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/80.diff">https://git.openjdk.java.net/jtreg/pull/80.diff</a>

</details>
