### PR TITLE
CODETOOLS-7903250: RerunTest fails if no display is set

### DIFF
--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -43,7 +43,7 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	unset GNOME_DESKTOP_SESSION_ID ; \
 	unset XMODIFIERS ; \
-	LANG=en_US.UTF-8 TZ=GMT+0.00 \
+	LANG=en_US.UTF-8 TZ=GMT+0.00 DISPLAY=$${DISPLAY:-dummy} \
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-J-Djavatest.regtest.allowTrailingBuild=true \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \


### PR DESCRIPTION
Please review a simple fix for a jtreg self-test, to set a dummy value for DISPLAY if no value already set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903250](https://bugs.openjdk.org/browse/CODETOOLS-7903250): RerunTest fails if no display is set


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/jtreg pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/101.diff">https://git.openjdk.org/jtreg/pull/101.diff</a>

</details>
