### PR TITLE
CODETOOLS-7903254: Fix trailing whitespace in files

### DIFF
--- a/make/Rules.gmk
+++ b/make/Rules.gmk
@@ -61,7 +61,7 @@ $(CLASSDIR) $(BUILDDIR) $(BUILDDIR)/testClasses $(BUILDDIR)/testWork $(BUILDDIR)
 JAR_COPYRIGHT = -C $(TOPDIR) COPYRIGHT
 
 $(IMAGES_DIR)/%.jar: pkgsToFiles.sh
-	$(RM) $@ $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%) 
+	$(RM) $@ $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%)
 	$(MKDIR) -p $(@D)
 	$(MKDIR) -p $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%)
 	( if [ -n "$(JAR_MAINCLASS)" ]; then echo "Main-class: $(JAR_MAINCLASS)" ; fi ; \
@@ -88,7 +88,7 @@ $(IMAGES_DIR)/%.jar: pkgsToFiles.sh
 #
 # Build zips with verbose names
 
-%-$(VERBOSE_ZIP_SUFFIX).zip: %.zip 
+%-$(VERBOSE_ZIP_SUFFIX).zip: %.zip
 	$(CP) $(@:%-$(VERBOSE_ZIP_SUFFIX).zip=%.zip) $@
 
 %-$(NEW_VERBOSE_ZIP_SUFFIX).zip: %.zip

--- a/make/jtdiff.gmk
+++ b/make/jtdiff.gmk
@@ -32,7 +32,7 @@ JAVAFILES.com.sun.javatest.diff := \
 
 $(BUILDDIR)/classes.com.sun.javatest.diff.ok: \
 		$(JAVAFILES.com.sun.javatest.diff) \
-		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok 
+		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok
 	CLASSPATH="$(CLASSDIR)$(PS)$(JAVATEST_JAR)$(PS)$(ANT_JAR)" \
 	    $(REGTEST_TOOL_JAVAC) $(REGTEST_TOOL_JAVAC_OPTIONS) \
 		-d $(CLASSDIR) \
@@ -62,7 +62,7 @@ TARGETS.JAR.jtreg += $(TARGETS.com.sun.javatest.diff)
 #
 # executable scripts
 
-$(JTREG_IMAGEDIR)/bin/jtdiff: $(SRCSHAREBINDIR)/jtdiff.sh 
+$(JTREG_IMAGEDIR)/bin/jtdiff: $(SRCSHAREBINDIR)/jtdiff.sh
 	$(MKDIR) -p $(@D)
 	$(RM) $@
 	$(CP) $<  $@
@@ -73,6 +73,6 @@ TARGETS.ZIP.jtreg += \
 
 #----------------------------------------------------------------------
 
-TESTS += $(TESTS.jtdiff) 
+TESTS += $(TESTS.jtdiff)
 
 

--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -104,7 +104,7 @@ $(BUILDDIR)/classes/com/sun/javatest/regtest/tool/jars.properties: \
 TARGETS.com.sun.javatest.regtest += $(RESOURCES.com.sun.javatest.regtest)
 
 #----------------------------------------------------------------------
-# 
+#
 # Misc. doc files
 
 JTREG_COPYRIGHT 	= $(JTREG_IMAGEDIR)/COPYRIGHT
@@ -154,7 +154,7 @@ $(JTREG_README): $(SRCJTREGDOCDIR)/README
 	$(RM) $@
 	$(CP) $< $@
 
-$(JTREG_TAGSPEC): $(JTREG_IMAGEDIR)/doc/jtreg/%: $(SRCJTREGDOCDIR)/% 
+$(JTREG_TAGSPEC): $(JTREG_IMAGEDIR)/doc/jtreg/%: $(SRCJTREGDOCDIR)/%
 	$(RM) $@
 	$(MKDIR) -p $(@D)
 	$(CP) $^ $@
@@ -310,7 +310,7 @@ ALL_JTREG_JARS = \
 #
 # executable scripts
 
-$(JTREG_IMAGEDIR)/bin/jtreg: $(SRCSHAREBINDIR)/jtreg.sh 
+$(JTREG_IMAGEDIR)/bin/jtreg: $(SRCSHAREBINDIR)/jtreg.sh
 	$(MKDIR) -p $(@D)
 	$(RM) $@
 	$(CP) $<  $@
@@ -363,5 +363,5 @@ NEWVERBOSEZIPFILES += $(JTREG_ZIPFILES:%.zip=%-$(NEW_VERBOSE_ZIP_SUFFIX).zip)
 #JTREG_JAVA_OPTS = -Ddebug.com.sun.javatest.TestResultCache=98
 #JTREG_OPTS = 	$(JTREG_JAVA_OPTS:%=-J%)
 
-TESTS += $(TESTS.jtreg) 
+TESTS += $(TESTS.jtreg)
 

--- a/test/6783039/T6783039.gmk
+++ b/test/6783039/T6783039.gmk
@@ -27,7 +27,7 @@
 
 $(BUILDTESTDIR)/T6783039.ok: \
 	$(JTREG_IMAGEDIR)/lib/javatest.jar \
-	$(JTREG_IMAGEDIR)/lib/jtreg.jar 
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(RM) $(BUILDTESTDIR)/6783039/
 	for p in p1 p2 ; do for y in 2007 2008 ; do for d in 1 2 3 ; do \
 	    mkdir -p $(BUILDTESTDIR)/6783039/$$p/$$y/$$d/JTreport/text/ ; touch $(BUILDTESTDIR)/6783039/$$p/$$y/$$d/JTreport/text/summary.txt ; \

--- a/test/badgroups/BadGroups.gmk
+++ b/test/badgroups/BadGroups.gmk
@@ -29,7 +29,7 @@
 $(BUILDTESTDIR)/BadGroups_badname.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
-	$(MKDIR) -p $(@:%.ok=%) 
+	$(MKDIR) -p $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
@@ -46,7 +46,7 @@ TESTS.jtreg += $(BUILDTESTDIR)/BadGroups_badname.ok
 $(BUILDTESTDIR)/BadGroups_badname51.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
-	$(MKDIR) -p $(@:%.ok=%) 
+	$(MKDIR) -p $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-J-DOVERRIDE-jtreg-Version=5.1 \
 		-J-DOVERRIDE-jtreg-Build=b01 \

--- a/test/basic/Basic.gmk
+++ b/test/basic/Basic.gmk
@@ -57,7 +57,7 @@ INITIAL_TESTS += \
 
 ENVVARS="DISPLAY=$${DISPLAY:-`uname -n`:0.0}"
 
-ifeq ($(OS_NAME), windows) 
+ifeq ($(OS_NAME), windows)
   BASIC_TESTS := $(shell cygpath -m $(abspath $(TESTDIR)/share/basic) )
 else
   BASIC_TESTS := $(abspath $(TESTDIR)/share/basic)

--- a/test/bootclasspath/BootClassPathTest.gmk
+++ b/test/bootclasspath/BootClassPathTest.gmk
@@ -34,7 +34,7 @@ $(BUILDTESTDIR)/BootClassPathTest.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		$(TESTDIR)/bootclasspath \
-			> $(@:%.ok=%/jt.log) 2>&1 
+			> $(@:%.ok=%/jt.log) 2>&1
 	echo "test passed at `date`" > $@
 
 ifdef JDK8HOME

--- a/test/build-wildcards/buildWildcards.gmk
+++ b/test/build-wildcards/buildWildcards.gmk
@@ -32,7 +32,7 @@ $(BUILDTESTDIR)/BuildWildcards.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		$(TESTDIR)/build-wildcards \
-			> $(@:%.ok=%/jt.log) 2>&1 
+			> $(@:%.ok=%/jt.log) 2>&1
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \

--- a/test/classDirs/ClassDirsTest.gmk
+++ b/test/classDirs/ClassDirsTest.gmk
@@ -29,7 +29,7 @@ $(BUILDTESTDIR)/ClassDirsTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	    $(JTREG_IMAGEDIR)/lib/testng.jar
 	$(RM) $(@:%.ok=%)
-	$(MKDIR) -p $(@:%.ok=%)/classes 
+	$(MKDIR) -p $(@:%.ok=%)/classes
 	$(JDKJAVAC) -d $(@:%.ok=%)/classes \
 		-Xlint -Werror \
 		$(TESTDIR)/classDirs/ClassDirsTest.java

--- a/test/cleanup/CleanupTest.gmk
+++ b/test/cleanup/CleanupTest.gmk
@@ -53,8 +53,8 @@ $(BUILDTESTDIR)/CleanupTests.othervm.ok: \
 
 
 #####
-# In agentvm and othervm mode using concurrency, jtreg should successfully 
-# run each test by moving to a new scratch directory when it can't clear 
+# In agentvm and othervm mode using concurrency, jtreg should successfully
+# run each test by moving to a new scratch directory when it can't clear
 # the previous one.
 
 $(BUILDTESTDIR)/CleanupTests.agentvm.conc.ok \
@@ -106,7 +106,7 @@ $(BUILDTESTDIR)/CleanupTests.agentvm.retain.ok: \
 
 #####
 # In othervm mode with -retain, the tests pass because the
-# problem tests are written directly to the correct location 
+# problem tests are written directly to the correct location
 # and do not need to be moved.
 
 $(BUILDTESTDIR)/CleanupTests.othervm.retain.ok: \

--- a/test/cleanupDirs/CleanupDirsTest.gmk
+++ b/test/cleanupDirs/CleanupDirsTest.gmk
@@ -53,8 +53,8 @@ $(BUILDTESTDIR)/CleanupDirsTests.othervm.ok: \
 
 
 #####
-# In agentvm and othervm mode using concurrency, jtreg should successfully 
-# run each test by moving to a new scratch directory when it can't clear 
+# In agentvm and othervm mode using concurrency, jtreg should successfully
+# run each test by moving to a new scratch directory when it can't clear
 # the previous one.
 # Note: without some form of `-retain`, we cannot rely on (and check for)
 # the final contents of the scratch directories, which depends on which
@@ -110,7 +110,7 @@ $(BUILDTESTDIR)/CleanupDirsTests.agentvm.retain.ok: \
 
 #####
 # In othervm mode with -retain, the tests pass because the
-# problem tests are written directly to the correct location 
+# problem tests are written directly to the correct location
 # and do not need to be moved.
 
 $(BUILDTESTDIR)/CleanupDirsTests.othervm.retain.ok: \

--- a/test/compileArgFileTest/CompileArgFileTest.gmk
+++ b/test/compileArgFileTest/CompileArgFileTest.gmk
@@ -36,7 +36,7 @@ $(BUILDTESTDIR)/CompileArgFileTest.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		$(@:%.ok=%)/tests \
-			> $(@:%.ok=%/jt.log) 2>&1 
+			> $(@:%.ok=%/jt.log) 2>&1
 	$(GREP) -s '^Test results: passed: [0-9]*\s*$$' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 

--- a/test/debug/DebugTest.gmk
+++ b/test/debug/DebugTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-# Although we run the same tests in the same manner (apart from the 
+# Although we run the same tests in the same manner (apart from the
 # mode option) for agentvm and othervm mode, currently, the detection
 # of whether or not an action is run with/without debug options is
 # different in the two modes. Ideally, the rerun sections should be
@@ -39,7 +39,7 @@ $(BUILDTESTDIR)/DebugTest.othervm.ok: \
 		-jdk:$(JDKHOME) \
 		-debug:-Ddebug=true \
 		$(TESTDIR)/debug \
-			> $(@:%.ok=%/jt.log) 2>&1 ; rc=$$? 
+			> $(@:%.ok=%/jt.log) 2>&1 ; rc=$$?
 	files=`( cd $(@:%.ok=%)/work ; $(GREP) --files-with-matches debug=true *.jtr )` ;\
 	if [ "$$files" != ExplicitCompile.jtr ]; then \
 	    echo "unexpected use of -debug options"; exit 1; \
@@ -61,7 +61,7 @@ $(BUILDTESTDIR)/DebugTest.agentvm.ok: \
 		-agentvm \
 		-debug:-Ddebug=true \
 		$(TESTDIR)/debug \
-			> $(@:%.ok=%/jt.log) 2>&1 ; rc=$$? 
+			> $(@:%.ok=%/jt.log) 2>&1 ; rc=$$?
 	agents=`$(GREP) '^\[[-0-9 :,]*\] Agent...: Started' $(@:%.ok=%)/jt.log | wc -l | tr -d ' '` ; \
  	debugAgents=`$(GREP) '^\[[-0-9 :,]*\] Agent...: Started.*-Ddebug=true' $(@:%.ok=%)/jt.log | wc -l | tr -d ' '` ; \
 	if [ "$$agents" != 2 -o "$$debugAgents" != 1 ]; then \

--- a/test/empty/EmptyTest.gmk
+++ b/test/empty/EmptyTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-# No Args:  
+# No Args:
 #   not allowed, exit code 1, Error: No tests selected
 #
 $(BUILDTESTDIR)/EmptyTest_NoArgs.ok: \
@@ -43,7 +43,7 @@ TESTS.jtreg += \
 
 #-------------------------------------------------------------------------------
 
-# Empty Group:  
+# Empty Group:
 #   allowed, exit code 0; Test results: No tests selected
 #
 $(BUILDTESTDIR)/EmptyTest_EmptyGroup.ok: \
@@ -55,7 +55,7 @@ $(BUILDTESTDIR)/EmptyTest_EmptyGroup.ok: \
 		-jdk:$(JDKHOME) \
 			> $(@:%.ok=%/jt.log) 2>&1 \
 		-dir:$(TESTDIR)/empty/ts1 \
-		:empty 
+		:empty
 	$(GREP) -s 'Test results: no tests selected' $(@:%.ok=%/jt.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
@@ -108,7 +108,7 @@ TESTS.jtreg += \
 
 #-------------------------------------------------------------------------------
 
-# Empty Group and a Test:  
+# Empty Group and a Test:
 #   allowed, exit code 0; Test results: passed: 1
 #
 $(BUILDTESTDIR)/EmptyTest_EmptyGroup_Test.ok: \
@@ -151,7 +151,7 @@ TESTS.jtreg += \
 
 #-------------------------------------------------------------------------------
 
-# Multiple Empty Group in same test suite:  
+# Multiple Empty Group in same test suite:
 #   allowed, exit code 0; Test results: No tests selected
 #
 $(BUILDTESTDIR)/EmptyTest_MultiEmptyGroup_1.ok: \
@@ -172,7 +172,7 @@ TESTS.jtreg += \
 
 #-------------------------------------------------------------------------------
 
-# Multiple Empty Group in separate test suites:  
+# Multiple Empty Group in separate test suites:
 #   allowed, exit code 0; Test results: No tests selected
 #
 $(BUILDTESTDIR)/EmptyTest_MultiEmptyGroup_2.ok: \

--- a/test/extra-props/bad-compile/TEST.ROOT
+++ b/test/extra-props/bad-compile/TEST.ROOT
@@ -21,6 +21,6 @@
  * questions.
  */
 
-requires.extraPropDefns = support/ExtraProps.java 
+requires.extraPropDefns = support/ExtraProps.java
 requires.properties = extra
 

--- a/test/extra-props/valid.libs/TEST.ROOT
+++ b/test/extra-props/valid.libs/TEST.ROOT
@@ -21,7 +21,7 @@
  * questions.
  */
 
-requires.extraPropDefns = support/ExtraProps.java 
+requires.extraPropDefns = support/ExtraProps.java
 requires.extraPropDefns.libs = support/lib
 requires.extraPropDefns.bootlibs = support/bootLib
 requires.extraPropDefns.vmOpts = -DhaveVMOpt=true

--- a/test/groups/GroupTest.gmk
+++ b/test/groups/GroupTest.gmk
@@ -35,7 +35,7 @@ $(BUILDTESTDIR)/GroupTest.ok: $(GroupTest.GROUPS:%=$(BUILDTESTDIR)/GroupTest.%.o
 $(GroupTest.GROUPS:%=$(BUILDTESTDIR)/GroupTest.%.ok): \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
-	$(MKDIR) -p $(@:%.ok=%) 
+	$(MKDIR) -p $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
@@ -54,7 +54,7 @@ TESTS.jtreg += $(BUILDTESTDIR)/GroupTest.ok
 $(BUILDTESTDIR)/ShowGroupTest.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
-	$(MKDIR) -p $(@:%.ok=%) 
+	$(MKDIR) -p $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \

--- a/test/interrupt/RunInterrupt.gmk
+++ b/test/interrupt/RunInterrupt.gmk
@@ -37,7 +37,7 @@ $(BUILDTESTDIR)/InterruptTest.ok: \
 		-encoding ASCII $(TESTDIR)/interrupt/InterruptTest.java
 	$(RM) -rf $(@:%.ok=%)/tmp
 	$(MKDIR) -p $(@:%.ok=%)/tmp
-	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" -Djava.io.tmpdir=$(@:%.ok=%)/tmp InterruptTest 
+	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" -Djava.io.tmpdir=$(@:%.ok=%)/tmp InterruptTest
 	echo "test passed at `date`" > $@
 
 # This is a manual GUI test. Do not run it by default.

--- a/test/jdkModulesTest/JDKModulesTest.gmk
+++ b/test/jdkModulesTest/JDKModulesTest.gmk
@@ -41,7 +41,7 @@ $(BUILDTESTDIR)/JDKModulesTest.ok: \
 		JDKModulesTest -Ddummy.vm.option
 	$(JDKHOME)/bin/java -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" \
 		-Djava.io.tmpdir=$(@:%.ok=%) \
-		JDKModulesTest 
+		JDKModulesTest
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/JDKModulesTest.ok

--- a/test/jdkOptsTest/JDKOptsTest.gmk
+++ b/test/jdkOptsTest/JDKOptsTest.gmk
@@ -37,7 +37,7 @@ $(BUILDTESTDIR)/JDKOptsTest.ok: \
 		-encoding ASCII $(TESTDIR)/jdkOptsTest/JDKOptsTest.java
 	$(RM) -rf $(@:%.ok=%)/tmp
 	$(MKDIR) -p $(@:%.ok=%)/tmp
-	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" -Djava.io.tmpdir=$(@:%.ok=%)/tmp JDKOptsTest 
+	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" -Djava.io.tmpdir=$(@:%.ok=%)/tmp JDKOptsTest
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/JDKOptsTest.ok

--- a/test/jdkVersion/JDKVersionTest.gmk
+++ b/test/jdkVersion/JDKVersionTest.gmk
@@ -29,7 +29,7 @@
 # test running jtreg using classes in build/classes
 
 $(BUILDTESTDIR)/TestJDKVersion.classes.ok: \
-		$(JTREG_IMAGEDIR)/lib/jtreg.jar 
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKJAVA) -cp "$(CLASSDIR)$(PS)$(JTREG_IMAGEDIR)/lib/javatest.jar" com.sun.javatest.regtest.Main \
 		-jdk:$(JDKHOME) \
@@ -44,7 +44,7 @@ $(BUILDTESTDIR)/TestJDKVersion.classes.ok: \
 # test running jtreg using classes in jtreg.jar on classpath
 
 $(BUILDTESTDIR)/TestJDKVersion.jar.ok: \
-		$(JTREG_IMAGEDIR)/lib/jtreg.jar 
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JDKJAVA) -cp "$(JTREG_IMAGEJARDIR)/jtreg.jar$(PS)$(JTREG_IMAGEDIR)/lib/javatest.jar" com.sun.javatest.regtest.Main \
 		-jdk:$(JDKHOME) \

--- a/test/maxOutputSize/MaxOutputSize.gmk
+++ b/test/maxOutputSize/MaxOutputSize.gmk
@@ -25,7 +25,7 @@
 
 #----------------------------------------------------------------------
 
-define check-found 
+define check-found
     if $(GREP) '$1' $2 > /dev/null ; then \
 	true; \
     else \
@@ -33,10 +33,10 @@ define check-found
     fi
 endef
 
-define check-not-found 
+define check-not-found
     if $(GREP) '$1' $2 > /dev/null ; then \
 	echo '$1' unexpectedly found in $2 ; exit 1 ; \
-    fi 
+    fi
 endef
 
 $(BUILDTESTDIR)/MaxOutputSize.ok: \

--- a/test/modules/ModulesTest.gmk
+++ b/test/modules/ModulesTest.gmk
@@ -33,7 +33,7 @@ $(BUILDTESTDIR)/ModulesTest_NoLimitMods.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK9HOME) \
 		$(TESTDIR)/modules \
-			> $(@:%.ok=%/jt.log) 2>&1 
+			> $(@:%.ok=%/jt.log) 2>&1
 	$(GREP) '^Test results: passed: 6$$' $(@:%.ok=%/jt.log)  > /dev/null
 	if $(GREP) 'TESTMODULES=jdk.compiler' $(@:%.ok=%/work/ModulesTest.jtr) ; then \
 	    true ; \
@@ -57,7 +57,7 @@ $(BUILDTESTDIR)/ModulesTest_LimitMods_java.se.ok: \
 		-jdk:$(JDK9HOME) \
 		-javaoptions:"--limit-modules $(@:$(BUILDTESTDIR)/ModulesTest_LimitMods_%.ok=%)" \
 		$(TESTDIR)/modules \
-			> $(@:%.ok=%/jt.log) 2>&1 
+			> $(@:%.ok=%/jt.log) 2>&1
 	$(GREP) '^Test results: passed: 2$$' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
@@ -69,7 +69,7 @@ $(BUILDTESTDIR)/ModulesTest_IgnoreAtModules.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK8HOME) \
 		$(TESTDIR)/modules \
-			> $(@:%.ok=%/jt.log) 2>&1 
+			> $(@:%.ok=%/jt.log) 2>&1
 	$(GREP) '^Test results: passed: 6$$' $(@:%.ok=%/jt.log)  > /dev/null
 	if $(GREP) 'TESTMODULES=jdk.compiler' $(@:%.ok=%/work/ModulesTest.jtr) ; then \
 	    echo "TESTMODULES entry found unexpectedly" ; exit 1 ; \

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -64,21 +64,21 @@ $(BUILDTESTDIR)/TestNativePath.ok: \
 		-jdk:$(JDKHOME) \
 		-nativepath:/this/path/does/not/exist \
 		$(TESTDIR)/nativepath \
-		2>&1 | grep -q "The -nativepath path does not exist" 
+		2>&1 | grep -q "The -nativepath path does not exist"
 
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
 		-nativepath:$(JTREG_IMAGEDIR)/bin/jtreg \
 		$(TESTDIR)/nativepath \
-		2>&1 | grep -q "The -nativepath path is not a directory" 
+		2>&1 | grep -q "The -nativepath path is not a directory"
 
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
 		-nativepath:"$(JTREG_IMAGEDIR)/bin/jtreg$(PS)$(JDK6HOME)" \
 		$(TESTDIR)/nativepath \
-		2>&1 | grep -q "The argument to -nativepath cannot be more than one path." 
+		2>&1 | grep -q "The argument to -nativepath cannot be more than one path."
 
-        # Run a test with native code without the -nativepath option 
+        # Run a test with native code without the -nativepath option
         # should yield an error
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \

--- a/test/openfiles/OpenFileTests.gmk
+++ b/test/openfiles/OpenFileTests.gmk
@@ -30,7 +30,7 @@
 # where open files can be a problem during file cleanup before/after
 # a test. On a non-Windows environment (i.e. Linux, Solaris) all
 # the tests in the openfiles test suite pass.
-# But, for now, these makefiles are not set up to run on Windows. 
+# But, for now, these makefiles are not set up to run on Windows.
 # When the makefiles are upgraded to run on Windows, the rules in this
 # makefile will have to be updated (perhaps by using target-specific
 # variable definitions) to behave correctly on Windows as well as

--- a/test/optionDecoder/OptionDecoderTest.gmk
+++ b/test/optionDecoder/OptionDecoderTest.gmk
@@ -35,7 +35,7 @@ $(BUILDTESTDIR)/OptionDecoderTest.ok: \
 		-cp $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-Xlint -Werror \
 		-encoding ASCII $(TESTDIR)/optionDecoder/OptionDecoderTest.java
-	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" OptionDecoderTest 
+	$(JDKJAVA) -cp "$(@:%.ok=%)/classes$(PS)$(JTREG_IMAGEDIR)/lib/jtreg.jar" OptionDecoderTest
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/OptionDecoderTest.ok

--- a/test/problemList/ProblemList.gmk
+++ b/test/problemList/ProblemList.gmk
@@ -47,7 +47,7 @@ $(BUILDTESTDIR)/ProblemList.ok: \
 		-jdk:$(JDKHOME) \
 		-agentvm \
 		$(TESTDIR)/problemList/  \
-			> $(@:%.ok=%/1/jt.log) 2>&1 
+			> $(@:%.ok=%/1/jt.log) 2>&1
 	$(GREP) -s 'Test results: passed: 6' $(@:%.ok=%/1/jt.log)  > /dev/null
 	$(MKDIR) $(@:%.ok=%)/2
 	@echo OS_ARCH $(OS_ARCH)
@@ -67,7 +67,7 @@ $(BUILDTESTDIR)/ProblemList.ok: \
 		-agentvm \
 		-exclude:$(@:%.ok=%)/2/ProblemList.txt \
 		$(TESTDIR)/problemList/  \
-			> $(@:%.ok=%/2/jt.log) 2>&1 
+			> $(@:%.ok=%/2/jt.log) 2>&1
 	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/2/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 

--- a/test/share/basic/TEST.ROOT
+++ b/test/share/basic/TEST.ROOT
@@ -1,6 +1,6 @@
 # This file identifies the root of the test-suite hierarchy.
 
-# Do not change the contents of this file unless you have spoken to 
+# Do not change the contents of this file unless you have spoken to
 # Mark Reinhold (mr@eng).
 
 # The list of acceptable keys for this testsuite.

--- a/test/share/basic/applet/ArchiveUnsupported.html
+++ b/test/share/basic/applet/ArchiveUnsupported.html
@@ -28,10 +28,10 @@
 -->
     <html>
     <body>
-    <applet 
-       height = 100 
-       width = 20 
-       code = ArchiveUnsupported 
+    <applet
+       height = 100
+       width = 20
+       code = ArchiveUnsupported
        archive = ArchiveUnsupported.jar
     >
     </applet>

--- a/test/share/basic/applet/BadTag.html
+++ b/test/share/basic/applet/BadTag.html
@@ -24,7 +24,7 @@
 <!-- @test
      @summary Error: Parse Exception: `applet' requires exactly one file argument
      @run applet
---> 
+-->
 
 <!-- @test
      @summary Error: Parse Exception: Bad option for applet: bad_opt
@@ -35,7 +35,7 @@
      @summary Error: Can't find HTML file: .../BadTug.html
      @run applet BadTug.html
 -->
-    
+
 <!-- @test
      @summary Error: Parse Exception: No </body> tag in .../BadTag.html
      @run applet BadTag.html
@@ -57,4 +57,4 @@
 
 <html>
 <body>
-    
+

--- a/test/share/basic/applet/MissApplet.html
+++ b/test/share/basic/applet/MissApplet.html
@@ -28,4 +28,4 @@
     <html>
     <body>
     </body>
-    
+

--- a/test/share/basic/applet/MissEndApplet.html
+++ b/test/share/basic/applet/MissEndApplet.html
@@ -29,4 +29,4 @@
     <body>
     <applet>
     </body>
-    
+

--- a/test/share/basic/applet/MissReqAttrib.html
+++ b/test/share/basic/applet/MissReqAttrib.html
@@ -31,4 +31,4 @@
     <applet height = 100 width = 20>
     </applet>
     </body>
-    
+

--- a/test/share/basic/applet/MissReqParam.html
+++ b/test/share/basic/applet/MissReqParam.html
@@ -27,12 +27,12 @@
 -->
     <html>
     <body>
-    <applet 
-       height = 100 
-       width = 20 
+    <applet
+       height = 100
+       width = 20
        code = MissingReqParam
     >
     <param name=foo>
     </applet>
     </body>
-    
+

--- a/test/statusFilter/StatusFilterTest.gmk
+++ b/test/statusFilter/StatusFilterTest.gmk
@@ -152,9 +152,9 @@ TESTS.jtreg += \
 
 #3310  ./build/images/jtreg/bin/jtreg -jdk:/opt/jdk/1.8.0 -w build/w -r build/r -e mode=fail test/statusFilter/
 # 3311  ./build/images/jtreg/bin/jtreg -jdk:/opt/jdk/1.8.0 -w build/w -r build/r -e mode=fail -status:fail test/statusFilter/
-# 3312  more build/r/text/summary.txt 
+# 3312  more build/r/text/summary.txt
 # 3313  ./build/images/jtreg/bin/jtreg -jdk:/opt/jdk/1.8.0 -w build/w -r build/r -ro test/statusFilter/
-# 3314  more build/r/text/summary.txt 
+# 3314  more build/r/text/summary.txt
 # 3315  ./build/images/jtreg/bin/jtreg -jdk:/opt/jdk/1.8.0 -w build/w -r build/r -status:fail -report:all test/statusFilter/
-# 3316  more build/r/text/summary.txt 
+# 3316  more build/r/text/summary.txt
 

--- a/test/testRequiredVersion.gmk
+++ b/test/testRequiredVersion.gmk
@@ -59,6 +59,6 @@ $(BUILDTESTDIR)/TestRequiredVersion.ok: \
 
 TESTS.jtreg += \
     $(BUILDTESTDIR)/TestRequiredVersion.ok
-    
+
 testrequiredversion: \
     $(BUILDTESTDIR)/TestRequiredVersion.ok

--- a/test/timeoutHandler/TimeoutHandlerTimeoutTest.gmk
+++ b/test/timeoutHandler/TimeoutHandlerTimeoutTest.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-# use target-specific variables to specify jtreg option 
+# use target-specific variables to specify jtreg option
 # and the resulting expected timeout
 
 $(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.default.ok: OPTION=
@@ -43,7 +43,7 @@ $(BUILDTESTDIR)/TimeoutHandlerTimeoutTest.timeout.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg \
 	    $(TESTDIR)/timeoutHandler/TestTimeoutHandler.java
-	$(MKDIR) -p $(@:%.ok=%)/classes 
+	$(MKDIR) -p $(@:%.ok=%)/classes
 	$(JDKJAVAC) -d $(@:%.ok=%)/classes \
 		-classpath $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		-Xlint -Werror \

--- a/test/timeouts/README
+++ b/test/timeouts/README
@@ -1,5 +1,5 @@
-This directory provides a collection of tests designed to exercise jtreg's 
-ability to handle tests that do not return or which kill the VM in which 
+This directory provides a collection of tests designed to exercise jtreg's
+ability to handle tests that do not return or which kill the VM in which
 they are executing.
 
 The tests can be run locally via the build/TimeoutTest.ok target.

--- a/test/timeouts/test/Makefile
+++ b/test/timeouts/test/Makefile
@@ -111,7 +111,7 @@ FATAL_JTREG_EXIT = 4
 # Exit -- used for final "normal" exit from "make". Redefine to "true" to avoid
 # having make exit with non-zero return code.
 EXIT = exit
-# Function to exit shell if exit code of preceding command is greater than or equal 
+# Function to exit shell if exit code of preceding command is greater than or equal
 # to a given level. Redefine function or preceding FATAL_*_EXIT codes as needed.
 EXIT_IF_FATAL = status=$$?; if [ $$status -ge $(1) ]; then exit $$status ; fi
 
@@ -140,7 +140,7 @@ summary: report
 	    exit 1 ; \
 	fi
 	
-	 
+	
 
 JTREG_OUTPUT_DIR = $(ABS_TEST_OUTPUT_DIR)/$(MODE)/$(subst .java,,$(TEST))
 
@@ -160,7 +160,7 @@ CHECK_PASS = \
 # JT_JAVA
 #	Version of java used to run jtreg.  Should normally be the same as TESTJAVA
 # TESTJAVA
-# 	Version of java to be tested.  
+# 	Version of java to be tested.
 # JTREG_OPTIONS
 #	Additional options for jtreg
 # JTREG_TESTDIRS

--- a/test/timeouts/test/jprt.config
+++ b/test/timeouts/test/jprt.config
@@ -72,7 +72,7 @@ dirMustExist "${slashjava}"  ALT_SLASH_JAVA
 # Uses 'uname -s', but only expect SunOS or Linux, assume Windows otherwise.
 osname=`uname -s`
 if [ "${osname}" = SunOS ] ; then
-   
+
     # SOLARIS: Sparc or X86
     osarch=`uname -p`
     if [ "${osarch}" = sparc ] ; then
@@ -90,7 +90,7 @@ if [ "${osname}" = SunOS ] ; then
 	make=/opt/sfw/bin/gmake
 	if [ ! -f ${make} ] ; then
 	    make=${slashjava}/devtools/${solaris_arch}/bin/gnumake
-        fi 
+        fi
     fi
     fileMustExist "${make}" make
 
@@ -98,7 +98,7 @@ if [ "${osname}" = SunOS ] ; then
     umask 002
 
 elif [ "${osname}" = Linux ] ; then
-   
+
     # Add basic paths
     path4sdk=/usr/bin:/bin:/usr/sbin:/sbin
 
@@ -111,7 +111,7 @@ elif [ "${osname}" = Linux ] ; then
 else
 
     # Windows: Differs on CYGWIN vs. MKS.
-   
+
     # We need to determine if we are running a CYGWIN shell or an MKS shell
     #    (if uname isn't available, then it will be unix_toolset=unknown)
     unix_toolset=unknown
@@ -140,12 +140,12 @@ else
       echo "WARNING: Cannot figure out if this is MKS or CYGWIN"
     fi
 
-    
+
     # For windows, it's hard to know where the system is, so we just add this
     #    to PATH.
     slash_path="`echo ${path4sdk} | sed -e 's@\\\\@/@g' -e 's@//@/@g' -e 's@/$@@' -e 's@/;@;@g'`"
     path4sdk="${slash_path};${PATH}"
-    
+
     # Convert path4sdk to cygwin style
     if [ "${unix_toolset}" = CYGWIN ] ; then
 	path4sdk="`/usr/bin/cygpath -p ${path4sdk}`"


### PR DESCRIPTION
Please review a scripted update to remove trailing white space from `make` and `test` files.

```
grep -rl ' $' open/make open/test | xargs sed -i .BAK -e 's/  *$//'
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903254](https://bugs.openjdk.org/browse/CODETOOLS-7903254): Fix trailing whitespace in files


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.org/jtreg pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/103.diff">https://git.openjdk.org/jtreg/pull/103.diff</a>

</details>
