### PR TITLE
CODETOOLS-7903294: Use `sw_vers` to get OS version on Mac

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -193,7 +193,7 @@ public class Tool {
         if (osName != null && osName.equals("Mac OS X")) {
             try {
                 String expectVersion;
-                Process p = new ProcessBuilder("defaults", "read", "loginwindow", "SystemVersionStampAsString")
+                Process p = new ProcessBuilder("sw_vers", "-productVersion")
                         .redirectErrorStream(true)
                         .start();
                 try (InputStream in = p.getInputStream();


### PR DESCRIPTION
Please review a small change to use
     `sw_vers -productVersion` 
to obtain the macOS version, instead of using 
    `defaults read loginwindow SystemVersionStampAsString`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903294](https://bugs.openjdk.org/browse/CODETOOLS-7903294): Use `sw_vers` to get OS version on Mac


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.org/jtreg pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/114.diff">https://git.openjdk.org/jtreg/pull/114.diff</a>

</details>
