### PR TITLE
7903356: jtreg Def.gmk fails to find tidy

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -168,7 +168,7 @@ TIDY 	:= $(shell if [ -r /usr/local/bin/tidy ]; then \
 	elif [ -r /opt/homebrew/bin/tidy ]; then \
 		echo /opt/homebrew/bin/tidy ; \
 	else \
-		echo/usr/bin/tidy ; \
+		echo /usr/bin/tidy ; \
 	fi )
 else
 TIDY	= /usr/bin/tidy


### PR DESCRIPTION
Added missing space.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903356](https://bugs.openjdk.org/browse/CODETOOLS-7903356): jtreg Def.gmk fails to find tidy


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Author)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/jtreg pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/132.diff">https://git.openjdk.org/jtreg/pull/132.diff</a>

</details>
