### PR TITLE
CODETOOLS-7903246: Use homebrew/bin for pandoc if available

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -150,6 +150,8 @@ PANDOC  := $(shell if [ -r /usr/bin/pandoc ]; then \
 		echo /usr/bin/pandoc ; \
 	elif [ -r /usr/local/bin/pandoc ]; then \
 		echo /usr/local/bin/pandoc ; \
+	elif [ -r /opt/homebrew/bin/tidy ]; then \
+		echo /opt/homebrew/bin/pandoc ; \
 	else \
 		echo /bin/echo "pandoc not available" ; \
 	fi )


### PR DESCRIPTION
Please review a simple patch to include `/opt/homebrew/bin` in the list of locations to look for pandoc.