### PR TITLE
CODETOOLS-7903183: Log start time for every action

### DIFF
--- a/make/CheckJavaOSVersion.java
+++ b/make/CheckJavaOSVersion.java
@@ -34,7 +34,7 @@ public class CheckJavaOSVersion {
 
     private static void checkJavaOSVersion(String expectVersion) {
         String osVersion = System.getProperty("os.version");
-        if (!osVersion.equals(expectVersion)) {
+        if (!osVersion.startsWith(expectVersion)) {
             System.err.println("The version of JDK you are using does not report the OS version correctly.");
             System.err.println("    java.home:    " + System.getProperty("java.home"));
             System.err.println("    java.version: " + System.getProperty("java.version"));

--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -389,7 +389,9 @@ public abstract class Action extends ActionHelper {
             configWriter = section.createOutput("configuration");
         }
 
-        startTime = (new Date()).getTime();
+        Date startDate = new Date();
+        startTime = startDate.getTime();
+        pw.println(LOG_STARTED + startDate);
     } // startAction()
 
     /**
@@ -399,8 +401,10 @@ public abstract class Action extends ActionHelper {
      * @param status The final status of the action.
      */
     protected void endAction(Status status) {
-        long elapsedTime = (new Date()).getTime() - startTime;
+        Date endDate = new Date();
+        long elapsedTime = endDate.getTime() - startTime;
         PrintWriter pw = section.getMessageWriter();
+        pw.println(LOG_FINISHED + endDate);
         pw.println(LOG_ELAPSED_TIME + ((double) elapsedTime/1000.0));
         recorder.close();
         section.setStatus(status);
@@ -704,6 +708,8 @@ public abstract class Action extends ActionHelper {
         LOG_JT_COMMAND        = "JavaTest command: ",
         LOG_REASON            = "reason: ",
         LOG_ELAPSED_TIME      = "elapsed time (seconds): ",
+        LOG_STARTED = "started: ",
+        LOG_FINISHED = "finished: ",
         //LOG_JDK               = "JDK under test: ",
 
         // COMMON

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -213,7 +213,7 @@ public class Tool {
 
     private static void checkJavaOSVersion(String expectVersion) {
         String osVersion = System.getProperty("os.version");
-        if (!osVersion.equals(expectVersion)) {
+        if (!osVersion.startsWith(expectVersion)) {
             System.err.println("The version of JDK you are using to run jtreg does not report the OS version correctly.");
             System.err.println("    java.home:    " + System.getProperty("java.home"));
             System.err.println("    java.version: " + System.getProperty("java.version"));

--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -66,6 +66,7 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 		    -e 's|$(ABSTOPDIR)|%WS%|g' \
 		    -e 's|junit-[A-Za-z0-9.-]*\.jar|junit.jar|g' \
 		    -e 's|testng-[A-Za-z0-9.-]*\.jar|testng.jar|g' \
+		    -e 's|%BUILD%.images.jtreg.lib.hamcrest[A-Za-z0-9.-]*\.jar.||g' \
 		    -e 's|%BUILD%.images.jtreg.lib.guice[A-Za-z0-9.-]*\.jar.||g' \
 		    -e 's|%BUILD%.images.jtreg.lib.jcommander[A-Za-z0-9.-]*\.jar.||g' \
 		> $(@:%.ok=%)/out/$${i%.*}.out ; \


### PR DESCRIPTION
Primarily, this is to log start and end times for each ac ton, to help diagnose where unaccounted time is occurring.

It also fixes two unrelated issues, needed to get tests to pass.  One is related to the OS version check, where a double-dotted number should be regarded as acceptable compared to a single-dotted number (e.g. 1.2.3 compared to 1.2).

Finally, there was some test betroth in RerunTest related to the latest JUnit version: Hamcrest should no longer be expected/required on the test class path.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [CODETOOLS-7903183](https://bugs.openjdk.java.net/browse/CODETOOLS-7903183): Log start time for every action
 * [CODETOOLS-7903185](https://bugs.openjdk.java.net/browse/CODETOOLS-7903185): Update RerunTest for latest JUnit
 * [CODETOOLS-7903184](https://bugs.openjdk.java.net/browse/CODETOOLS-7903184): Update OS version check


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.java.net/jtreg pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/82.diff">https://git.openjdk.java.net/jtreg/pull/82.diff</a>

</details>
