### PR TITLE
CODETOOLS-7903325: jtreg check for macos version should take into account the process exit code

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -183,9 +183,10 @@ public class Tool {
     private static void checkJavaOSVersion() {
         String osName = System.getProperty("os.name");
         if (osName != null && osName.equals("Mac OS X")) {
+            var command = List.of("sw_vers", "-productVersion");
             try {
                 String expectVersion;
-                Process p = new ProcessBuilder("sw_vers", "-productVersion")
+                Process p = new ProcessBuilder(command)
                         .redirectErrorStream(true)
                         .start();
                 try (InputStream in = p.getInputStream();
@@ -193,11 +194,18 @@ public class Tool {
                     expectVersion = r.lines().collect(Collectors.joining());
                 }
                 p.waitFor();
+                int rc = p.exitValue();
+                if (rc != 0) {
+                    System.err.println("Error getting OS version: "
+                            + String.join(" ", command) + ": rc=" + rc);
+                    System.exit(99);
+                }
 
                 checkJavaOSVersion(expectVersion);
 
             } catch (IOException | InterruptedException e) {
-                System.err.println("Error getting OS version: " + e);
+                System.err.println("Error getting OS version: "
+                        + String.join(" ", command) + ": " + e);
                 System.exit(99);
             }
         }


### PR DESCRIPTION
Please review a simple change to improve the reporting in the check for the macOS version.

Tested by temporarily modifying the code in place to change the command or its exit code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903325](https://bugs.openjdk.org/browse/CODETOOLS-7903325): jtreg check for macos version should take into account the process exit code


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/jtreg pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/124.diff">https://git.openjdk.org/jtreg/pull/124.diff</a>

</details>
