### PR TITLE
CODETOOLS-7903225: StringIndexOutOfBoundsException in ReportOnlyTest

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -59,7 +59,7 @@ import com.sun.javatest.util.I18NResourceBundle;
  * Manage tests to be run by jtreg.
  */
 public class TestManager {
-    public class NoTests extends Fault {
+    public static class NoTests extends Fault {
         private static final long serialVersionUID = 1L;
 
         public NoTests() {
@@ -76,7 +76,7 @@ public class TestManager {
 
     Map<Path, Entry> map = new TreeMap<>();
 
-    private class Entry {
+    private static class Entry {
         final Path rootDir;
         boolean all = false;
         Map<String, Boolean> files = new LinkedHashMap<>();
@@ -131,7 +131,7 @@ public class TestManager {
             throw new Fault(i18n, "tm.cantDetermineTestSuite", tf);
 
         Entry e = getEntry(rootDir);
-        if (tf.equals(rootDir)) {
+        if (f.equals(rootDir)) {
             e.all = true;
             e.files.clear();
         } else if (!e.all) {
@@ -169,7 +169,7 @@ public class TestManager {
                 if (!e.testSuite.getRootDir().toPath().equals(e.rootDir)) {
                     System.err.println("e.testSuite.getRootDir(): " + e.testSuite.getRootDir());
                     System.err.println("e.rootDir: " + e.rootDir);
-                    System.err.println(e.testSuite.getRootDir().equals(e.rootDir));
+                    System.err.println(e.testSuite.getRootDir().toPath().equals(e.rootDir));
                     throw new AssertionError();
                 }
                 } catch (TestSuite.Fault f) {
@@ -211,9 +211,7 @@ public class TestManager {
                     e.workDir = WorkDirectory.convert(wdf, ts);
                 else
                     e.workDir = WorkDirectory.create(wdf, ts);
-            } catch (WorkDirectory.Fault ex) {
-                throw new Fault(i18n, "tm.cantRead", wd.getFileName().toString(), ex);
-            } catch (FileNotFoundException ex) {
+            } catch (WorkDirectory.Fault | FileNotFoundException ex) {
                 throw new Fault(i18n, "tm.cantRead", wd.getFileName().toString(), ex);
             }
         }
@@ -305,9 +303,9 @@ public class TestManager {
                 File f = new File(rootDir, path);
                 if (f.isDirectory())
                     return true;
-                TreeIterator iter = trt.getIterator(new String[] { path }, new TestFilter[0]);
+                TreeIterator iter = trt.getIterator(new String[] { path });
                 while (iter.hasNext()) {
-                    TestResult tr = (TestResult) iter.next();
+                    TestResult tr = iter.next();
                     String trp = tr.getDescription().getRootRelativePath();
                     if (path.equals(trp))
                         return true;

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1124,7 +1124,7 @@ public class Tool {
         testManager.addGroups(testGroupArgs);
 
         if (testManager.isEmpty())
-            throw testManager.new NoTests();
+            throw new TestManager.NoTests();
 
         boolean multiRun = testManager.isMultiRun();
 

--- a/test/badgroups/BadGroups.gmk
+++ b/test/badgroups/BadGroups.gmk
@@ -33,7 +33,7 @@ $(BUILDTESTDIR)/BadGroups_badname.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(TESTDIR)/badgroups/$(@:$(BUILDTESTDIR)/BadGroups_%.ok=%) \
+		$(TESTDIR)/badgroups/$(@:$(BUILDTESTDIR)/BadGroups_%.ok=%)/Test.java \
                 > $(@:%.ok=%)/jt.log 2>&1 ; \
             status=$$? ; echo status=$$status ; \
             if [ "$$status" != "0" ]; then echo "unexpected exit: $$status" ; exit 1; fi
@@ -52,7 +52,7 @@ $(BUILDTESTDIR)/BadGroups_badname51.ok: \
 		-J-DOVERRIDE-jtreg-Build=b01 \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(TESTDIR)/badgroups/$(@:$(BUILDTESTDIR)/BadGroups_%.ok=%) \
+		$(TESTDIR)/badgroups/$(@:$(BUILDTESTDIR)/BadGroups_%.ok=%)/Test.java \
                 > $(@:%.ok=%)/jt.log 2>&1 ; \
             status=$$? ; echo status=$$status ; \
             if [ "$$status" != "5" ]; then echo "unexpected exit: $$status" ; exit 1; fi
@@ -60,4 +60,4 @@ $(BUILDTESTDIR)/BadGroups_badname51.ok: \
 	$(GREP) "Error: One or more groups are invalid" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDTESTDIR)/BadGroups_badname.ok
+TESTS.jtreg += $(BUILDTESTDIR)/BadGroups_badname51.ok


### PR DESCRIPTION
Please review a minor fix to address a hitherto unnoticed exception that occurred while running `ReportOnlyTest`.

The immediate cause was an empty string for a test file being passed down into JT Harness from jtreg, 

The root cause is a bad check in `TestManager`, comparing the wrong form of a path (relative, not canonical) against the canonical file for the test suite root. This indirectly leads to computing an empty relative path between the two, causing the issue.  The fix is to compare the correct form of the path, in `TestManager.java` line 34.

The fix exposes a minor issue in another test, to detect bad groups.  The issue is on the command line where the path for the test-suite root is provided. Because of the preceding fix, that path is now recognized as the root of the test suite, meaning "all tests in the test suite", which disables the need to check groups. The fix is to specify a test within the test suite, which allows the groups to be checked.     There was a latest typo in one of the test target names in the makefile, which is corrected.

Other changes in TestManager and Tool are from fixing warnings reported by the IDE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903225](https://bugs.openjdk.org/browse/CODETOOLS-7903225): StringIndexOutOfBoundsException in ReportOnlyTest


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.org/jtreg pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/93.diff">https://git.openjdk.org/jtreg/pull/93.diff</a>

</details>
