### PR TITLE
7903217: jtreg could try killing descendants of stuck test, before timing out the test

### DIFF
--- a/src/share/classes/com/sun/javatest/diff/SuperDiff.java
+++ b/src/share/classes/com/sun/javatest/diff/SuperDiff.java
@@ -282,8 +282,8 @@ class SuperDiff extends Diff {
             return infoTable.get(path);
         }
 
-        final Set<String> platforms = new TreeSet<>();
-        final Map<String, Info> infoTable = new HashMap<>();
+        final transient Set<String> platforms = new TreeSet<>();
+        final transient Map<String, Info> infoTable = new HashMap<>();
     }
 
     static class YearDay implements Comparable<YearDay> {

--- a/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
+++ b/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
@@ -156,7 +156,7 @@ public abstract class TimeoutHandler {
      * @param proc the process
      * @return The process id, or 0 if the process id cannot be found
      */
-    protected long getProcessId(Process proc) {
+    public long getProcessId(Process proc) {
         try {
             try {
                 Method pid = Process.class.getMethod("pid");

--- a/src/share/classes/com/sun/javatest/regtest/exec/ProcessCommand.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ProcessCommand.java
@@ -254,33 +254,51 @@ public class ProcessCommand
             if (timeout > 0) {
                 final Thread victim = Thread.currentThread();
                 pre_alarm = Alarm.schedule(timeout, TimeUnit.MILLISECONDS, out, new Runnable() {
-                  // at the timeout, as the last resort, we will exit all the (possibly hanging),
-                  // descendants of the process, in the hope that doing so will unstuck the process itself
-                  public void run() {
-                    long pid = getTimeoutHandler().getProcessId(process);
-                    Optional<ProcessHandle> oph = ProcessHandle.of(pid);
-                    if (oph.isPresent()) {
-                      ProcessHandle processHandle = oph.get();
-                      Stream<ProcessHandle> descendants = processHandle.descendants();
-                      long count = descendants.count();
-                      if (count > 0) {
-                        System.err.println("Detected a possibly stuck process (pid:"+pid+") with "+count+" descendants");
-                        System.err.println("Attempting to kill:");
-                        descendants = processHandle.descendants();
-                        descendants.forEachOrdered(child -> System.err.println(" child process with pid:"+child.pid()));
-                        descendants = processHandle.descendants();
-                        descendants.forEachOrdered(child -> child.destroy());
-                        descendants = processHandle.descendants();
-                        descendants.forEachOrdered(child -> child.destroyForcibly());
-                      }
+                    // at the timeout, as the last resort, we will exit all the (possibly hanging),
+                    // descendants of the process, in the hope that doing so will unstuck the process itself
+                    public void run() {
+                        long pid = getTimeoutHandler().getProcessId(process);
+                        Optional<ProcessHandle> oph = ProcessHandle.of(pid);
+                        if (oph.isPresent()) {
+                            ProcessHandle processHandle = oph.get();
+                            Stream<ProcessHandle> descendants = processHandle.descendants();
+                            long count = descendants.count();
+                            if (count > 0) {
+                                OutputStream processOut = process.getOutputStream();  // input stream to process
+                                if (processOut != null) {
+                                    try {
+                                        processOut.write(new String("Detected a possibly stuck process (pid:"+pid+") with "+count+" descendants").getBytes());
+                                        processOut.write(new String("Attempting to kill:").getBytes());
+                                    } catch (IOException e) {
+                                        // ignore
+                                    }
+                                }
+                                descendants = processHandle.descendants();
+                                if (processOut != null) {
+                                    List<Long> pids = new java.util.ArrayList<Long>();
+                                    descendants.forEachOrdered(child -> pids.add(Long.valueOf(child.pid())));
+                                    try {
+                                        for (Long l : pids) {
+                                            processOut.write(new String(" child process with pid:"+l.longValue()).getBytes());
+                                        }
+                                        processOut.flush();
+                                    } catch (IOException e) {
+                                        // ignore
+                                    }
+                                }
+                                descendants = processHandle.descendants();
+                                descendants.forEachOrdered(child -> child.destroy());
+                                descendants = processHandle.descendants();
+                                descendants.forEachOrdered(child -> child.destroyForcibly());
+                            }
+                        }
                     }
-                  }
                 });
                 alarm = Alarm.schedule(timeout+PRE_ALARM_TIME_MS, TimeUnit.MILLISECONDS, out, new Runnable() {
-                  // if we reach here, then we tried everything and the only option now is to timeout
-                  public void run() {
-                    invokeTimeoutHandler(timeoutHandler, timeoutHandlerDone, process, victim);
-                  }
+                    // if we reach here, then we tried everything and the only option now is to timeout
+                    public void run() {
+                        invokeTimeoutHandler(timeoutHandler, timeoutHandlerDone, process, victim);
+                    }
                 });
             }
 


### PR DESCRIPTION
This is an enhancement that aims to improve the robustness of the testing by attempting to quit any child processes (that are possibly stuck and are blocking the parent process from terminating) before timing out the target parent process.

Aborting a process will flush its stdout/stderr streams, which will hopefully get captured in the test's log and provide additional clues as to why a test was timing out.

This enhancement was locally tested with a handcrafted test that itself launched a child process that would get stuck on purpose and worked as intended.

Hopefully, this will help debug issues such as [JDK-8286345](https://bugs.openjdk.org/browse/JDK-8286345)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903217](https://bugs.openjdk.org/browse/CODETOOLS-7903217): jtreg could try killing descendants of stuck test, before timing out the test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jtreg pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/97.diff">https://git.openjdk.org/jtreg/pull/97.diff</a>

</details>
