### PR TITLE
CODETOOLS-7903370: Update openjdk.java.net URLs to openjdk.org

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/GetJDKProperties.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/GetJDKProperties.java
@@ -57,7 +57,7 @@ public class GetJDKProperties {
             e.getCause().printStackTrace(System.err);
             System.exit(1);
         } catch (Exception e) {
-            System.err.println("Internal error: please report to jtreg-dev@openjdk.java.net");
+            System.err.println("Internal error: please report to jtreg-dev@openjdk.org");
             e.printStackTrace(System.err);
             System.exit(1);
         }

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -50,14 +50,14 @@
 <div style="text-align:center">
 <h1>The JDK Test Framework: Tag Language Specification</h1>
 <p>Comments and questions to:
-<a href="mailto:jtreg-use@openjdk.java.net">jtreg-use@openjdk.java.net</a>.
+<a href="mailto:jtreg-use@openjdk.org">jtreg-use@openjdk.org</a>.
 <br>
 1.47, 7 July, 2020
 </div>
 
 <p>This is a specification document, not a tutorial.  For more basic information
 please consult the jtreg FAQ at
-<a href="http://openjdk.java.net/jtreg">http://openjdk.java.net/jtreg</a>.
+<a href="http://openjdk.org/jtreg">http://openjdk.org/jtreg</a>.
 
 <p style="margin: 10pt 15pt"><b>Contents:</b>
 <a href="#LEADING_COMMENTS">Leading comments and defining files</a> &middot;


### PR DESCRIPTION
Please review a trivial patch to update `openjdk.java.net` URLs to use `openjdk.org`.