### PR TITLE
CODETOOLS-7903331: jtreg fails with StringIndexOutOfBoundsException: Index -1 out of bounds for length 0

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestManager.java
@@ -503,22 +503,25 @@ public class TestManager {
     }
 
     /**
-     * Returns the set of tests to be run in a given test suite.
+     * Returns the set of tests to be run in a given test suite,
+     * or {@code null} meaning "all tests".
      * The tests are identified in "URL form", containing the
      * path of the test relative to the test suite root, and
      * with an id if given. The query part of a test spec is
      * not included.
      *
      * @param ts the test suite
-     * @return the list of tests
+     * @return the list of tests, or {@code null} for all tests
      * @throws Fault if there is a problem with the tests to be run
      */
     public Set<String> getTests(RegressionTestSuite ts) throws Fault {
         Entry e = map.get(ts.getRootDir().toPath());
-        if (e == null)
+        if (e == null) {
             throw new IllegalArgumentException();
-        if (e.all)
-            return null;
+        }
+        if (e.all) {
+            return null; // all tests
+        }
         WorkDirectory wd = getWorkDirectory(ts);
         Set<String> tests = new LinkedHashSet<>();
         for (TestSpec test: e.tests) {
@@ -531,8 +534,11 @@ public class TestManager {
         }
         for (Path f: expandGroups(e)) {
             String test = pathToString(e.rootDir.relativize(f));
-            if (validatePath(wd, test))
+            if (test.isEmpty()) {
+                return null; // all tests
+            } else if (validatePath(wd, test)) {
                 tests.add(test);
+            }
         }
         if (tests.isEmpty() && (!allowEmptyGroups || e.groups.isEmpty()))
             throw new NoTests();

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1614,6 +1614,7 @@ public class Tool {
 
             // the tests are the tests to be executed by the harness, and do not
             // include the "query" component
+            // 'null' means "all tests"
             rp.setTests(testManager.getTests(testSuite));
 
             // the tests that have an associated query component, included in

--- a/test/groups2/Group2Test.gmk
+++ b/test/groups2/Group2Test.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,46 +25,36 @@
 
 #----------------------------------------------------------------------
 
-GroupTest.GROUPS := $(shell $(GREP) -h '=' \
-	$(TESTDIR)/groups/TEST.group* | \
-	$(AWK) '{print $$1}' | $(SORT) -unk 1.2 )
+Group2Test.GROUPS = all indirectAll allWithExtra
 
-$(BUILDTESTDIR)/GroupTest.ok: $(GroupTest.GROUPS:%=$(BUILDTESTDIR)/GroupTest.%.ok)
+$(BUILDTESTDIR)/Group2Test.ok: \
+		$(Group2Test.GROUPS:%=$(BUILDTESTDIR)/Group2Test.%.ok) \
+		$(Group2Test.GROUPS:%=$(BUILDTESTDIR)/Group2Test.report-files.%.ok)
 	echo $@ passed at `date` > $@
 
-$(GroupTest.GROUPS:%=$(BUILDTESTDIR)/GroupTest.%.ok): \
+$(Group2Test.GROUPS:%=$(BUILDTESTDIR)/Group2Test.%.ok): \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		$(TESTDIR)/groups:$(@:$(BUILDTESTDIR)/GroupTest.%.ok=%) ; \
-	status=$$? ; echo status=$$status ; \
-	case "$(@:$(BUILDTESTDIR)/GroupTest.%.ok=%)" in \
-		g6 )  expect=1 ;; \
-		g10|g11|g12 ) expect=5 ;; \
-		* ) expect=0 ;; \
-	esac ; \
-	if [ "$$status" != "$$expect" ]; then echo "unexpected exit: $$status" ; exit 1; fi
+		$(TESTDIR)/groups2:$(@:$(BUILDTESTDIR)/Group2Test.%.ok=%) \
+		1>$(@:%.ok=%)/jt.log 2>&1
+	$(GREP) '^Test results: passed: 3$$' $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDTESTDIR)/GroupTest.ok
-
-$(BUILDTESTDIR)/ShowGroupTest.ok: \
+$(Group2Test.GROUPS:%=$(BUILDTESTDIR)/Group2Test.report-files.%.ok): \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg
 	$(MKDIR) -p $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-                -showGroups \
-		$(TESTDIR)/groups \
-                > $(@:%.ok=%)/jt.log 2>&1
-	$(GREP) '^g3[0-9]' $(@:%.ok=%)/jt.log > $(@:%.ok=%)/g3.found
-	$(GREP) '^# g3[0-9]*' $(TESTDIR)/groups/TEST.groups3 \
-	        | $(SED) -e 's/# //' > $(@:%.ok=%)/g3.expect
-	$(DIFF) --strip-trailing-cr $(@:%.ok=%)/g3.expect $(@:%.ok=%)/g3.found
+		-report:files \
+		$(TESTDIR)/groups2:$(@:$(BUILDTESTDIR)/Group2Test.report-files.%.ok=%) \
+		1>$(@:%.ok=%)/jt.log 2>&1
+	$(GREP) '^Test results: passed: 3$$' $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
-TESTS.jtreg += $(BUILDTESTDIR)/ShowGroupTest.ok
+TESTS.jtreg += $(BUILDTESTDIR)/Group2Test.ok

--- a/test/groups2/TEST.ROOT
+++ b/test/groups2/TEST.ROOT
@@ -1,0 +1,1 @@
+groups = TEST.groups

--- a/test/groups2/TEST.groups
+++ b/test/groups2/TEST.groups
@@ -1,0 +1,5 @@
+all = .
+
+indirectAll = :all
+
+allWithExtra = Test1.java Test2.java :all

--- a/test/groups2/Test1.java
+++ b/test/groups2/Test1.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ */
+public class Test1 {
+    public static void main(String... args) {
+        System.err.println(System.getProperties());
+    }
+}

--- a/test/groups2/Test2.java
+++ b/test/groups2/Test2.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ */
+public class Test2 {
+    public static void main(String... args) {
+        System.err.println(System.getProperties());
+    }
+}

--- a/test/groups2/Test3.java
+++ b/test/groups2/Test3.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ */
+public class Test3 {
+    public static void main(String... args) {
+        System.err.println(System.getProperties());
+    }
+}


### PR DESCRIPTION
Please review a simple fix, with new test, for a recently discovered issue, such that including "." in a test group (to mean "all tests") caused an exception.

Updating to JT Harness 6+24 improved the reporting of the exception but did not fix the root cause.

The root cause came from jtreg setting an empty path for an "initial URL" in the `Parameters` object. 

In `TestManager.getTests` there was already precedent for returning `null` to mean "all tests", for tests specified on the command line.  The fix is to extend that precedent to tests found in groups as well.

There is an existing test `GroupTest`, but that one intentionally has an invalid test which should not normally be read, since it causes a parse failure when reading tests.   So a new test is added, with different flavors of including "all" tests. In addition, since the original JDK bug was discovered in relation to the new `-report:files` option, the tests are extended to use that option as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903331](https://bugs.openjdk.org/browse/CODETOOLS-7903331): jtreg fails with StringIndexOutOfBoundsException: Index -1 out of bounds for length 0


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/jtreg pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/131.diff">https://git.openjdk.org/jtreg/pull/131.diff</a>

</details>
