### PR TITLE
CODETOOLS-7903220: Improve setting of the generated "release" file

### DIFF
--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -333,8 +333,8 @@ $(JTREG_IMAGEDIR)/release:
 	echo "BUILD_DATE=`/bin/date +'%B %d, %Y'`" >> $@
 	if [ -r $(TOPDIR)/.git ]; then \
 	    echo "SOURCE=$$($(ID_COMMAND))" >> $@ ; \
-	elif [ -r $(TOPDIR)/.src-rev ]; then \
-	    echo "SOURCE=\"$$($(CAT) $(TOPDIR)/.src-rev | $(SED) -e 's/:/:git:/' -e 's/  *$$//')\"" >> $@ ; \
+	elif [ -n "$(SRCREV)" -a -r $(SRCREV) ]; then \
+	    echo "SOURCE=\"$$($(CAT) $(SRCREV) | $(SED) -e 's/:/:git:/' -e 's/  *$$//')\"" >> $@ ; \
 	fi
 
 TARGETS.ZIP.jtreg += \


### PR DESCRIPTION
Please review a small change to permit  more flexible, optional setting of the `.src-rev` file used to generate info in the `release` file for an image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903220](https://bugs.openjdk.org/browse/CODETOOLS-7903220): Improve setting of the generated "release" file


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/jtreg pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/89.diff">https://git.openjdk.org/jtreg/pull/89.diff</a>

</details>
