### PR TITLE
CODETOOLS-7903185: Update RerunTest for latest JUnit

### DIFF
--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -66,6 +66,7 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 		    -e 's|$(ABSTOPDIR)|%WS%|g' \
 		    -e 's|junit-[A-Za-z0-9.-]*\.jar|junit.jar|g' \
 		    -e 's|testng-[A-Za-z0-9.-]*\.jar|testng.jar|g' \
+		    -e 's|%BUILD%.images.jtreg.lib.hamcrest[A-Za-z0-9.-]*\.jar.||g' \
 		    -e 's|%BUILD%.images.jtreg.lib.guice[A-Za-z0-9.-]*\.jar.||g' \
 		    -e 's|%BUILD%.images.jtreg.lib.jcommander[A-Za-z0-9.-]*\.jar.||g' \
 		> $(@:%.ok=%)/out/$${i%.*}.out ; \


### PR DESCRIPTION
Please review a small test fix for RerunTest following the recent update for JUnit.
.
Hamcrest (now typically part of the JUnit uber-jar) should not be expected/required to be on the test class path

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [CODETOOLS-7903185](https://bugs.openjdk.java.net/browse/CODETOOLS-7903185): Update RerunTest for latest JUnit


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.java.net/jtreg pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/84.diff">https://git.openjdk.java.net/jtreg/pull/84.diff</a>

</details>
