### PR TITLE
CODETOOLS-7903323: Review and improve performance of jtreg reporting.

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionTestFinder.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionTestFinder.java
@@ -50,6 +50,7 @@ import com.sun.javatest.finder.HTMLCommentStream;
 import com.sun.javatest.finder.JavaCommentStream;
 import com.sun.javatest.finder.ShScriptCommentStream;
 import com.sun.javatest.finder.TagTestFinder;
+import com.sun.javatest.regtest.agent.Flags;
 import com.sun.javatest.regtest.exec.Action;
 import com.sun.javatest.regtest.util.StringUtils;
 import com.sun.javatest.util.I18NResourceBundle;
@@ -127,6 +128,10 @@ public class RegressionTestFinder extends TagTestFinder
 
     @Override
     protected void scanFile(File file) {
+        if (traceFinder) {
+            System.err.println("RegressionTestFinder: reading " + file);
+        }
+
         try {
             File tngRoot = properties.getTestNGRoot(file);
             if (tngRoot != null) {
@@ -1058,4 +1063,6 @@ public class RegressionTestFinder extends TagTestFinder
     private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(RegressionTestFinder.class);
     private static final boolean rejectTrailingBuild =
             !Boolean.getBoolean("javatest.regtest.allowTrailingBuild");
+
+    private static final boolean traceFinder = Flags.get("traceFinder");
 }

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -385,7 +385,7 @@ public class Tool {
             }
 
             @Override
-            public void process(String opt, String arg) {
+            public void process(String opt, String arg) throws BadArgs {
                 switch (arg) {
                     case "none":
                         reportMode = ReportMode.NONE;
@@ -396,9 +396,14 @@ public class Tool {
                     case "all-executed":
                         reportMode = ReportMode.ALL_EXECUTED;
                         break;
+                    case "files":
+                        reportMode = ReportMode.FILES;
+                        break;
                     case "all":
                         reportMode = ReportMode.ALL;
                         break;
+                    default:
+                        throw new BadArgs(i18n, "main.badReportOption", arg);
                 }
             }
         },
@@ -1920,11 +1925,12 @@ public class Tool {
                         default:
                             throw new IllegalStateException();
 
-                        case EXECUTED:
+                        case EXECUTED: {
                             ParameterFilter pf = new ParameterFilter();
                             pf.update(params);
                             tf = pf;
                             break;
+                        }
 
                         case ALL_EXECUTED:
                             boolean[] statusValues = new boolean[Status.NUM_STATES];
@@ -1938,8 +1944,21 @@ public class Tool {
                         case ALL:
                             tf = new AllTestsFilter();
                             break;
-                    }
 
+                        case FILES: {
+                            try {
+                                RegressionParameters reportParams = new RegressionParameters("regtest", params.getTestSuite(), out::println);
+                                reportParams.setWorkDirectory(params.getWorkDirectory());
+                                reportParams.setTests(params.getTests());
+                                ParameterFilter pf = new ParameterFilter();
+                                pf.update(reportParams);
+                                tf = pf;
+                                break;
+                            } catch (Interview.Fault e) {
+                                throw new Fault(i18n, "main.cantCreateReportParameters", e);
+                            }
+                        }
+                    }
                 }
                 r.report(params, elapsedTimeHandler, stats, tf, quiet);
             }
@@ -2239,7 +2258,7 @@ public class Tool {
     private boolean guiFlag;
     private boolean reportOnlyFlag;
     private String showStream;
-    public enum ReportMode { NONE, EXECUTED, ALL_EXECUTED, ALL }
+    public enum ReportMode { NONE, EXECUTED, FILES, ALL_EXECUTED, ALL }
     private ReportMode reportMode;
     private boolean allowSetSecurityManagerFlag = true;
     private static Verbose  verbose;

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -196,6 +196,8 @@ help.main.report.all-executed.desc=Include all tests that have been executed in 
      current work directory
 help.main.report.all.desc=Include all tests that are present in the test suite, \
      whether they have been executed
+help.main.report.files.desc=Include all tests specified by groups and paths \
+     on the command line, ignoring filters like status, exclude lists, and keywords.
 help.main.startHttpd.desc=Start the http server to view test results
 help.main.showGroups.desc=Show the expansion (to files and directories) of the \
     groups given on the command line. To see the expansion of all the groups \
@@ -444,12 +446,14 @@ main.badLockFile=Bad lock file: {0}
 main.badMaxPoolSize=Bad value for maximum pool size: {0}
 main.badParams=Bad parameters specified: {0}
 main.badPoolIdleTimeout=Bad value for agent pool idle timeout: {0}
+main.badReportOption=Bad value for -report: {0}
 main.badRetainNone="none" cannot be combined with other options for -retain
 main.badRetainLastRun="lastRun" cannot be combined with other options for -retain
 main.badTestOrGroup=bad test or group specification: {0}
 main.badTimeLimit=Bad value for -timeLimit
 main.badTimeoutFactor=Bad use of -timeoutFactor
 main.badTimeoutHandlerTimeout=Bad value for -timeoutHandlerTimeout
+main.cantCreateReportParameters=Cannot create report parameters: {0}
 main.cantCreateDir=Cannot create directory: {0}
 main.cantCreateLockFile="Can''t create lock file: {0}
 main.cantCreateParameters="Can''t create parameters: {0}

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -58,7 +58,7 @@ implement this specification, and is an older name for what is now known as
 
 ### What are the system requirements for using the JDK regression extensions?
 
-It is recommended that you run jtreg using JDK 1.8 or later.
+It is recommended that you run jtreg using JDK 11 or later.
 
 ### Where can I find a copy of jtreg?
 
@@ -559,7 +559,8 @@ The plain text files in the report directory include the following:
 * `summary.txt`: summary of test results: one test per line, suitable for use with `grep`
 * `timeStats.txt`: some statistics regarding test execution times
 
-Reports can be disabled with the `-noreport` option.
+Reports can be disabled with the `-noreport` option; the set of tests included
+in the report can be selected with the `-report:`_value_ option.
 
 It is generally recommended that the work and report directories should _not_ be
 placed anywhere in the test suite itself. Since jtreg may scan the entire test suite
@@ -1090,6 +1091,16 @@ These values are then followed by the mean and standard deviation
 of the test execution times.  If there are any tests taking an
 unexpectedly long time to execute, they can be determined by examining
 the `elapsed` entries in the `.jtr` files.
+
+### Why is there a delay after the tests have been run, before jtreg exits?
+
+By default, jtreg reports on all the tests that have been executed
+and which have results in the work directory. It may take a few seconds
+to find the set of tests for the report. You can use the `-report:`_value_
+option to specify which tests should be in the report. If you are just
+running a single test or a few tests, you may want to use `-report:files`,
+to just report on the tests specified in the files and/or groups given on the
+command line.
 
 ### How do I find the tests that took longest to run?
 

--- a/test/reportOption/ReportOptionTest.gmk
+++ b/test/reportOption/ReportOptionTest.gmk
@@ -1,0 +1,322 @@
+#
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# These tests first do an initial run of jtreg to set up results in
+# a work directory, and then do a subsequent run with varying options
+# to verify the expected set of tests are reported.
+
+#-------------------------------------------------------------------------------
+#
+# -report:none
+#
+# No report directory should be written.
+# Just the test files and no extra files should be read.
+
+$(BUILDTESTDIR)/ReportOptionTest.none.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -nr \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/reportOption/also-run $(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/setup-jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	JTREG_TRACEFINDER=1 \
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-report:none \
+		$(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s 'Test results: passed: 1; failed: 1; error: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	if grep 'Report written' $(@:%.ok=%/jt.log) ; then \
+	    echo "error: report written unexpectedly" ; exit 1 ; \
+	fi
+	if [ "`$(GREP) RegressionTestFinder $(@:%.ok=%/jt.log) | $(WC) -l`" -ne "3" ]; then \
+	    echo "error: unexpected number of files read" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%/jt.log) ; then \
+	    echo "error: do-not-run files were read unexpectedly" ; exit 1 ; \
+	fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/ReportOptionTest.none.ok
+
+
+#-------------------------------------------------------------------------------
+#
+# -report:executed
+#
+# The report directory should be written.
+# The report should just list the executed tests.
+# Just the test files and no extra files should be read.
+
+$(BUILDTESTDIR)/ReportOptionTest.executed.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -nr \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/reportOption/also-run $(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/setup-jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	JTREG_TRACEFINDER=1 \
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-report:executed \
+		$(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s 'Test results: passed: 1; failed: 1; error: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	if [ ! -d $(@:%.ok=%)/report ]; then \
+	    echo "error: report not found" ; exit 1 ; \
+	fi
+	if [ "`$(CAT) $(@:%.ok=%)/report/text/summary.txt | $(WC) -l`" -ne "3" ]; then \
+	    echo "error: unexpected number of tests in summary report" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%)/report/text/summary.txt ; then \
+	    echo "error: do-not-run tests in summary report" ; exit 1 ; \
+	fi
+	if [ "`$(GREP) RegressionTestFinder $(@:%.ok=%/jt.log) | $(WC) -l`" -ne "3" ]; then \
+	    echo "error: unexpected number of files read" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%/jt.log) ; then \
+	    echo "error: do-not-run files were read unexpectedly" ; exit 1 ; \
+	fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/ReportOptionTest.executed.ok
+
+
+#-------------------------------------------------------------------------------
+#
+# -report:all-executed
+#
+# The report directory should be written.
+# The report should just list all the executed tests.
+# All the test files should be read.
+
+$(BUILDTESTDIR)/ReportOptionTest.all-executed.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -nr \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/reportOption/also-run $(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/setup-jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	JTREG_TRACEFINDER=1 \
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-report:all-executed \
+		$(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s 'Test results: passed: 1; failed: 1; error: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	if [ ! -d $(@:%.ok=%)/report ]; then \
+	    echo "error: report not found" ; exit 1 ; \
+	fi
+	if [ "`$(CAT) $(@:%.ok=%)/report/text/summary.txt | $(WC) -l`" -ne "6" ]; then \
+	    echo "error: unexpected number of tests in summary report" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%)/report/text/summary.txt ; then \
+	    echo "error: do-not-run tests in summary report" ; exit 1 ; \
+	fi
+	if [ "`$(GREP) RegressionTestFinder $(@:%.ok=%/jt.log) | $(WC) -l`" -ne "9" ]; then \
+	    echo "error: unexpected number of files read" ; exit 1 ; \
+	fi
+	if ! $(GREP) "do-not-run" $(@:%.ok=%/jt.log) ; then \
+	    echo "error: do-not-run files were not read" ; exit 1 ; \
+	fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/ReportOptionTest.all-executed.ok
+
+
+#-------------------------------------------------------------------------------
+#
+# -report:all
+#
+# The report directory should be written.
+# The report should list all the tests.
+# All the test files should be read.
+
+$(BUILDTESTDIR)/ReportOptionTest.all.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -nr \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/reportOption/also-run $(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/setup-jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	JTREG_TRACEFINDER=1 \
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-report:all \
+		$(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s 'Test results: passed: 1; failed: 1; error: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	if [ ! -d $(@:%.ok=%)/report ]; then \
+	    echo "error: report not found" ; exit 1 ; \
+	fi
+	if [ "`$(CAT) $(@:%.ok=%)/report/text/summary.txt | $(WC) -l`" -ne "9" ]; then \
+	    echo "error: unexpected number of tests in summary report" ; exit 1 ; \
+	fi
+	if ! $(GREP) "do-not-run" $(@:%.ok=%)/report/text/summary.txt ; then \
+	    echo "error: do-not-run tests not found in summary report" ; exit 1 ; \
+	fi
+	if [ "`$(GREP) RegressionTestFinder $(@:%.ok=%/jt.log) | $(WC) -l`" -ne "9" ]; then \
+	    echo "error: unexpected number of files read" ; exit 1 ; \
+	fi
+	if ! $(GREP) "do-not-run" $(@:%.ok=%/jt.log) ; then \
+	    echo "error: do-not-run files were not read" ; exit 1 ; \
+	fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/ReportOptionTest.all.ok
+
+
+#-------------------------------------------------------------------------------
+#
+# -report:files
+#
+# The report directory should be written.
+# The report should just list all the tests given on the command line.
+# Just the test files and no extra files should be read.
+
+$(BUILDTESTDIR)/ReportOptionTest.files.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -nr \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/reportOption/also-run $(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/setup-jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	JTREG_TRACEFINDER=1 \
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-report:files \
+		$(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s 'Test results: passed: 1; failed: 1; error: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	if [ ! -d $(@:%.ok=%)/report ]; then \
+	    echo "error: report not found" ; exit 1 ; \
+	fi
+	if [ "`$(CAT) $(@:%.ok=%)/report/text/summary.txt | $(WC) -l`" -ne "3" ]; then \
+	    echo "error: unexpected number of tests in summary report" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%)/report/text/summary.txt ; then \
+	    echo "error: do-not-run tests found in summary report" ; exit 1 ; \
+	fi
+	if [ "`$(GREP) RegressionTestFinder $(@:%.ok=%/jt.log) | $(WC) -l`" -ne "3" ]; then \
+	    echo "error: unexpected number of files read" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%/jt.log) ; then \
+	    echo "error: do-not-run files were read unexpectedly" ; exit 1 ; \
+	fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/ReportOptionTest.files.ok
+
+
+#-------------------------------------------------------------------------------
+#
+# -report:files -status:fail
+#
+# The report directory should be written.
+# The report should just list all the tests given on the command line.
+# Just the test files and no extra files should be read.
+
+$(BUILDTESTDIR)/ReportOptionTest.files-status.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -nr \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/reportOption/also-run $(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/setup-jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	JTREG_TRACEFINDER=1 \
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-report:files -status:fail \
+		$(TESTDIR)/reportOption/to-be-run \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from jtreg intentionally ignored"
+	$(GREP) -s 'Test results: failed: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	if [ ! -d $(@:%.ok=%)/report ]; then \
+	    echo "error: report not found" ; exit 1 ; \
+	fi
+	if [ "`$(CAT) $(@:%.ok=%)/report/text/summary.txt | $(WC) -l`" -ne "3" ]; then \
+	    echo "error: unexpected number of tests in summary report" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%)/report/text/summary.txt ; then \
+	    echo "error: do-not-run tests found in summary report" ; exit 1 ; \
+	fi
+	if [ "`$(GREP) RegressionTestFinder $(@:%.ok=%/jt.log) | $(WC) -l`" -ne "3" ]; then \
+	    echo "error: unexpected number of files read" ; exit 1 ; \
+	fi
+	if $(GREP) "do-not-run" $(@:%.ok=%/jt.log) ; then \
+	    echo "error: do-not-run files were read unexpectedly" ; exit 1 ; \
+	fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/ReportOptionTest.files-status.ok
+
+
+
+#----------------------------------------------------------------------
+#
+# Convenience target
+
+report-option-tests: \
+    $(BUILDTESTDIR)/ReportOptionTest.none.ok \
+    $(BUILDTESTDIR)/ReportOptionTest.executed.ok \
+    $(BUILDTESTDIR)/ReportOptionTest.all-executed.ok \
+    $(BUILDTESTDIR)/ReportOptionTest.all.ok \
+    $(BUILDTESTDIR)/ReportOptionTest.files.ok \
+    $(BUILDTESTDIR)/ReportOptionTest.files-status.ok

--- a/test/reportOption/also-run/Error.java
+++ b/test/reportOption/also-run/Error.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory may be run
+
+/*
+ * @test
+ * @run syntax-error
+ */
+public class Error {
+    public static void main(String... args) { }
+}

--- a/test/reportOption/also-run/Fail.java
+++ b/test/reportOption/also-run/Fail.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory may be run
+
+/*
+ * @test
+ * @run main Fail
+ */
+public class Fail {
+    public static void main(String... args) {
+        throw new RuntimeException("this test should fail");
+    }
+}

--- a/test/reportOption/also-run/Pass.java
+++ b/test/reportOption/also-run/Pass.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory may be run
+
+/*
+ * @test
+ * @run main Pass
+ */
+public class Pass {
+    public static void main(String... args) { }
+}

--- a/test/reportOption/do-not-run/Error.java
+++ b/test/reportOption/do-not-run/Error.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory should not be run
+
+/*
+ * @test
+ * @run syntax-error
+ */
+public class Error {
+    public static void main(String... args) { }
+}

--- a/test/reportOption/do-not-run/Fail.java
+++ b/test/reportOption/do-not-run/Fail.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory should not be run
+
+/*
+ * @test
+ * @run main Fail
+ */
+public class Fail {
+    public static void main(String... args) {
+        throw new RuntimeException("this test should fail");
+    }
+}

--- a/test/reportOption/do-not-run/Pass.java
+++ b/test/reportOption/do-not-run/Pass.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory should not be run
+
+/*
+ * @test
+ * @run main Pass
+ */
+public class Pass {
+    public static void main(String... args) { }
+}

--- a/test/reportOption/to-be-run/Error.java
+++ b/test/reportOption/to-be-run/Error.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory are to be run
+
+/*
+ * @test
+ * @run syntax-error
+ */
+public class Error {
+    public static void main(String... args) { }
+}

--- a/test/reportOption/to-be-run/Fail.java
+++ b/test/reportOption/to-be-run/Fail.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory are to be run
+
+/*
+ * @test
+ * @run main Fail
+ */
+public class Fail {
+    public static void main(String... args) {
+        throw new RuntimeException("this test should fail");
+    }
+}

--- a/test/reportOption/to-be-run/Pass.java
+++ b/test/reportOption/to-be-run/Pass.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// tests in this directory are to be run
+
+/*
+ * @test
+ * @run main Pass
+ */
+public class Pass {
+    public static void main(String... args) { }
+}


### PR DESCRIPTION
Please review a medium simple update to address the annoying delay between the last test being executed and jtreg exiting.

The delay is due to writing the report, a side-effect of which is to scan the entire test-suite, to determine which tests have been executed.

It is not easy/simple to optimize that default; instead, a new report mode is added, that reports on all the tests in the test files and groups given on the command line -- ignoring any additional filters such as the status filter, keyword filter and exclude list filter.  As such, it has more "common-sense" semantics when rerunning tests with `-status:fail`.

There were no existing tests for the `-report` option.  Tests have been added for all flavors of the `-report` option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903323](https://bugs.openjdk.org/browse/CODETOOLS-7903323): Review and improve performance of jtreg reporting.


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.org/jtreg pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/125.diff">https://git.openjdk.org/jtreg/pull/125.diff</a>

</details>
