### PR TITLE
7903318: Make -report:executed the default

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1179,7 +1179,7 @@ public class Tool {
         }
 
         if (reportMode == null) {
-            reportMode = ReportMode.ALL_EXECUTED;
+            reportMode = ReportMode.EXECUTED;
         }
 
         if (workDirArg == null) {


### PR DESCRIPTION
Please review this change to the default value of `reportMode` property.

The proposed report mode produces a report on the selected tests only; it is very fast to execute, and usually completes under a second.
The current default mode produces a report on all tests in the same test suite. It requires scanning all directories and source files in the test suite, requires a long time to produce, and usually produces the same results when jtreg is invoked from make.

If this change is integrated, the old report mode will be available under command line option `-report:all-executed`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903318](https://bugs.openjdk.org/browse/CODETOOLS-7903318): Make -report:executed the default


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jtreg pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/123.diff">https://git.openjdk.org/jtreg/pull/123.diff</a>

</details>
