### PR TITLE
CODETOOLS-7903184: Update OS version check

### DIFF
--- a/make/CheckJavaOSVersion.java
+++ b/make/CheckJavaOSVersion.java
@@ -34,7 +34,7 @@ public class CheckJavaOSVersion {
 
     private static void checkJavaOSVersion(String expectVersion) {
         String osVersion = System.getProperty("os.version");
-        if (!osVersion.equals(expectVersion)) {
+        if (!osVersion.startsWith(expectVersion)) {
             System.err.println("The version of JDK you are using does not report the OS version correctly.");
             System.err.println("    java.home:    " + System.getProperty("java.home"));
             System.err.println("    java.version: " + System.getProperty("java.version"));

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -213,7 +213,7 @@ public class Tool {
 
     private static void checkJavaOSVersion(String expectVersion) {
         String osVersion = System.getProperty("os.version");
-        if (!osVersion.equals(expectVersion)) {
+        if (!osVersion.startsWith(expectVersion)) {
             System.err.println("The version of JDK you are using to run jtreg does not report the OS version correctly.");
             System.err.println("    java.home:    " + System.getProperty("java.home"));
             System.err.println("    java.version: " + System.getProperty("java.version"));


### PR DESCRIPTION
Please review a small fix to be slightly more permissive in the check for the os.version property, and allow a double-dotted number (like 1.2.3) to be accepted as better than a single-dotted prefix (like 1.2).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [CODETOOLS-7903184](https://bugs.openjdk.java.net/browse/CODETOOLS-7903184): Update OS version check


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Christian Stein](https://openjdk.java.net/census#cstein) (@sormuras - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.java.net/jtreg pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/83.diff">https://git.openjdk.java.net/jtreg/pull/83.diff</a>

</details>
