### PR TITLE
CODETOOLS-7903251: ProblemList test fails on M1 Mac

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/OS.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/OS.java
@@ -88,6 +88,7 @@ public class OS {
     //
     // On a Mac, we see the following types of values
     //    os.arch              x86_64
+    //    os.arch              aarch64
     //    os.arch              universal
     //    os.name              Darwin
     //    os.name              Mac OS X

--- a/test/problemList/ProblemList.gmk
+++ b/test/problemList/ProblemList.gmk
@@ -50,17 +50,10 @@ $(BUILDTESTDIR)/ProblemList.ok: \
 			> $(@:%.ok=%/1/jt.log) 2>&1 
 	$(GREP) -s 'Test results: passed: 6' $(@:%.ok=%/1/jt.log)  > /dev/null
 	$(MKDIR) $(@:%.ok=%)/2
-	@echo OS_ARCH $(OS_ARCH)
-	@echo OS_ARCH2 $(OS_ARCH2)
-	@echo OS_NAME $(OS_NAME)
-	@echo OS_VERSION $(OS_VERSION)
-	@echo PLATFORM_OS $(PLATFORM_OS)
-	cat $(TESTDIR)/problemList/ProblemList.template | sed \
-		-e 's/OSNAME-\([A-Za-z]*\)$$/$(OS_NAME)-\1/' \
-		-e 's/\([A-Za-z]*\)-ARCH2$$/\1-$(OS_ARCH2)/' \
-		-e 's/\([A-Za-z]*\)-ARCH$$/\1-$(OS_ARCH)/' \
-		-e 's/\([A-Za-z]*\)-REV$$/\1-$(OS_VERSION)/' \
-		> $(@:%.ok=%)/2/ProblemList.txt
+	$(JDKHOME)/bin/javac -d $(@:%.ok=%)/classes $(TESTDIR)/problemList/ProblemList.java
+	$(JDKHOME)/bin/java -cp $(@:%.ok=%)/classes ProblemList \
+	    $(TESTDIR)/problemList/ProblemList.template \
+	    > $(@:%.ok=%)/2/ProblemList.txt
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/2/work -r:$(@:%.ok=%)/2/report \
 		-jdk:$(JDKHOME) \

--- a/test/problemList/ProblemList.java
+++ b/test/problemList/ProblemList.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Reads the file given on the command line as a problem-list template,
+ * substitutes values, and writes the result to System.out.
+ */
+class ProblemList {
+    public static void main(String... args) throws IOException {
+        new ProblemList().run(args);
+    }
+
+    void run(String... args) throws IOException {
+        String osName = System.getProperty("os.name");
+        String osArch = System.getProperty("os.arch");
+        String osVersion = System.getProperty("os.version");
+
+        List<String> lines = Files.readAllLines(Path.of(args[0]));
+        lines.stream()
+                .map(l -> l.startsWith("#") ? l
+                        : l.replace("OSNAME", standardize(osName))
+                            .replace("ARCH", standardize(osArch))
+                            .replace("REV", standardize(osVersion)))
+                .forEach(System.out::println);
+    }
+
+    static String standardize(String s) {
+        return s.replaceAll("\\s+", "").toLowerCase(Locale.ROOT);
+    }
+}


### PR DESCRIPTION
Please review a test fix for a jtreg self-test.(There's also an update to a comment in a source file.)

This one is somewhat interesting.  Despite the name `System.getProperty("os.arch")` depends on the JDK being run, more than anything derived from `uname`.  In particular, for older JDKs on an M1 Mac, they report `os.arch` as the older `x86_64`, since older JDKs, up to JDK 11.0.15 inclusive, do not come as `aarch64` binaries.   But newer JDKs do report `os.arch` as `aarch64`.   

The fix for the test is to use the JDK being tested to update the problem-list template with the values that it will recognize when used as the test OS.  Tested with `JDKHOME` set to  JDK 11.0.15 and JDK 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903251](https://bugs.openjdk.org/browse/CODETOOLS-7903251): ProblemList test fails on M1 Mac


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.org/jtreg pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/102.diff">https://git.openjdk.org/jtreg/pull/102.diff</a>

</details>
