### PR TITLE
CODETOOLS-7903281: support alternate build for FAQ

### DIFF
--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -127,7 +127,12 @@ $(JTREG_COPYRIGHT): $(TOPDIR)/COPYRIGHT
 	$(RM) $@
 	$(CP) $< $@
 
-$(JTREG_FAQ):   $(SRCJTREGDOCDIR)/faq.md \
+$(JTREG_FAQ): FAQ_PANDOC_OPTIONS = --to html5
+
+$(BUILDDIR)/alt-faq.html: FAQ_PANDOC_OPTIONS = --to html4 --ascii
+$(BUILDDIR)/alt-faq.html: FAQ_SED_OPTIONS = -e '/max-width: 36em;/d'
+
+$(JTREG_FAQ) $(BUILDDIR)/alt-faq.html:   $(SRCJTREGDOCDIR)/faq.md \
 		$(SRCJTREGDOCDIR)/faq-local-style.html \
 		$(SRCJTREGDOCDIR)/faq-intro.html
 	$(MKDIR) -p $(@D)
@@ -137,7 +142,7 @@ $(JTREG_FAQ):   $(SRCJTREGDOCDIR)/faq.md \
 	    --include-in-header $(SRCJTREGDOCDIR)/faq-local-style.html \
 	    --include-before $(SRCJTREGDOCDIR)/faq-intro.html \
 	    --toc \
-	    --to html5 \
+	    $(FAQ_PANDOC_OPTIONS) \
 	    --number-sections \
 	    $(SRCJTREGDOCDIR)/faq.md | \
 	$(SED) \
@@ -146,7 +151,8 @@ $(JTREG_FAQ):   $(SRCJTREGDOCDIR)/faq.md \
 	    -e 's/…/\&hellip;/g' \
 	    -e 's/™/\&trade;/g' \
 	    -f  $(BUILDDIR)/fixupheader \
-	    > $(JTREG_FAQ)	
+	    $(FAQ_SED_OPTIONS) \
+	    > $@
 
 
 $(JTREG_README): $(SRCJTREGDOCDIR)/README

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -448,6 +448,8 @@ in the test suite, and define a collection of tests to be run.
 
 To summarise, you can use the following to specify tests to be run:
 
+Table: Kinds of Supported Arguments
+
 | Argument                | Description                                         |
 |-------------------------|-----------------------------------------------------|
 | _directory_             | All tests found in files in and under the directory |


### PR DESCRIPTION
Please review a small update to allow an alternate form of the FAQ to be generated, with different/extra options for `pandoc` and `sed`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903281](https://bugs.openjdk.org/browse/CODETOOLS-7903281): support alternate build for FAQ


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/jtreg pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/110.diff">https://git.openjdk.org/jtreg/pull/110.diff</a>

</details>
