### PR TITLE
CODETOOLS-7903329: Trace reasons to recompile extra property definition files

### DIFF
--- a/test/extra-props/ExtraPropDefnsTest.gmk
+++ b/test/extra-props/ExtraPropDefnsTest.gmk
@@ -127,21 +127,22 @@ $(BUILDTESTDIR)/ExtraPropDefnsTest.comments.ok: \
 		-jdk:$(JDKHOME) \
 		-J-Dtrace.extraPropDefns=true \
 		$(TESTDIR)/extra-props/comments \
-			> $(@:%.ok=%/jt.log) 2>&1
-	$(GREP) -s "Compiling extra property definition files" $(@:%.ok=%/jt.log)
-	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.log)  > /dev/null
+			> $(@:%.ok=%/jt.1.log) 2>&1
+	$(GREP) -s "Compiling extra property definition files" $(@:%.ok=%/jt.1.log)
+	$(GREP) -s "Class file not found" $(@:%.ok=%/jt.1.log)
+	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.1.log)  > /dev/null
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-J-Dtrace.extraPropDefns=true \
 		$(TESTDIR)/extra-props/comments \
-			> $(@:%.ok=%/jt.log) 2>&1
-	if $(GREP) -s "Compiling extra property definition files" $(@:%.ok=%/jt.log) ; then \
+			> $(@:%.ok=%/jt.2.log) 2>&1
+	if $(GREP) -s "Compiling extra property definition files" $(@:%.ok=%/jt.2.log) ; then \
 	    echo "error: files compiled unexpectedly" ; exit 1 ; \
 	else \
 	    echo "no files recompiled, as expected" ; \
 	fi
-	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.2.log)  > /dev/null
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \


### PR DESCRIPTION
Please review a small change to optionally trace why the "extra property definitions" files need to be (re)compiled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903329](https://bugs.openjdk.org/browse/CODETOOLS-7903329): Trace reasons to recompile extra property definition files


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.org/jtreg pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/126.diff">https://git.openjdk.org/jtreg/pull/126.diff</a>

</details>
