### PR TITLE
CODETOOLS-7903221: broken self-tests

### DIFF
--- a/test/7113596/T7113596.gmk
+++ b/test/7113596/T7113596.gmk
@@ -30,9 +30,10 @@ $(BUILDTESTDIR)/T7113596.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(LN) -s $(JDKHOME) $(@:%.ok=%)/jdk
+	ABS_TESTDIR=`cd $(TESTDIR) ; pwd` ; \
 	cd $(@:%.ok=%) && $(JDKJAVA) -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-jdk:jdk \
-		../../$(TESTDIR)/7113596
+		$${ABS_TESTDIR}/7113596
 	for i in COMPILEJAVA TESTJAVA ; do \
 	    value=`$(GREP) $$i= $(@:%.ok=%)/JTwork/Test.jtr | $(SED) -e 's/[^=]*=//' | head -n 1` ; \
 	    case $$value in \

--- a/test/share/basic/junit/BadTestClass.java
+++ b/test/share/basic/junit/BadTestClass.java
@@ -31,6 +31,9 @@
  * @run junit/othervm BadTestClass
  */
 
-class BadTestClass
-{
+import org.junit.*;
+
+public class BadTestClass {
+    @Test
+    private void m() { }
 }


### PR DESCRIPTION
Please review a couple of test changes to make them more robust in the face of using alternate locations for the build directory, and choice of JUnit library

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903221](https://bugs.openjdk.org/browse/CODETOOLS-7903221): broken self-tests


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jtreg pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/90.diff">https://git.openjdk.org/jtreg/pull/90.diff</a>

</details>
