### PR TITLE
CODETOOLS-7903228: RerunTest2 fails with an alternate build directory

### DIFF
--- a/test/rerun2/RerunTest2.gmk
+++ b/test/rerun2/RerunTest2.gmk
@@ -27,22 +27,21 @@
 
 $(BUILDTESTDIR)/RerunTest2.ok: \
 	    $(TESTDIR)/rerun2/RerunTest2.java \
-	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
-	    $(JTREG_IMAGEDIR)/lib/junit.jar \
-	    $(JTREG_IMAGEDIR)/lib/testng.jar \
+	    $(ALL_JTREG_JARS) \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
-	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(RM) $(@:%.ok=%) ; $(MKDIR) -p $(@:%.ok=%)
 	$(MKDIR) $(@:%.ok=%)/classes
 	$(JDKHOME)/bin/javac \
 		-d $(@:%.ok=%)/classes \
 		-cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-Xlint -Werror \
 		$(TESTDIR)/rerun2/RerunTest2.java
+	ABS_TESTDIR=`cd $(TESTDIR) ; pwd` ; \
 	cd $(@:%.ok=%) && $(JDKJAVA) \
 		-classpath classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		RerunTest2 \
 		$(JDK8HOME) \
-		../../$(TESTDIR)/rerun2/test
+		$${ABS_TESTDIR}/rerun2/test
 	echo "test passed at `date`" > $@
 
 ifdef JDK8HOME


### PR DESCRIPTION
Please review a test fix for another test that fails when run with an alternate location for the build directory.

The fix is as before, ensure to use absolute paths after using `cd` within a make rule.

With this fix in place, there should be  no more test failures when running with an alternate build directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903228](https://bugs.openjdk.org/browse/CODETOOLS-7903228): RerunTest2 fails with an alternate build directory


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jtreg pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/95.diff">https://git.openjdk.org/jtreg/pull/95.diff</a>

</details>
