### PR TITLE
CODETOOLS-7903183: Log start time for every action

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -389,7 +389,9 @@ public abstract class Action extends ActionHelper {
             configWriter = section.createOutput("configuration");
         }
 
-        startTime = (new Date()).getTime();
+        Date startDate = new Date();
+        startTime = startDate.getTime();
+        pw.println(LOG_STARTED + startDate);
     } // startAction()
 
     /**
@@ -399,8 +401,10 @@ public abstract class Action extends ActionHelper {
      * @param status The final status of the action.
      */
     protected void endAction(Status status) {
-        long elapsedTime = (new Date()).getTime() - startTime;
+        Date endDate = new Date();
+        long elapsedTime = endDate.getTime() - startTime;
         PrintWriter pw = section.getMessageWriter();
+        pw.println(LOG_FINISHED + endDate);
         pw.println(LOG_ELAPSED_TIME + ((double) elapsedTime/1000.0));
         recorder.close();
         section.setStatus(status);
@@ -704,6 +708,8 @@ public abstract class Action extends ActionHelper {
         LOG_JT_COMMAND        = "JavaTest command: ",
         LOG_REASON            = "reason: ",
         LOG_ELAPSED_TIME      = "elapsed time (seconds): ",
+        LOG_STARTED = "started: ",
+        LOG_FINISHED = "finished: ",
         //LOG_JDK               = "JDK under test: ",
 
         // COMMON


### PR DESCRIPTION
Please review a small update to provide start and end times for each action in a .jtr file, to help better track "unaccounted" time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [CODETOOLS-7903183](https://bugs.openjdk.java.net/browse/CODETOOLS-7903183): Log start time for every action


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jtreg pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.java.net/jtreg pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jtreg/pull/85.diff">https://git.openjdk.java.net/jtreg/pull/85.diff</a>

</details>
