### PR TITLE
CODETOOLS-7903260: Fix support for JUnit tests in a system module

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -455,6 +455,13 @@ public class MainAction extends Action
             }
         }
 
+        if (driverClass != null && testModuleName != null && testClassName.contains(".")) {
+            Module driverModule = driverClass.getModule();
+            String exportTarget = driverModule.isNamed() ? driverModule.getName() : "ALL-UNNAMED";
+            String testPackage = testClassName.substring(0, testClassName.lastIndexOf("."));
+            javaOpts.add("--add-exports=" + testModuleName + "/" + testPackage + "=" + exportTarget);
+        }
+
         javaOpts.addAll(getExtraModuleConfigOptions(Modules.Phase.DYNAMIC));
         javaOpts.addAll(script.getTestVMJavaOptions());
         javaOpts.addAll(script.getTestDebugOptions());


### PR DESCRIPTION
Please review a simple patch to allow a directory of TestNG or JUnit tests to be patched into a system module, in order to access package-private API.

The patch is just to export the package containing the patched test to the possibly-unnamed module containing the library code to run the tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903260](https://bugs.openjdk.org/browse/CODETOOLS-7903260): Fix support for JUnit tests in a system module


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/jtreg pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/105.diff">https://git.openjdk.org/jtreg/pull/105.diff</a>

</details>
