### PR TITLE
CODETOOLS-7903346: Cannot compile jtreg with jdk-19

### DIFF
--- a/src/share/classes/com/sun/javatest/diff/SuperDiff.java
+++ b/src/share/classes/com/sun/javatest/diff/SuperDiff.java
@@ -212,9 +212,8 @@ class SuperDiff extends Diff {
         }
     }
 
+    @SuppressWarnings("serial")
     static class SuperTable extends TreeMap<YearDay, Map<String, File>> {
-
-        static final long serialVersionUID = 5933594140534747584L;
 
         SuperTable(File inDir, String resultPath) {
             super();


### PR DESCRIPTION
Please review a trivial change to a class in the jtreg repo, to disable warnings on an "unintentionally serializable" class.
The class extends `TreeMap` which happens to be `Serializable`, and the class contains some non-serializable fields.

In JDK 18, the javac serialization warnings were enhanced, causing this code to fail to compile with `-Xlint -Werror`.