### PR TITLE
CODETOOLS-7903245: Save copy of `make` command after running `make/build.sh`

### DIFF
--- a/make/build.sh
+++ b/make/build.sh
@@ -764,20 +764,27 @@ if [ -n "${SKIP_MAKE:-}" ]; then
     exit
 fi
 
-# Build jtreg
+# save make command for possible later reuse, bypassing this script
+mkdir -p ${BUILD_DIR}
+cat > ${BUILD_DIR}/make.sh << EOF
+#!/bin/sh
+
 cd "${ROOT}/make"
-make ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \
-     ASMTOOLS_NOTICES="${ASMTOOLS_NOTICES}"                   \
-     BUILDDIR="${BUILD_DIR}"                                  \
-     BUILD_MILESTONE="${JTREG_BUILD_MILESTONE}"               \
-     BUILD_NUMBER="${JTREG_BUILD_NUMBER}"                     \
-     BUILD_VERSION="${JTREG_VERSION}"                         \
-     BUILD_VERSION_STRING="${JTREG_VERSION_STRING}"           \
-     JAVATEST_JAR="$(mixed_path "${JTHARNESS_JAVATEST_JAR}")" \
-     JDKHOME="$(mixed_path ${JAVA_HOME})"                     \
-     JTHARNESS_NOTICES="${JTHARNESS_NOTICES}"                 \
-     JUNIT_JARS="${JUNIT_JARS}"                               \
-     JUNIT_NOTICES="${JUNIT_NOTICES}"                         \
-     TESTNG_JARS="${TESTNG_JARS}"                             \
-     TESTNG_NOTICES="${TESTNG_NOTICES}"                       \
+make ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
+     ASMTOOLS_NOTICES="${ASMTOOLS_NOTICES}"                   \\
+     BUILDDIR="${BUILD_DIR}"                                  \\
+     BUILD_MILESTONE="${JTREG_BUILD_MILESTONE}"               \\
+     BUILD_NUMBER="${JTREG_BUILD_NUMBER}"                     \\
+     BUILD_VERSION="${JTREG_VERSION}"                         \\
+     BUILD_VERSION_STRING="${JTREG_VERSION_STRING}"           \\
+     JAVATEST_JAR="$(mixed_path "${JTHARNESS_JAVATEST_JAR}")" \\
+     JDKHOME="$(mixed_path ${JAVA_HOME})"                     \\
+     JTHARNESS_NOTICES="${JTHARNESS_NOTICES}"                 \\
+     JUNIT_JARS="${JUNIT_JARS}"                               \\
+     JUNIT_NOTICES="${JUNIT_NOTICES}"                         \\
+     TESTNG_JARS="${TESTNG_JARS}"                             \\
+     TESTNG_NOTICES="${TESTNG_NOTICES}"                       \\
    ${MAKE_ARGS:-}
+EOF
+
+sh ${BUILD_DIR}/make.sh


### PR DESCRIPTION
Please review a simple change to save a copy of the make command generated by `make/build.sh`, for later reuse to bypass downloading and building dependencies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903245](https://bugs.openjdk.org/browse/CODETOOLS-7903245): Save copy of `make` command after running `make/build.sh`


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jtreg pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/98.diff">https://git.openjdk.org/jtreg/pull/98.diff</a>

</details>
