### PR TITLE
CODETOOLS-7903223: Enable no-display-required parts of Basic tests in HEADLESS mode

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -107,6 +107,9 @@ public class Agent {
             cmd.addAll(vmOpts);
             if (policyFile != null)
                 cmd.add("-Djava.security.policy=" + policyFile.toURI());
+            String headless = System.getProperty("java.awt.headless");
+            if (headless != null)
+                cmd.add("-Djava.awt.headless=" + headless);
             cmd.add(AgentServer.class.getName());
 
             cmd.add(AgentServer.ID);

--- a/test/basic/Basic.gmk
+++ b/test/basic/Basic.gmk
@@ -63,18 +63,23 @@ else
   BASIC_TESTS := $(abspath $(TESTDIR)/share/basic)
 endif
 
+$(BUILDTESTDIR)/Basic.classes.ok: \
+		$(ALL_JTREG_JARS) \
+		$(TESTDIR)/basic/Basic.java
+	$(MKDIR) -p $(BUILDTESTDIR)/basic/classes
+	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
+		$(JDKJAVAC) -Xlint -Werror -encoding ASCII -d $(BUILDTESTDIR)/basic/classes $(TESTDIR)/basic/Basic.java
+	echo Basic.java compiled at `date` > $@
+
 $(BUILDTESTDIR)/Basic.othervm.ok \
 $(BUILDTESTDIR)/Basic.agentvm.ok: \
-                $(ALL_JTREG_JARS) \
-		$(TESTDIR)/basic/Basic.java \
+		$(BUILDTESTDIR)/Basic.classes.ok \
 		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.config.ok \
 		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.report.ok \
 		$(BUILDTESTDIR)/i18n.com.sun.javatest.regtest.tool.ok \
 	        $(BASIC.files)
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
-	$(MKDIR) -p $(@:%.ok=%/work/scratch) $(@:%.ok=%/report) $(BUILDTESTDIR)/basic/classes
-	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
-		$(JDKJAVAC) -Xlint -Werror -encoding ASCII -d $(BUILDTESTDIR)/basic/classes $(TESTDIR)/basic/Basic.java
+	$(MKDIR) -p $(@:%.ok=%/work/scratch) $(@:%.ok=%/report)
 	cd $(@:%.ok=%/work/scratch) ; \
 	    $(JDKJAVA) \
 		-cp "../../../basic/classes$(PS)$(JTREG_IMAGEJARDIR)/jtreg.jar" \
@@ -95,9 +100,7 @@ $(BUILDTESTDIR)/Basic.agentvm.ok: \
 	    || (cat ../../log ; exit 1)
 	echo $@ passed at `date` > $@
 
-ifndef HEADLESS
 INITIAL_TESTS += \
 	$(BUILDTESTDIR)/Basic.othervm.ok \
 	$(BUILDTESTDIR)/Basic.agentvm.ok
-endif
 

--- a/test/basic/ReportOnlyTest.gmk
+++ b/test/basic/ReportOnlyTest.gmk
@@ -25,6 +25,14 @@
 
 #----------------------------------------------------------------------
 
+ifdef HEADLESS
+REPORT_EXPECT_PASS = 91
+REPORT_EXPECT_FAIL = 40
+else
+REPORT_EXPECT_PASS = 93
+REPORT_EXPECT_FAIL = 44
+endif
+
 # for full JavaTest gui, add "-gui" to jtreg call
 $(BUILDTESTDIR)/ReportOnlyTest.ok: $(BUILDTESTDIR)/Basic.othervm.ok \
 		   $(JTREG_IMAGEDIR)/lib/javatest.jar \
@@ -38,10 +46,8 @@ $(BUILDTESTDIR)/ReportOnlyTest.ok: $(BUILDTESTDIR)/Basic.othervm.ok \
 		$(TESTDIR)/share/basic \
 			> $(@:%.ok=%.jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: 93; failed: 44; error: 88' $(@:%.ok=%.jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: $(REPORT_EXPECT_PASS); failed: $(REPORT_EXPECT_FAIL); error: 88' $(@:%.ok=%.jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
-ifndef HEADLESS
 TESTS.jtreg += $(BUILDTESTDIR)/ReportOnlyTest.ok
-endif
 

--- a/test/env/EnvTest.gmk
+++ b/test/env/EnvTest.gmk
@@ -25,6 +25,10 @@
 
 ENV.files := $(shell find $(TESTDIR)/env -type f)
 
+ifdef HEADLESS
+ENV_JTREG_OPT = -k:!needDisplay
+endif
+
 $(BUILDTESTDIR)/EnvTest.simple.ok: $(ENV.files) \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
@@ -37,13 +41,14 @@ $(BUILDTESTDIR)/EnvTest.simple.ok: $(ENV.files) \
 	  echo "test.tool.vm.opts=" ; \
 	  echo "test.compiler.opts=" ; \
 	  echo "test.java.opts="; \
-	  echo "test.jdk=$(JDK6HOME)"; \
-	  echo "compile.jdk=$(JDK6HOME)" ) > $(@:%.ok=%/ref.properties)
+	  echo "test.jdk=$(JDK8HOME)"; \
+	  echo "compile.jdk=$(JDK8HOME)" ) > $(@:%.ok=%/ref.properties)
 	JT_JAVA=$(JDKHOME) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
-		-jdk:$(JDK6HOME) \
+		-jdk:$(JDK8HOME) \
 		-e:refprops=`cd $(@:%.ok=%); pwd`/ref.properties \
 		-va \
+		$(ENV_JTREG_OPT) \
 		$(TESTDIR)/env \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    ( cat $(@:%.ok=%/jt.log) ; exit 1 )
@@ -61,17 +66,18 @@ $(BUILDTESTDIR)/EnvTest.full.ok: $(ENV.files) \
 	  echo "test.tool.vm.opts=-J-DVM_OPT=vm_opt" ; \
 	  echo "test.compiler.opts=-XDJAVAC_OPT=javac_opt" ; \
 	  echo "test.java.opts=-DJAVA_OPT=java_opt"; \
-	  echo "test.jdk=$(JDK7HOME)"; \
-	  echo "compile.jdk=$(JDK6HOME)" ) > $(@:%.ok=%/ref.properties)
+	  echo "test.jdk=$(JDK9HOME)"; \
+	  echo "compile.jdk=$(JDK8HOME)" ) > $(@:%.ok=%/ref.properties)
 	JT_JAVA=$(JDKHOME) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
-		-compilejdk:$(JDK6HOME) \
-		-testjdk:$(JDK7HOME) \
+		-compilejdk:$(JDK8HOME) \
+		-testjdk:$(JDK9HOME) \
 		-vmoption:-DVM_OPT=vm_opt \
 		-javaoption:-DJAVA_OPT=java_opt \
 		-javacoption:-XDJAVAC_OPT=javac_opt \
 		-e:refprops=`cd $(@:%.ok=%); pwd`/ref.properties \
 		-va \
+		$(ENV_JTREG_OPT) \
 		$(TESTDIR)/env \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    ( cat $(@:%.ok=%/jt.log) ; exit 1 )
@@ -79,13 +85,11 @@ $(BUILDTESTDIR)/EnvTest.full.ok: $(ENV.files) \
 
 
 ifneq ($(OS_NAME), windows)
-ifdef JDK6HOME
-ifdef JDK7HOME
-ifndef HEADLESS
+ifdef JDK8HOME
+ifdef JDK9HOME
 TESTS.jtreg += \
 	$(BUILDTESTDIR)/EnvTest.simple.ok \
 	$(BUILDTESTDIR)/EnvTest.full.ok
-endif
 endif
 endif
 endif

--- a/test/env/TEST.ROOT
+++ b/test/env/TEST.ROOT
@@ -1,1 +1,2 @@
 requiredVersion = 4.2 b08
+keys = needDisplay

--- a/test/env/applet/AppletTest1.html
+++ b/test/env/applet/AppletTest1.html
@@ -24,6 +24,7 @@
 
 <!--
   @test
+  @key needDisplay
   @build AppletTest
   @run applet AppletTest1.html
 -->

--- a/test/env/applet/AppletTest2.html
+++ b/test/env/applet/AppletTest2.html
@@ -24,6 +24,7 @@
 
 <!--
   @test
+  @key needDisplay
   @library lib
   @build AppletTest
   @run applet AppletTest2.html

--- a/test/env/applet/AppletTest3.html
+++ b/test/env/applet/AppletTest3.html
@@ -24,6 +24,7 @@
 
 <!--
   @test
+  @key needDisplay
   @library ../lib
   @build AppletTest
   @run applet AppletTest3.html

--- a/test/env/applet/AppletTest4.html
+++ b/test/env/applet/AppletTest4.html
@@ -24,6 +24,7 @@
 
 <!--
   @test
+  @key needDisplay
   @library /lib
   @build AppletTest
   @run applet AppletTest4.html

--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -29,6 +29,13 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok:  JAVAOPTION =-javaoption:-Dmy.java.option=
 $(BUILDTESTDIR)/RerunTest.agentvm.ok \
 $(BUILDTESTDIR)/RerunTest.othervm.ok:  JAVACOPTION=-javacoption:-XDmy.javac.option=x
 
+ifdef HEADLESS
+RERUN_JTREG_OPT = -k:!needDisplay
+RERUN_EXPECT_PASS = 9
+else
+RERUN_EXPECT_PASS = 10
+endif
+
 $(BUILDTESTDIR)/RerunTest.agentvm.ok \
 $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
@@ -43,12 +50,14 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 		-jdk:$(JDK8HOME) \
 		-verbose:summary \
 		-e:MY_ENV_VAR=x -vmoption:-Dmy.vm.option=x $(JAVAOPTION) $(JAVACOPTION) \
-                -ignore:run \
+		-ignore:run \
+		$(RERUN_JTREG_OPT) \
 		$(@:$(BUILDTESTDIR)/RerunTest.%.ok=-%) \
 		$(TESTDIR)/rerun  \
 			> $(@:%.ok=%/jt.log) 2>&1
-	$(GREP) -s 'Test results: passed: 10' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: $(RERUN_EXPECT_PASS)' $(@:%.ok=%/jt.log)  > /dev/null
 	for i in `cd $(TESTDIR)/rerun ; ls */*.sh */*.java` ; do \
+	    if [ -n "$(HEADLESS)" -a $$i = std/AppletTest.java ]; then continue; fi ; \
 	    echo Checking $(@:$(BUILDTESTDIR)/RerunTest.%.ok=%) $$i ; \
 	    mkdir -p `dirname $(@:%.ok=%)/out/$$i` ; \
 	    JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg \
@@ -77,10 +86,8 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 
 ifdef JDK8HOME
 ifneq ($(OS_NAME), windows)
-ifndef HEADLESS
 TESTS.jtreg += \
 	$(BUILDTESTDIR)/RerunTest.agentvm.ok \
 	$(BUILDTESTDIR)/RerunTest.othervm.ok
-endif
 endif
 endif

--- a/test/rerun/TEST.ROOT
+++ b/test/rerun/TEST.ROOT
@@ -1,2 +1,3 @@
 requiredVersion = 4.2 b08
 TestNG.dirs = testng
+keys = needDisplay

--- a/test/rerun/std/AppletTest.java
+++ b/test/rerun/std/AppletTest.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @key needDisplay
  * @run applet AppletTest.html
  */
 

--- a/test/share/basic/TEST.ROOT
+++ b/test/share/basic/TEST.ROOT
@@ -4,7 +4,7 @@
 # Mark Reinhold (mr@eng).
 
 # The list of acceptable keys for this testsuite.
-keys=2d dnd i18n
+keys=2d dnd i18n needDisplay
 
 # TestNG subdirectories
 TestNG.dirs=testng/group

--- a/test/share/basic/applet/ExitNonZero.java
+++ b/test/share/basic/applet/ExitNonZero.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @summary Failed: Unexpected exit from test [exit code: 1]
+ * @key needDisplay
  * @run applet ExitNonZero.html
  */
 

--- a/test/share/basic/applet/ExitZero.java
+++ b/test/share/basic/applet/ExitZero.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @summary Failed: Unexpected exit from test [exit code: 0]
+ * @key needDisplay
  * @run applet ExitZero.html
  */
 

--- a/test/share/basic/applet/Fail.java
+++ b/test/share/basic/applet/Fail.java
@@ -23,41 +23,49 @@
 
 /* @test
  * @summary Failed: Execution failed: Applet thread threw exception: java.lang.RuntimeException: I should fail
+ * @key needDisplay
  * @run applet Fail.html
  */
 
 /* @test
  * @summary Failed: Execution failed: Applet thread threw exception: java.lang.RuntimeException: I should fail
+ * @key needDisplay
  * @run applet/manual Fail.html
  */
 
 /* @test
  * @summary Failed: Execution failed: Applet thread threw exception: java.lang.RuntimeException: I should fail
+ * @key needDisplay
  * @run applet/manual=yesno Fail.html
  */
 
 /* @test
  * @summary Failed: Execution failed: Applet thread threw exception: java.lang.RuntimeException: I should fail
+ * @key needDisplay
  * @run applet/manual=done Fail.html
  */
 
 /* @test
  * @summary Passed: Execution failed as expected
+ * @key needDisplay
  * @run applet/fail Fail.html
  */
 
 /* @test
  * @summary Passed: Execution failed as expected
+ * @key needDisplay
  * @run applet/manual/fail Fail.html
  */
 
 /* @test
  * @summary Passed: Execution failed as expected
+ * @key needDisplay
  * @run applet/manual=yesno/fail Fail.html
  */
 
 /* @test
  * @summary Passed: Execution failed as expected
+ * @key needDisplay
  * @run applet/manual=done/fail Fail.html
  */
 import java.applet.Applet;

--- a/test/share/basic/applet/Pass.java
+++ b/test/share/basic/applet/Pass.java
@@ -23,41 +23,49 @@
 
 /* @test
  * @summary Passed: Execution successful
+ * @key needDisplay
  * @run applet Pass.html
  */
 
 /* @test
  * @summary Passed: Execution successful
+ * @key needDisplay
  * @run applet/manual Pass.html
  */
 
 /* @test
  * @summary ...Manual test, user evaluated: Result depends on user selection
+ * @key needDisplay
  * @run applet/manual=yesno Pass.html
  */
 
 /* @test
  * @summary Passed: Manual test: Execution successful
+ * @key needDisplay
  * @run applet/manual=done Pass.html
  */
 
 /* @test
  * @summary Failed: Execution passed unexpectedly
+ * @key needDisplay
  * @run applet/fail Pass.html
  */
 
 /* @test
  * @summary Result depends on user selection
+ * @key needDisplay
  * @run applet/manual/fail Pass.html
  */
 
 /* @test
  * @summary ...Manual test, user evaluated: Result depends on user selection
+ * @key needDisplay
  * @run applet/manual=yesno/fail Pass.html
  */
 
 /* @test
  * @summary Failed: Manual test: Execution passed unexpectedly
+ * @key needDisplay
  * @run applet/manual=done/fail Pass.html
  */
 import java.applet.Applet;


### PR DESCRIPTION
Please review a mostly-test-only fix to run more tests when running in HEADLESS mode, such as in GitHub Actions.

4 jtreg self-tests, including the important `Basic` tests, involve test suites with `@run applet` tests. These tests fail on a headless system, and were previously disabled on such systems by using `ifndef HEADLESS` to exclude the tests from execution. But these tests exercise more than just applet functionality, and excluding the entire test is too drastic a solution.

The change is to always enable these tests, modifying their behavior to avoid using the parts of the test that use `@run applet`.

The changes fall into 5 groups:

1. `Agent.java` ... if the `java.awt.headless` property is set in jtreg, it is propagated to any agents that are started. This is primarily for testing/debugging. The property does not normally need to be set, even on a headless system.

2. The `Basic` tests ... a new keyword is added to those tests in the `basic` suite that should not be run in headless mode, which is determined automatically by calling `GraphicsEnvironment.isHeadless()`.  The expected  number of tests in different categories is adjusted accordingly.  Note that bad/malformed tests using `@run applet` are not affected, because they result in an `Error` result and the action is never invoked.

3. `ReportOnlyTest` ... this is a follow-up to the `Basic` tests, to verify the test counts are reported accurately in report-only mode. If HEADLESS is set, the expected numbers of passed and failed tests are adjusted.

4. `EnvTests` ... as with the `Basic` tests, a new keyword is added to applet tests, so that if HEADLESS is set, the applet tests are not executed. The tests are also modified to use JDK 8 and 9 as older versions, instead of JDK 6 and 7.

5. `Rerun tests` ... similar to the preceding cases. If HEADLESS is set, the applet tests are not executed, the expected number of tests is modified, and the applet tests are ignored when checking the rerun info.

## Testing

Locally, the modifications are tested by a combination of setting `-Djava.awt.headless=true` for the `Basic` tests and `HEADLESS` for the other tests.

More notably, the `Basic` and `ReportOnlyTest` tests are seen to be executed, and pass, in the Github Actions for the repo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903223](https://bugs.openjdk.org/browse/CODETOOLS-7903223): Enable no-display-required parts of Basic tests in HEADLESS mode


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.org/jtreg pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/92.diff">https://git.openjdk.org/jtreg/pull/92.diff</a>

</details>
