### PR TITLE
CODETOOLS-7903287: Remove left-over obsolete support for Ant task

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1119,10 +1119,6 @@ public class Tool {
             baseDir = baseDirArg.toAbsolutePath();
         }
 
-        String antFileList = System.getProperty(JAVATEST_ANT_FILE_LIST);
-        if (antFileList != null)
-            antFileArgs.addAll(readFileList(Path.of(antFileList)));
-
         final TestManager testManager = new TestManager(out, baseDir, new TestFinder.ErrorHandler() {
             @Override
             public void error(String msg) {
@@ -1131,7 +1127,6 @@ public class Tool {
         });
         testManager.addTestFiles(testFileArgs, false);
         testManager.addTestFileIds(testFileIdArgs, false);
-        testManager.addTestFiles(antFileArgs, true);
         testManager.addGroups(testGroupArgs);
 
         if (testManager.isEmpty())
@@ -2296,9 +2291,6 @@ public class Tool {
     public List<String> testGroupArgs = new ArrayList<>();
     public List<Path> testFileArgs = new ArrayList<>();
     public List<TestManager.FileId> testFileIdArgs = new ArrayList<>();
-    // TODO: consider making this a "pathset" to detect redundant specification
-    // of directories and paths within them.
-    public final List<Path> antFileArgs = new ArrayList<>();
 
     // these args are jtreg extras
     private Path baseDirArg;


### PR DESCRIPTION
Please review a trivial update to remove some dead code left over from when the Ant task was removed earlier this year.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903287](https://bugs.openjdk.org/browse/CODETOOLS-7903287): Remove left-over obsolete support for Ant task


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.org/jtreg pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/111.diff">https://git.openjdk.org/jtreg/pull/111.diff</a>

</details>
