### PR TITLE
CODETOOLS-7903288: Remove dead code from TestManager

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -79,7 +79,7 @@ public class TestManager {
     private static class Entry {
         final Path rootDir;
         boolean all = false;
-        Map<String, Boolean> files = new LinkedHashMap<>();
+        Set<String> files = new LinkedHashSet<>();
         Set<String> groups = new LinkedHashSet<>();
 
         RegressionTestSuite testSuite;
@@ -108,21 +108,21 @@ public class TestManager {
         this.errHandler = errHandler;
     }
 
-    public void addTestFiles(Collection<Path> testFiles, boolean ignoreEmptyFiles) throws Fault {
+    public void addTestFiles(Collection<Path> testFiles) throws Fault {
         Map<Path, Path> rootDirCache = new HashMap<>();
         for (Path tf: testFiles) {
-            addTest(rootDirCache, tf, null, ignoreEmptyFiles);
+            addTest(rootDirCache, tf, null);
         }
     }
 
-    public void addTestFileIds(Collection<FileId> testFiles, boolean ignoreEmptyFiles) throws Fault {
+    public void addTestFileIds(Collection<FileId> testFiles) throws Fault {
         Map<Path, Path> rootDirCache = new HashMap<>();
         for (FileId tf: testFiles) {
-            addTest(rootDirCache, tf.file, tf.id, ignoreEmptyFiles);
+            addTest(rootDirCache, tf.file, tf.id);
         }
     }
 
-    private void addTest(Map<Path, Path> rootDirCache, Path tf, String id, boolean ignoreEmptyFiles) throws Fault {
+    private void addTest(Map<Path, Path> rootDirCache, Path tf, String id) throws Fault {
         Path f = canon(tf.toFile()).toPath();
         if (!Files.exists(f))
             throw new Fault(i18n, "tm.cantFindFile", tf);
@@ -135,7 +135,7 @@ public class TestManager {
             e.all = true;
             e.files.clear();
         } else if (!e.all) {
-            e.files.put(getRelativePath(rootDir, f, id), ignoreEmptyFiles);
+            e.files.add(getRelativePath(rootDir, f, id));
         }
     }
 
@@ -265,13 +265,12 @@ public class TestManager {
             return null;
         WorkDirectory wd = getWorkDirectory(ts);
         Set<String> tests = new LinkedHashSet<>();
-        for (Map.Entry<String,Boolean> me: e.files.entrySet()) {
-            String test = me.getKey();
-            boolean ignoreEmptyFiles = me.getValue();
-            if (validatePath(wd, test))
+        for (String test: e.files) {
+            if (validatePath(wd, test)) {
                 tests.add(test);
-            else if (!ignoreEmptyFiles)
+            } else {
                 throw new Fault(i18n, "tm.notATest", test);
+            }
         }
         for (Path f: expandGroups(e)) {
             String test = getRelativePath(e.rootDir, f, null);

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1125,8 +1125,8 @@ public class Tool {
                 Tool.this.error(msg);
             }
         });
-        testManager.addTestFiles(testFileArgs, false);
-        testManager.addTestFileIds(testFileIdArgs, false);
+        testManager.addTestFiles(testFileArgs);
+        testManager.addTestFileIds(testFileIdArgs);
         testManager.addGroups(testGroupArgs);
 
         if (testManager.isEmpty())


### PR DESCRIPTION
Please review another simple cleanup for TestManager, removing dead code, as we head towards more interesting improvements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903288](https://bugs.openjdk.org/browse/CODETOOLS-7903288): Remove dead code from TestManager


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jtreg pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/112.diff">https://git.openjdk.org/jtreg/pull/112.diff</a>

</details>
