### PR TITLE
CODETOOLS-7903267: Support executing a single test method in a JUnit class

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -113,9 +113,12 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
         // https://junit.org/junit5/docs/current/user-guide/#launcher-api-execution
         Thread.currentThread().setContextClassLoader(mainClass.getClassLoader());
         try {
-
+            String testQuery = System.getProperty("test.query");
+            // if test.query is set, treat it as a method name to be executed
             LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
-                .selectors(DiscoverySelectors.selectClass(mainClass))
+                .selectors(testQuery == null
+                        ? DiscoverySelectors.selectClass(mainClass)
+                        : DiscoverySelectors.selectMethod(mainClass, testQuery))
                 .build();
 
             SummaryGeneratingListener summaryGeneratingListener = new SummaryGeneratingListener();

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
@@ -629,6 +629,7 @@ public class RegressionParameters
     private static final String TIMEOUT_HANDLER = ".timeoutHandler";
     private static final String TIMEOUT_HANDLER_PATH = ".timeoutHandlerPath";
     private static final String TIMEOUT_HANDLER_TIMEOUT = ".timeoutHandlerTimeout";
+    private static final String TEST_QUERIES = ".testQueries";
 
     @Override @SuppressWarnings({"rawtypes", "unchecked"})
     public void load(Map data, boolean checkChecksum) throws Interview.Fault {
@@ -722,6 +723,11 @@ public class RegressionParameters
             if (v != null)
                 setTimeoutHandlerTimeout(v);
 
+            v = data.get(prefix + TEST_QUERIES);
+            if (v != null) {
+                setTestQueries(List.of(StringUtils.splitSeparator("\n", v)));
+            }
+
         } catch (InvalidPathException e) {
             // This is unlikely to happen, but pretty serious if it does.
             // Since we only put valid paths into the parameters, there should be
@@ -800,6 +806,10 @@ public class RegressionParameters
 
         if (timeoutHandlerTimeout != -1) {  // -1: default; 0: no timeout; >0: timeout in seconds
             data.put(prefix + TIMEOUT_HANDLER_TIMEOUT, String.valueOf(timeoutHandlerTimeout));
+        }
+
+        if (testQueries != null) {
+            data.put(prefix + TEST_QUERIES, join(testQueries, "\n"));
         }
     }
 
@@ -1274,6 +1284,41 @@ public class RegressionParameters
     }
 
     private boolean useWindowsSubsystemForLinux;
+
+    //---------------------------------------------------------------------
+
+    public void setTestQueries(List<String> testQueries) {
+        this.testQueries = testQueries;
+    }
+
+    public List<String> getTestQueries() {
+        return testQueries;
+    }
+
+    /**
+     * Returns the query component for a given test, if one was specified,
+     * or null if there is no query component for this test.
+     *
+     * @param test the name of the test
+     * @return the query component associated with this test, or null
+     */
+    public String getTestQuery(String test) {
+        // There are two common cases:
+        // 1. any number of tests are being run, none of which have queries, or
+        // 2. a single test is being run, which has query.
+        // As such, it is probably not worth parsing testQueries into a map.
+        if (testQueries != null) {
+            for (String tq : testQueries) {
+                int sep = tq.indexOf("?");
+                if (test.equals(tq.substring(0, sep))) {
+                    return tq.substring(sep + 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    private List<String> testQueries;
 
     //---------------------------------------------------------------------
 

--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -217,7 +217,7 @@ public class TestManager {
          * The form contains the file and id as a relative URL.
          * It does not include the query.
          *
-         * @return
+         * @return the path for a test
          */
         String getTestPath() {
             return id == null ? pathToString(file) : pathToString(file) + "#" + id;

--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -38,12 +38,16 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
-import com.sun.javatest.TestFilter;
 import com.sun.javatest.TestFinder;
 import com.sun.javatest.TestResult;
 import com.sun.javatest.TestResultTable;
@@ -76,29 +80,217 @@ public class TestManager {
 
     Map<Path, Entry> map = new TreeMap<>();
 
-    private static class Entry {
-        final Path rootDir;
-        boolean all = false;
-        Set<String> files = new LinkedHashSet<>();
-        Set<String> groups = new LinkedHashSet<>();
+    /**
+     * A GroupSpec embodies an argument of the form  [path]:name  where path is
+     * a file path to the root of a test suite and name is the name of a group
+     * of tests defined in the files given in the "groups" entry in TEST.ROOT.
+     */
+    public static class GroupSpec {
+        /** The test suite containing the group, or null for the default test suite. */
+        final Path dir;
+        /** The name for the group. */
+        final String groupName;
 
+        /* A "group" argument is of the form  [path]:id  where the path is a file path
+         * to the root of the test suite. On Windows, we have to be careful about
+         * the ambiguity between an absolute path beginning with a drive letter
+         * and a relative path that is a single letter. Therefore, on Windows,
+         * we accept the following for a path:
+         * - (empty)
+         * - a single non-alphabetic character followed by :id
+         * - two or more characters followed by :id
+         * Thus, letter:id is not accepted as a group spec, and so will be treated
+         * elsewhere as a plain absolute file path instead.
+         */
+        static final Pattern groupPtn = System.getProperty("os.name").matches("(?i)windows.*")
+                ? Pattern.compile("(?<dir>|[^A-Za-z]|.{2,}):(?<group>[A-Za-z0-9_,]+)")
+                : Pattern.compile("(?<dir>.*):(?<group>[A-Za-z0-9_,]+)");
+
+        /**
+         * Returns true if a string may represent a named group of tests.
+         *
+         * @param s the string
+         * @return true if the string may represent a named group of tests, and false otherwise
+         */
+        public static boolean isGroupSpec(String s) {
+            return groupPtn.matcher(s).matches();
+        }
+
+        /**
+         * Returns an object indicating a named group of tests in a specific test suite.
+         *
+         * @param s a string identifying the named group of tests
+         * @return an object indicating a named group of tests in a specific test suite
+         */
+        public static GroupSpec of(String s) {
+            Matcher m = groupPtn.matcher(s);
+            if (!m.matches()) {
+                throw new IllegalArgumentException(s);
+            }
+
+            String d = m.group("dir");
+            Path dir = d.isEmpty() ? null : Path.of(d);
+            String groupName = m.group("group");
+            return new GroupSpec(dir, groupName);
+        }
+
+        private GroupSpec(Path dir, String groupName) {
+            this.dir = dir;
+            this.groupName = Objects.requireNonNull(groupName);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GroupSpec groupSpec = (GroupSpec) o;
+            return Objects.equals(dir, groupSpec.dir) && groupName.equals(groupSpec.groupName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dir, groupName);
+        }
+
+        @Override
+        public String toString() {
+            return (dir == null ? "" : dir) + ":" + groupName;
+        }
+    }
+
+    /**
+     * A TestSpec embodies an argument of the form path[#id][?query] where
+     * path is the path for a file in a test suite, id may indicate the name
+     * of a test within that file, and query may indicate the part of that
+     * test to be executed.
+     *
+     * Note the pattern is similar to but intentionally different from that
+     * of a URL, where the query component precedes the fragment component.
+     * As given, path, id and query are hierarchically related.
+     *
+     * The path may be a directory to indicate all the tests in the files
+     * in and under that directory.
+     */
+    public static class TestSpec {
+        private final Path file;
+        private final String id;
+        private final String query;
+
+        /**
+         * Returns true if a string may represent one or more tests.
+         *
+         * @param s the string
+         * @return true if the string may represent one or more tests, and false otherwise
+         */
+        public static boolean isTestSpec(String s) {
+            return fileIdQueryPtn.matcher(s).matches();
+        }
+
+        /**
+         * Returns an object indicating one or more tests.
+         *
+         * @param s a string identifying one or more tests
+         * @return an object indicating one or more tests in a specific test suite
+         */
+        public static TestSpec of(String s) {
+            Matcher m = fileIdQueryPtn.matcher(s);
+            if (!m.matches()) {
+                throw new IllegalArgumentException(s);
+            }
+
+            Path file = Path.of(m.group("file"));
+            String id = m.group("id"); // may be null
+            String query = m.group("query"); // may be null
+            return new TestSpec(file, id, query);
+        }
+
+        static Pattern fileIdQueryPtn = Pattern.compile("(?<file>.+?)(#(?<id>[A-Za-z0-9-_]+))?(\\?(?<query>.*))?");
+
+        private TestSpec(Path file, String id, String query) {
+            this.file = Objects.requireNonNull(file);
+            this.id = id;
+            this.query = query;
+        }
+
+        /**
+         * Returns the path for a test, as required by JavaTest.
+         * The form contains the file and id as a relative URL.
+         * It does not include the query.
+         *
+         * @return
+         */
+        String getTestPath() {
+            return id == null ? pathToString(file) : pathToString(file) + "#" + id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TestSpec testSpec = (TestSpec) o;
+            return file.equals(testSpec.file) && Objects.equals(id, testSpec.id) && Objects.equals(query, testSpec.query);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(file, id, query);
+        }
+
+        @Override
+        public String toString() {
+            return file + (id == null ? "" : "#" + id) + (query == null ? "" : "?" + query);
+        }
+    }
+
+    /**
+     * An object to encapsulate the details for the tests to be run in a single test suite.
+     */
+    private static class Entry {
+        /**
+         * The root directory for the test specs and group specs in this entry.
+         */
+        final Path rootDir;
+
+        /**
+         * Whether all tests in the test suite are to be included.
+         * When true, the test specs and group specs are ignored.
+         */
+        boolean all = false;
+
+        /**
+         * The test specs for the tests to be run.
+         * In these specs, the file is relative to the rootDir.
+         */
+        final Set<TestSpec> tests = new LinkedHashSet<>();
+
+        /**
+         * The names of the groups to be run.
+         */
+        final Set<String> groups = new LinkedHashSet<>();
+
+        /**
+         * The test suite containing the test specs and group specs for this entry.
+         */
         RegressionTestSuite testSuite;
+
+        /**
+         * The subdirectory to use for the work directory and report directory,
+         * when tests are to be run from multiple test suites.
+         */
         String subdir;
+
+        /**
+         * The work directory to use when running the tests in this entry.
+         */
         WorkDirectory workDir;
+
+        /**
+         * The report directory to use when running the tests in this entry.
+         */
         Path reportDir;
 
         Entry(Path rootDir) {
             this.rootDir = rootDir;
-        }
-    }
-
-    public static class FileId {
-        final Path file;
-        final String id;
-
-        public FileId(Path file, String id) {
-            this.file = file;
-            this.id = id;
         }
     }
 
@@ -108,58 +300,63 @@ public class TestManager {
         this.errHandler = errHandler;
     }
 
-    public void addTestFiles(Collection<Path> testFiles) throws Fault {
+    public void addTestSpecs(Collection<TestSpec> tests) throws Fault {
         Map<Path, Path> rootDirCache = new HashMap<>();
-        for (Path tf: testFiles) {
-            addTest(rootDirCache, tf, null);
+        for (TestSpec t : tests) {
+            Path f = canon(t.file);
+            if (!Files.exists(f))
+                throw new Fault(i18n, "tm.cantFindFile", t.file);
+            Path rootDir = getRootDir(rootDirCache, f);
+            if (rootDir == null)
+                throw new Fault(i18n, "tm.cantDetermineTestSuite", t.file);
+
+            Entry e = getEntry(rootDir);
+            if (f.equals(rootDir)) {
+                e.all = true;
+                e.tests.clear();
+            } else if (!e.all) {
+                e.tests.add(new TestSpec(rootDir.relativize(f), t.id, t.query));
+            }
         }
     }
 
-    public void addTestFileIds(Collection<FileId> testFiles) throws Fault {
-        Map<Path, Path> rootDirCache = new HashMap<>();
-        for (FileId tf: testFiles) {
-            addTest(rootDirCache, tf.file, tf.id);
-        }
-    }
-
-    private void addTest(Map<Path, Path> rootDirCache, Path tf, String id) throws Fault {
-        Path f = canon(tf.toFile()).toPath();
-        if (!Files.exists(f))
-            throw new Fault(i18n, "tm.cantFindFile", tf);
-        Path rootDir = getRootDir(rootDirCache, f);
-        if (rootDir == null)
-            throw new Fault(i18n, "tm.cantDetermineTestSuite", tf);
-
-        Entry e = getEntry(rootDir);
-        if (f.equals(rootDir)) {
-            e.all = true;
-            e.files.clear();
-        } else if (!e.all) {
-            e.files.add(getRelativePath(rootDir, f, id));
-        }
-    }
-
-    public void addGroups(Collection<String> groups) throws Fault {
-        for (String g: groups) {
-            int sep = g.lastIndexOf(":");
-            if (sep == -1)
-                throw new Fault(i18n, "tm.badGroupSpec", g);
-            Path rootDir = canon((sep == 0) ? baseDir : Path.of(g.substring(0, sep)));
+    public void addGroupSpecs(Collection<GroupSpec> groups) throws Fault {
+        for (GroupSpec g: groups) {
+            Path rootDir = canon((g.dir == null) ? baseDir : g.dir);
             if (!Files.exists(rootDir.resolve("TEST.ROOT")))
                 throw new Fault(i18n, "tm.badGroupTestSuite", g);
             Entry e = getEntry(rootDir);
-            e.groups.add(g.substring(sep + 1));
+            e.groups.add(g.groupName);
         }
     }
 
+    /**
+     * Returns whether the test manager is empty or not.
+     *
+     * @return true if the test manager does not contain any tests specs or group specs.
+     */
     public boolean isEmpty() {
         return map.isEmpty();
     }
 
+    /**
+     * Returns whether the test manager contains test specs or group specs
+     * from different test suites.
+     *
+     * @return true if the test manager contains test specs or group specs
+     * from different test suites
+     */
     public boolean isMultiRun() {
         return (map.size() > 1);
     }
 
+    /**
+     * Returns the set of test suites that contain the test specs or group specs
+     * that have been added.
+     *
+     * @return the test suites
+     * @throws Fault if there is an error accessing any of the test suites
+     */
     public Set<RegressionTestSuite> getTestSuites() throws Fault {
         LinkedHashSet<RegressionTestSuite> set = new LinkedHashSet<>();
         for (Entry e: map.values()) {
@@ -181,6 +378,14 @@ public class TestManager {
         return set;
     }
 
+    /**
+     * Sets the path for the work directory to be used for this run.
+     * When running tests in multiple test suites, separate work
+     * directories for each test suite will be created as subdirectories
+     * of this directory.
+     *
+     * @param wd the path for the work directory
+     */
     public void setWorkDirectory(Path wd) {
         if (wd == null)
             throw new NullPointerException();
@@ -189,12 +394,24 @@ public class TestManager {
         workDir = wd;
     }
 
+    /**
+     * Returns the path for the work directory to be used for this run.
+     *
+     * @return the path for the work directory
+     */
     public Path getWorkDirectory() {
         if (workDir == null)
             throw new IllegalStateException();
         return workDir;
     }
 
+    /**
+     * Returns the work directory to be used when running tests in a given test suite.
+     *
+     * @param ts the test suite
+     * @return the work directory
+     * @throws Fault if there is a problem accessing the work directory
+     */
     public WorkDirectory getWorkDirectory(RegressionTestSuite ts) throws Fault {
         Entry e = map.get(ts.getRootDir().toPath());
         if (e == null)
@@ -219,6 +436,14 @@ public class TestManager {
 
     }
 
+    /**
+     * Sets the path for the report directory to be used for this run.
+     * When running tests in multiple test suites, separate report
+     * directories for each test suite will be created as subdirectories
+     * of this directory.
+     *
+     * @param rd the path
+     */
     public void setReportDirectory(Path rd) {
         if (rd == null)
             throw new NullPointerException();
@@ -227,12 +452,24 @@ public class TestManager {
         reportDir = rd;
     }
 
+    /**
+     * Returns the path for the report directory to be used for this run.
+     *
+     * @return the path
+     */
     public Path getReportDirectory() {
         if (reportDir == null)
             throw new IllegalStateException();
         return reportDir;
     }
 
+    /**
+     * Returns the report directory to be used when running tests in a given test suite.
+     *
+     * @param ts the test suite
+     * @return the report directory
+     * @throws Fault if there is a problem accessing the report directory
+     */
     public Path getReportDirectory(RegressionTestSuite ts) throws Fault {
         Entry e = map.get(ts.getRootDir().toPath());
         if (e == null)
@@ -245,6 +482,14 @@ public class TestManager {
         return e.reportDir;
     }
 
+    /**
+     * Returns the name of the subdirectory to use when running tests from
+     * multiple test suites.
+     *
+     * @param ts the test suite
+     * @return the name of the subdirectory
+     * @throws Fault if there is a problem accessing the test suite
+     */
     String getSubdirectory(RegressionTestSuite ts) throws Fault {
         if (map.size() <= 1)
             return null;
@@ -257,6 +502,17 @@ public class TestManager {
         return e.subdir;
     }
 
+    /**
+     * Returns the set of tests to be run in a given test suite.
+     * The tests are identified in "URL form", containing the
+     * path of the test relative to the test suite root, and
+     * with an id if given. The query part of a test spec is
+     * not included.
+     *
+     * @param ts the test suite
+     * @return the list of tests
+     * @throws Fault if there is a problem with the tests to be run
+     */
     public Set<String> getTests(RegressionTestSuite ts) throws Fault {
         Entry e = map.get(ts.getRootDir().toPath());
         if (e == null)
@@ -265,21 +521,60 @@ public class TestManager {
             return null;
         WorkDirectory wd = getWorkDirectory(ts);
         Set<String> tests = new LinkedHashSet<>();
-        for (String test: e.files) {
-            if (validatePath(wd, test)) {
-                tests.add(test);
+        for (TestSpec test: e.tests) {
+            String t = test.getTestPath();
+            if (validatePath(wd, t)) {
+                tests.add(t);
             } else {
                 throw new Fault(i18n, "tm.notATest", test);
             }
         }
         for (Path f: expandGroups(e)) {
-            String test = getRelativePath(e.rootDir, f, null);
+            String test = pathToString(e.rootDir.relativize(f));
             if (validatePath(wd, test))
                 tests.add(test);
         }
         if (tests.isEmpty() && (!allowEmptyGroups || e.groups.isEmpty()))
             throw new NoTests();
         return tests;
+    }
+
+    /**
+     * Returns the list of tests to be run in a given test suite that
+     * contain a non-null query in the test spec.
+     * If there are multiple test specs for the same test path, then
+     * the last one wins. This applies regardless of whether the test spec
+     * contains a query or not.
+     * The tests are identified in "modified URL form",  containing the
+     * path of the test relative to the test suite root, an id if given,
+     * and the query part of the test spec.
+     *
+     * @param ts the test suite
+     * @return the list of tests
+     * @throws Fault if there is a problem with the tests to be run
+     */
+    public List<String> getTestQueries(RegressionTestSuite ts) throws Fault {
+        Entry e = map.get(ts.getRootDir().toPath());
+        if (e == null) {
+            throw new IllegalArgumentException();
+        }
+        if (e.all) {
+            return List.of();
+        }
+
+        // Eliminate any duplicates for each test path with "last one wins"
+        Map<String, TestSpec> map = new LinkedHashMap<>();
+        for (TestSpec t : e.tests) {
+            if (t.query != null && Files.isDirectory(e.rootDir.resolve(t.file))) {
+                throw new Fault(i18n, "tm.invalidQuery", t);
+            }
+            map.put(t.getTestPath(), t);
+        }
+        // Return the remaining test specs that contain a query component
+        return map.values().stream()
+                .filter(t -> t.query != null)
+                .map(t -> t.getTestPath() + "?" + t.query)
+                .collect(Collectors.toList());
     }
 
     // This method is to work around a bug in TestResultTable.validatePath
@@ -290,7 +585,6 @@ public class TestManager {
     // The solution is to check the root-relative path in the test description
     // to make sure it is the same as the original path.
     // See JBS CODETOOLS-7900138, CODETOOLS-7900139
-    @SuppressWarnings("cast") // temporary: to cover transition for generifying TreeIterator
     private boolean validatePath(WorkDirectory wd, String path) {
         try {
             TestResultTable trt = wd.getTestResultTable();
@@ -316,6 +610,14 @@ public class TestManager {
         }
     }
 
+    /**
+     * Returns the names of the groups containing tests to be run in
+     * the given test suite.
+     *
+     * @param ts the test suite
+     * @return the names of the groups to be run
+     * @throws Fault if there is a problem accessing the groups
+     */
     public Set<String> getGroups(RegressionTestSuite ts) throws Fault {
         Entry e = map.get(ts.getRootDir().toPath());
         if (e == null)
@@ -444,16 +746,7 @@ public class TestManager {
         }
     }
 
-    File canon(File file) {
-        File f = file.isAbsolute() ? file : new File(baseDir.toFile(), file.getPath());
-        try {
-            return f.getCanonicalFile();
-        } catch (IOException e) {
-            return getNormalizedFile(f);
-        }
-    }
-
-    Path canon(Path file) {
+    private Path canon(Path file) {
         Path f = file.isAbsolute() ? file : baseDir.resolve(file);
         try {
             return f.toRealPath();
@@ -462,28 +755,12 @@ public class TestManager {
         }
     }
 
-    static File getNormalizedFile(File f) {
-        return new File(f.getAbsoluteFile().toURI().normalize());
-    }
-
-    static Path getNormalizedFile(Path f) {
+    private static Path getNormalizedFile(Path f) {
         return f.toAbsolutePath().normalize();
     }
 
-    static String getRelativePath(Path base, Path f, String id) {
-        // maybe use base.relativize(f) ?
-        StringBuilder sb = new StringBuilder();
-        for ( ; f != null; f = f.getParent()) {
-            if (f.equals(base)) {
-                if (id != null)
-                    sb.append("#").append(id);
-                return sb.toString();
-            }
-            if (sb.length() > 0)
-                sb.insert(0, '/');
-            sb.insert(0, f.getFileName().toString());
-        }
-        return null;
+    private static String pathToString(Path p) {
+        return p.toString().replace(File.separatorChar, '/');
     }
 
     private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(TestManager.class);

--- a/src/share/classes/com/sun/javatest/regtest/config/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/config/i18n.properties
@@ -43,7 +43,6 @@ gm.invalid.name.for.group=invalid name for group
 
 rp.badPath="Bad path: {0}: {1}
 
-tm.badGroupSpec=Bad group spec: {0}
 tm.badGroupTestSuite=Group spec does not specify a valid test suite: {0}
 tm.cantDetermineTestSuite=Cannot determine test suite from test (is TEST.ROOT missing?): {0}
 tm.cantFindFile=Cannot find file: {0}
@@ -52,6 +51,7 @@ tm.cantReadGroups=Cannot read group files for {0}: {1}
 tm.cantOpenTestSuite=Cannot open test suite {0}: {1}
 tm.invalidGroup=Group is invalid: {0}
 tm.invalidGroups=One or more groups are invalid
+tm.invalidQuery=Invalid use of query component: {0}
 tm.notADirectory=Not a directory: {0}
 tm.notATest=Not a test or directory containing tests: {0}
 tm.noTests=No tests selected

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -735,6 +735,11 @@ public class RegressionScript extends Script {
         }
     }
 
+    String getTestQuery() {
+        String testName = testResult.getTestName();
+        return params.getTestQuery(testName);
+    }
+
     //----------------------- computing paths ---------------------------------
 
     Path absTestWorkFile(String name) {
@@ -1167,7 +1172,12 @@ public class RegressionScript extends Script {
         // initialize the properties with standard properties common to all tests
         Map<String, String> p = new LinkedHashMap<>(params.getBasicTestProperties());
         // add test-specific properties
-        p.put("test.name", testResult.getTestName());
+        String testName = testResult.getTestName();
+        p.put("test.name", testName);
+        String testQuery = params.getTestQuery(testName);
+        if (testQuery != null) {
+            p.put("test.query", testQuery);
+        }
         p.put("test.file", locations.absTestFile().toString());
         p.put("test.src", locations.absTestSrcDir().toString());
         p.put("test.src.path", toString(locations.absTestSrcPath()));

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -232,6 +232,10 @@ public class ShellAction extends Action
             if (script.enablePreview()) {
                 env.put("TESTENABLEPREVIEW", "true");
             }
+            String testQuery = script.getTestQuery();
+            if (testQuery != null) {
+                env.put("TESTQUERY", testQuery);
+            }
 
             List<String> command = new ArrayList<>();
             if (script.useWindowsSubsystemForLinux()) {

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -43,7 +43,6 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StreamTokenizer;
-import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -66,7 +65,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.swing.Timer;
@@ -114,9 +112,7 @@ import com.sun.javatest.regtest.report.TestStats;
 import com.sun.javatest.regtest.report.Verbose;
 import com.sun.javatest.regtest.report.VerboseHandler;
 import com.sun.javatest.regtest.report.XMLWriter;
-import com.sun.javatest.regtest.tool.Help.VersionHelper;
 import com.sun.javatest.regtest.util.NaturalComparator;
-import com.sun.javatest.regtest.util.StringUtils;
 import com.sun.javatest.tool.Desktop;
 import com.sun.javatest.util.BackupPolicy;
 import com.sun.javatest.util.I18NResourceBundle;
@@ -1002,35 +998,15 @@ public class Tool {
 
         new Option(FILE, MAIN, null) {
             @Override
-            public void process(String opt, String arg) {
-                if (groupPtn.matcher(arg).matches()) {
-                    testGroupArgs.add(arg);
-                } else if (fileIdPtn.matcher(arg).matches()) {
-                    int sep = arg.lastIndexOf("#");
-                    Path file = Path.of(arg.substring(0, sep));
-                    String id = arg.substring(sep + 1);
-                    testFileIdArgs.add(new TestManager.FileId(file, id));
+            public void process(String opt, String arg) throws BadArgs {
+                if (TestManager.GroupSpec.isGroupSpec(arg)) {
+                    testGroupSpecArgs.add(TestManager.GroupSpec.of(arg));
+                } else if (TestManager.TestSpec.isTestSpec(arg)) {
+                    testSpecArgs.add(TestManager.TestSpec.of(arg));
                 } else {
-                    testFileArgs.add(Path.of(arg));
+                    throw new BadArgs(i18n, "main.badTestOrGroup", arg);
                 }
             }
-
-            /* A "group" argument is of the form  [path]:id  where the path is a file path
-             * to the root of the test suite. On Windows, we have to be careful about
-             * the ambiguity between an absolute path beginning with a drive letter
-             * and a relative path that is a single letter. Therefore, on Windows,
-             * we accept the following for a path:
-             * - (empty)
-             * - a single non-alphabetic character followed by :id
-             * - two or more characters followed by :id
-             * Thus, letter:id is not accepted as a group spec, and so will be treated
-             * elsewhere as a plain absolute file path instead.
-             */
-            Pattern groupPtn = System.getProperty("os.name").matches("(?i)windows.*")
-                    ? Pattern.compile("(|[^A-Za-z]|.{2,}):[A-Za-z0-9_,]+")
-                    : Pattern.compile(".*:[A-Za-z0-9_,]+");
-
-            Pattern fileIdPtn = Pattern.compile(".*#[A-Za-z0-9-_]+");
         }
     );
 
@@ -1125,9 +1101,11 @@ public class Tool {
                 Tool.this.error(msg);
             }
         });
-        testManager.addTestFiles(testFileArgs);
-        testManager.addTestFileIds(testFileIdArgs);
-        testManager.addGroups(testGroupArgs);
+//        testManager.addTestFiles(testFileArgs);
+//        testManager.addTestFileIds(testFileIdArgs);
+        testManager.addTestSpecs(testSpecArgs);
+//        testManager.addGroups(testGroupArgs);
+        testManager.addGroupSpecs(testGroupSpecArgs);
 
         if (testManager.isEmpty())
             throw new TestManager.NoTests();
@@ -1397,7 +1375,7 @@ public class Tool {
      * for the test suites on the command line.  If a test suite is given
      * without qualifying with a group, all groups in that test suite are
      * shown.
-     * No filters (like keywords, status, etc) are taken into account.
+     * No filters (like keywords, status, etc.) are taken into account.
      */
     void showGroups(TestManager testManager) throws Fault {
         for (RegressionTestSuite ts : testManager.getTestSuites()) {
@@ -1662,7 +1640,16 @@ public class Tool {
 
             rp.setRetainArgs(retainArgs);
 
+            // the tests are the tests to be executed by the harness, and do not
+            // include the "query" component
             rp.setTests(testManager.getTests(testSuite));
+
+            // the tests that have an associated query component, included in
+            // the string
+            List<String> testQueries = testManager.getTestQueries(testSuite);
+            if (!testQueries.isEmpty()) {
+                rp.setTestQueries(testQueries);
+            }
 
             if (userKeywordExpr != null || extraKeywordExpr != null) {
                 String expr =
@@ -2134,7 +2121,7 @@ public class Tool {
     private void startHttpServer() {
         // start the http server
         // do this as early as possible, since objects may check
-        // HttpdServer.isActive() and decide whether or not to
+        // HttpdServer.isActive() and decide whether to
         // register their handlers
         HttpdServer server = new HttpdServer();
         Thread thr = new Thread(server);
@@ -2230,9 +2217,8 @@ public class Tool {
     }
 
     /**
-     * Returns whether or not Windows Subsystem for Linux may be
-     * available, by examining to see whether wsl.exe can be found on
-     * the path.
+     * Returns whether Windows Subsystem for Linux may be available,
+     * by examining to see whether wsl.exe can be found on the path.
      */
     private boolean isWindowsSubsystemForLinuxDetected() {
         if (isWindows()) {
@@ -2288,9 +2274,11 @@ public class Tool {
     private Float timeoutFactorArg;
     private String priorStatusValuesArg;
     private Path reportDirArg;
-    public List<String> testGroupArgs = new ArrayList<>();
-    public List<Path> testFileArgs = new ArrayList<>();
-    public List<TestManager.FileId> testFileIdArgs = new ArrayList<>();
+//    public List<String> testGroupArgs = new ArrayList<>();
+    public List<TestManager.GroupSpec> testGroupSpecArgs = new ArrayList<>();
+//    public List<Path> testFileArgs = new ArrayList<>();
+//    public List<TestManager.FileId> testFileIdArgs = new ArrayList<>();
+    public List<TestManager.TestSpec> testSpecArgs = new ArrayList<>();
 
     // these args are jtreg extras
     private Path baseDirArg;
@@ -2300,7 +2288,7 @@ public class Tool {
     private boolean guiFlag;
     private boolean reportOnlyFlag;
     private String showStream;
-    public enum ReportMode { NONE, EXECUTED, ALL_EXECUTED, ALL };
+    public enum ReportMode { NONE, EXECUTED, ALL_EXECUTED, ALL }
     private ReportMode reportMode;
     private boolean allowSetSecurityManagerFlag = true;
     private static Verbose  verbose;
@@ -2353,8 +2341,6 @@ public class Tool {
     private static final String[] DEFAULT_WINDOWS_ENV_VARS = {
         "SystemDrive", "SystemRoot", "windir", "TMP", "TEMP", "TZ"
     };
-
-    private static final String JAVATEST_ANT_FILE_LIST = "javatest.ant.file.list";
 
     private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Tool.class);
 }

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1101,10 +1101,7 @@ public class Tool {
                 Tool.this.error(msg);
             }
         });
-//        testManager.addTestFiles(testFileArgs);
-//        testManager.addTestFileIds(testFileIdArgs);
         testManager.addTestSpecs(testSpecArgs);
-//        testManager.addGroups(testGroupArgs);
         testManager.addGroupSpecs(testGroupSpecArgs);
 
         if (testManager.isEmpty())
@@ -2218,7 +2215,7 @@ public class Tool {
 
     /**
      * Returns whether Windows Subsystem for Linux may be available,
-     * by examining to see whether wsl.exe can be found on the path.
+     * by examining whether wsl.exe can be found on the path.
      */
     private boolean isWindowsSubsystemForLinuxDetected() {
         if (isWindows()) {
@@ -2274,13 +2271,10 @@ public class Tool {
     private Float timeoutFactorArg;
     private String priorStatusValuesArg;
     private Path reportDirArg;
-//    public List<String> testGroupArgs = new ArrayList<>();
-    public List<TestManager.GroupSpec> testGroupSpecArgs = new ArrayList<>();
-//    public List<Path> testFileArgs = new ArrayList<>();
-//    public List<TestManager.FileId> testFileIdArgs = new ArrayList<>();
-    public List<TestManager.TestSpec> testSpecArgs = new ArrayList<>();
 
     // these args are jtreg extras
+    public List<TestManager.GroupSpec> testGroupSpecArgs = new ArrayList<>();
+    public List<TestManager.TestSpec> testSpecArgs = new ArrayList<>();
     private Path baseDirArg;
     private ExecMode execMode;
     private JDK compileJDK;

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -369,11 +369,16 @@ help.tests.summary.directory.name=directory
 help.tests.summary.directory.desc=\
     All tests found in and under the given directory.
 
-help.tests.summary.file.name=file[#id]
+help.tests.summary.file.name=file[#id][?string]
 help.tests.summary.file.desc=\
     Either all tests in the given file if no id is given, or the specified \
     test if an id is given. A file contains multiple tests if there are \
-    multiple test descriptions, in separate comment blocks.
+    multiple test descriptions, in separate comment blocks.\n\
+    If '?string' is specified, the string will be passed to the test \
+    so that it may filter the parts of the test to be executed. \
+    The string will typically be the name of a method to be executed.\n\
+    If conflicting values for the string are given for a specific test, \
+    the last one given will be used.
 
 help.timeout.name=Timeout Options
 help.timeout.desc=These options control the behavior when tests run longer than their \
@@ -441,6 +446,7 @@ main.badParams=Bad parameters specified: {0}
 main.badPoolIdleTimeout=Bad value for agent pool idle timeout: {0}
 main.badRetainNone="none" cannot be combined with other options for -retain
 main.badRetainLastRun="lastRun" cannot be combined with other options for -retain
+main.badTestOrGroup=bad test or group specification: {0}
 main.badTimeLimit=Bad value for -timeLimit
 main.badTimeoutFactor=Bad use of -timeoutFactor
 main.badTimeoutHandlerTimeout=Bad value for -timeoutHandlerTimeout

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -434,11 +434,17 @@ the sections containing any of the specified terms. For example:
 
 The most basic way to specify which tests to run is to give one or more paths
 directly on the command line, for directories and files containing tests.
+
 If a file contains multiple tests, you can specify the name of a test within
 that file by appending `#`_ID_ to the file path, where _ID_ is either defined
 in the test itself after the `@test` tag, or the string `id`_N_  if no id is 
 explicitly defined, where N is the number of the test within the file, 
 and where `0` identifies the first test. 
+
+If you specify `?`_string_ after the name of a test, the _string_ will be
+passed down to the test, for the test to filter the parts of the test to be
+executed. For any tests executed by JUnit Platform, the string is interpreted
+as the name of a single method in the test to be executed.
 
 If you wish to specify a long list of arguments, you can put the list in a file
 and specify that file using the `@`_file_ option.
@@ -450,12 +456,13 @@ To summarise, you can use the following to specify tests to be run:
 
 Table: Kinds of Supported Arguments
 
-| Argument                | Description                                         |
-|-------------------------|-----------------------------------------------------|
+| Argument                | Description                                        |
+|-------------------------|----------------------------------------------------|
 | _directory_             | All tests found in files in and under the directory |
-| _file[#id]_             | All tests in a file, or a specific test in a file   |
-| _[directory]_`:`_group_ | All tests in a group defined for a testsuite        |   
-| `@`_file_               | Expand arguments in a file                          |
+| _file[#id]_             | All tests in a file, or a specific test in a file  |
+| _file[#id]?string_      | Parts of a test in a file                          |
+| _[directory]_`:`_group_ | All tests in a group defined for a testsuite       |   
+| `@`_file_               | Expand arguments in a file                         |
 
 
 You can further refine the set of tests to be run in various ways.
@@ -481,6 +488,14 @@ You can refine the set of tests to be run in various ways:
 Note that in addition to the command-line options just listed, a test
 may contain tags such as `@requires` and `@modules` that determine whether
 a test should be run on any particular system.
+
+### How do I specify to run a single test method in a JUnit test?
+
+Specify the test and method name on the command-line with the `?` syntax:
+
+    path-to-test?method-name
+
+See [How do I specify which tests to run?](#how-do-i-specify-which-tests-to-run).
 
 ### How do I specify the JDK to use?
 

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -444,7 +444,9 @@ and where `0` identifies the first test.
 If you specify `?`_string_ after the name of a test, the _string_ will be
 passed down to the test, for the test to filter the parts of the test to be
 executed. For any tests executed by JUnit Platform, the string is interpreted
-as the name of a single method in the test to be executed.
+as the name of a single method in the test to be executed.  If you give
+conflicting values for the string, including not setting any value, the last
+one specified will be used.
 
 If you wish to specify a long list of arguments, you can put the list in a file
 and specify that file using the `@`_file_ option.
@@ -489,7 +491,7 @@ Note that in addition to the command-line options just listed, a test
 may contain tags such as `@requires` and `@modules` that determine whether
 a test should be run on any particular system.
 
-### How do I specify to run a single test method in a JUnit test?
+### How do I run a single test method in a JUnit test?
 
 Specify the test and method name on the command-line with the `?` syntax:
 

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -1327,6 +1327,15 @@ as indicated by <code>@enablePreview</code> in the test description
 or an <code>enablePreview</code> entry in a TEST.properties file.
 
 <tr>
+<td><code>test.query</code>
+<td><code>TESTQUERY</code>
+<td>Set to the string specified on the command-line for this test,
+or not set if no value was specified. If set, a test may use
+the value to filter the parts of the test to be executed.
+For example, JUnit tests executed by the JUnit Platform, will interpret
+the value as the name of a single method to be executed.
+
+<tr>
 <td><i>Not Applicable</i>
 <td><code>FS</code>
 <td>The file separator character to use.

--- a/test/junitQueryTest/JUnitQueryTest.gmk
+++ b/test/junitQueryTest/JUnitQueryTest.gmk
@@ -231,6 +231,30 @@ $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok: $(JTREG_IMAGEDIR)/lib/javatest.j
 
 TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok
 
+
+#----------------------------------------------------------------------
+#
+# Invalid method name
+
+$(BUILDTESTDIR)/JUnitQueryTest.invalidMethod.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m14 \
+			> $(@:%.ok=%)/jt.log 2>&1 || \
+		true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s 'Could not find method with name \[m14] in class \[Test1]' $(@:%.ok=%)/jt.log
+	$(GREP) -s "TEST RESULT: Failed. Execution failed: .*JUnitException: .* failed to discover tests" $(@:%.ok=%)/jt.log
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.invalidMethod.ok
+
 #----------------------------------------------------------------------
 #
 # Convenience target
@@ -243,4 +267,5 @@ junit-query-tests: \
     $(BUILDTESTDIR)/JUnitQueryTest.m12.m13.ok \
     $(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok \
     $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok \
-    $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok
+    $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.invalidMethod.ok

--- a/test/junitQueryTest/JUnitQueryTest.gmk
+++ b/test/junitQueryTest/JUnitQueryTest.gmk
@@ -1,0 +1,246 @@
+#
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#----------------------------------------------------------------------
+#
+# Execute all (6) test methods in the test suite
+
+$(BUILDTESTDIR)/JUnitQueryTest.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/ \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.m11 Test1.m12 Test1.m13 Test2.m21 Test2.m22 Test2.m23" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ containers: 6, .* started: 6, succeeded: 6" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.all.ok
+
+#----------------------------------------------------------------------
+#
+# Execute a single specific method (Test1.m12) using the query syntax  Test1.java?m12
+
+$(BUILDTESTDIR)/JUnitQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.m12" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ containers: 3, .* started: 1, succeeded: 1" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.m12.ok
+
+#----------------------------------------------------------------------
+#
+# Execute a mixture of 4 tests:
+# - a single specific method (Test1.m12) using the query syntax  Test1.java?m12
+# - all (3) test methods in Test2.java
+
+$(BUILDTESTDIR)/JUnitQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test2.java \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.m12 Test2.m21 Test2.m22 Test2.m23" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ containers: 6, .* started: 4, succeeded: 4" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.m12.Test2.ok
+
+#----------------------------------------------------------------------
+#
+# Execute tests when duplicates are given: last one wins (m13, m12)
+# See related test for the reverse order
+
+$(BUILDTESTDIR)/JUnitQueryTest.m13.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.m12" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ containers: 3, .* started: 1, succeeded: 1" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.m13.m12.ok
+
+#----------------------------------------------------------------------
+#
+# Execute tests when duplicates are given: last one wins (m12, m13)
+# See related test for the reverse order
+
+$(BUILDTESTDIR)/JUnitQueryTest.m12.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.m13" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ containers: 3, .* started: 1, succeeded: 1" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.m12.m13.ok
+
+#----------------------------------------------------------------------
+#
+# Execute tests when duplicates are given: last one wins (m13, all)
+# See related test for the reverse order
+
+$(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.m11 Test1.m12 Test1.m13" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ containers: 3, .* started: 3, succeeded: 3" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok
+
+#----------------------------------------------------------------------
+#
+# Execute tests when duplicates are given: last one wins (all, m13)
+# See related test for the reverse order
+
+$(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java \
+		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.m13" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ containers: 3, .* started: 1, succeeded: 1" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok
+
+#----------------------------------------------------------------------
+#
+# Invalid use of query
+
+$(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		$(TESTDIR)/junitQueryTest/a/b/c?m13 \
+			> $(@:%.ok=%)/jt.log 2>&1 || \
+		true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s "Error: Invalid use of query component: a/b/c?m13" $(@:%.ok=%)/jt.log
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok
+
+#----------------------------------------------------------------------
+#
+# Convenience target
+
+junit-query-tests: \
+    $(BUILDTESTDIR)/JUnitQueryTest.all.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.m12.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.m12.Test2.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.m13.m12.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.m12.m13.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok

--- a/test/junitQueryTest/a/b/c/TEST.properties
+++ b/test/junitQueryTest/a/b/c/TEST.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+JUnit.dirs = .

--- a/test/junitQueryTest/a/b/c/Test1.java
+++ b/test/junitQueryTest/a/b/c/Test1.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A collection of test methods, to help exercise the query mechanism.
+ * Each method just prints its name.
+ */
+public class Test1 {
+    @Test
+    public void m11() {
+        System.out.println("Test1.m11");
+    }
+
+    @Test
+    public void m12() {
+        System.out.println("Test1.m12");
+    }
+
+    @Test
+    public void m13() {
+        System.out.println("Test1.m13");
+    }
+}

--- a/test/junitQueryTest/a/b/c/Test2.java
+++ b/test/junitQueryTest/a/b/c/Test2.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A collection of test methods, to help exercise the query mechanism.
+ * Each method just prints its name.
+ */
+public class Test2 {
+    @Test
+    public void m21() {
+        System.out.println("Test2.m21");
+    }
+
+    @Test
+    public void m22() {
+        System.out.println("Test2.m22");
+    }
+
+    @Test
+    public void m23() {
+        System.out.println("Test2.m23");
+    }
+}


### PR DESCRIPTION
Please review a medium-sized patch to support new feature that provides a way to specify that only parts of a test should be executed.  For JUnit tests, this allows a single method in the test to be executed, but the underlying mechanism is more general than that and can be leveraged by any framework that supports running many test cases within an overall test.

The feature is enabled by using a new syntactic form on the command line, informally called _query syntax_: `path-to-test?string`. The syntax is based on URL syntax, but note that unlike URLs, the query component comes at the end, and not before any fragment component. In other words, the full syntax is `path#id?string`. Generally, this reflects the hierarchical structure:   a path to a file, a test description within the file, and a string to specify part of the test to be run.

In terms of implementation, the "heavy lifting" is done in `TestManager`, to track the _file, id, query_ tuple, as compared to the previous _file, id_.  New abstractions `TestSpec` and `GroupSpec` are introduced, to replace stylistic use of simple strings.

The underlying JT Harness does not know (or need to know) about query components and so is unchanged. But the back end `RegressionScript` used to execute each test _does_ need to know the query component, and so the information about which tests involve a query component is tunneled through the `RegressionParameters` in a side channel, embodied by a new resource in the object. In itself, the `RegressionScript` has little to do with the query component, it is simply passed down to the actions of the test in a new `test.query` property or `TESTQUERY` environment variable.

`JUnitRunner` is updated to check for the new `test.query` property: if set, it is used as the name of a test method to be run. Note: a JUnit exception will be thrown and the test will fail if the method is not found. The exception does contain enough useful information to diagnose the issue, but we may want to detect and report the issue in a more friendly form in a followup change.

Finally, new jtreg self-tests are added to exercise the new feature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903267](https://bugs.openjdk.org/browse/CODETOOLS-7903267): Support executing a single test method in a JUnit class


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.org/jtreg pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/115.diff">https://git.openjdk.org/jtreg/pull/115.diff</a>

</details>
