### PR TITLE
7903299: Add '.gradle/' and 'build/' to file '.gitignore'

### DIFF
--- a/plugins/idea/.gitignore
+++ b/plugins/idea/.gitignore
@@ -1,1 +1,4 @@
 .idea
+.gradle/
+build/
+


### PR DESCRIPTION
Hi all,

The directories '.gradle' and 'build/' are autumaticall created when opening and building the plugin project. It is good to ignore them in the git repo.

Thanks for taking time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903299](https://bugs.openjdk.org/browse/CODETOOLS-7903299): Add '.gradle/' and 'build/' to file '.gitignore'


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/jtreg pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/116.diff">https://git.openjdk.org/jtreg/pull/116.diff</a>

</details>
