### PR TITLE
7903289: the option '-tagspec' in jtreg doesn't work as expected

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Help.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Help.java
@@ -193,15 +193,11 @@ public class Help {
 
     void showTagSpec(PrintWriter out) {
         File docDir = getDocDir();
-        File tagSpec = new File(docDir, "tag-spec.txt");
-        try (BufferedReader in = new BufferedReader(new FileReader(tagSpec))) {
-            String line;
-            while ((line = in.readLine()) != null)
-                out.println(line);
-        } catch (FileNotFoundException e) {
+        File tagSpec = new File(docDir, "tag-spec.html");
+        if (tagSpec.exists()) {
+            out.println(i18n.getString("help.findSpecSuccessfully", tagSpec.toURI()));
+        } else {
             out.println(i18n.getString("help.cantFindSpec"));
-        } catch (IOException e) {
-            out.println(i18n.getString("help.cantReadSpec", e));
         }
     }
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -427,7 +427,7 @@ help.verbose.vt.desc=Short for -verbose:time
 
 help.cantFindReleaseNotes=The Release Notes are not available.
 help.cantFindSpec=The Tag Specification is not available.
-help.cantReadSpec=Error reading the Tag Specification: {0}
+help.findSpecSuccessfully=Please open this link in the broswer to get the newest Tag Specification: {0}
 help.releaseNotes=The Release Notes are available in {0}
 help.version.txt={0} {1}\nInstalled in {2}\nRunning on platform version {3} from {4}.\nBuilt with {5} on {6}.
 help.version.unknown=(unknown)


### PR DESCRIPTION
Hi all,

When using the command `jtreg -tagspec`, jtreg replies `The Tag Specification is not available`. It is because the file `tag-spec.txt` has not exsited after commit [ae6b9001](https://github.com/openjdk/jtreg/commit/ae6b9001). This patch fixes it by providing the `tag-spec.html` file link.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903289](https://bugs.openjdk.org/browse/CODETOOLS-7903289): the option '-tagspec' in jtreg doesn't work as expected (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/jtreg.git pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/113.diff">https://git.openjdk.org/jtreg/pull/113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/113#issuecomment-1239368614)