### PR TITLE
CODETOOLS-7903371: Use multi-catch where applicable

### DIFF
--- a/src/share/classes/com/sun/javatest/diff/Diff.java
+++ b/src/share/classes/com/sun/javatest/diff/Diff.java
@@ -141,11 +141,9 @@ public abstract class Diff {
 
             throw new Fault(i18n, "main.unrecognizedFile", f);
 
-        } catch (TestSuite.Fault e) {
-            throw new Fault(i18n, "main.cantOpenFile", f, e);
-        } catch (WorkDirectory.Fault e) {
-            throw new Fault(i18n, "main.cantOpenFile", f, e);
-        } catch (IOException e) {
+        } catch (TestSuite.Fault
+                 | WorkDirectory.Fault
+                 | IOException e) {
             throw new Fault(i18n, "main.cantOpenFile", f, e);
         }
 
@@ -158,5 +156,5 @@ public abstract class Diff {
     protected boolean includeReason;
     protected String format;
     protected String title;
-    private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Diff.class);
+    private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Diff.class);
 }

--- a/src/share/classes/com/sun/javatest/diff/HTMLWriter.java
+++ b/src/share/classes/com/sun/javatest/diff/HTMLWriter.java
@@ -332,7 +332,7 @@ public class HTMLWriter
      */
     public void writeLink(File file, String body) throws IOException {
         startTag(A);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         String path = file.getPath().replace(File.separatorChar, '/');
         if (file.isAbsolute() && !path.startsWith("/"))
             sb.append('/');

--- a/src/share/classes/com/sun/javatest/regtest/agent/GetJDKProperties.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/GetJDKProperties.java
@@ -151,15 +151,11 @@ public class GetJDKProperties {
                 sb.append(getNameMethod.invoke(module));
             }
             return sb.toString();
-        } catch (ClassNotFoundException e) {
-            return null;
-        } catch (IllegalAccessException e) {
-            return null;
-        } catch (IllegalArgumentException e) {
-            return null;
-        } catch (NoSuchMethodException e) {
-            return null;
-        } catch (InvocationTargetException e) {
+        } catch (ClassNotFoundException
+                 | IllegalAccessException
+                 | IllegalArgumentException
+                 | NoSuchMethodException
+                 | InvocationTargetException e) {
             return null;
         }
     }
@@ -194,15 +190,11 @@ public class GetJDKProperties {
                 sb.append(nameMethod.invoke(md));
             }
             return sb.toString();
-        } catch (ClassNotFoundException e) {
-            return null;
-        } catch (IllegalAccessException e) {
-            return null;
-        } catch (IllegalArgumentException e) {
-            return null;
-        } catch (NoSuchMethodException e) {
-            return null;
-        } catch (InvocationTargetException e) {
+        } catch (ClassNotFoundException
+                 | InvocationTargetException
+                 | NoSuchMethodException
+                 | IllegalArgumentException
+                 | IllegalAccessException e) {
             return null;
         }
     }

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -39,6 +39,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -236,7 +237,7 @@ public class RegressionScript extends Script {
                     // output for default case unchanged
                     printJDKInfo(msgPW, "JDK under test", getTestJDK(), getTestVMOptions());
                 } else {
-                    printJDKInfo(msgPW, "compile JDK", getCompileJDK(), Collections.<String>emptyList());
+                    printJDKInfo(msgPW, "compile JDK", getCompileJDK(), Collections.emptyList());
                     printJDKInfo(msgPW, "test JDK", getTestJDK(), getTestVMOptions());
                 }
 
@@ -420,9 +421,7 @@ public class RegressionScript extends Script {
                 opts.put(keyValue[0], keyValue[1]);
                 // [[fail,], [ref, Foo.ref]]
             }
-            List<String> args = new ArrayList<>();
-            for (int i = 2; i < tokens.length; i++)
-                args.add(tokens[i]);
+            List<String> args = new ArrayList<>(Arrays.asList(tokens).subList(2, tokens.length));
             // [-debug, Foo.java] (everything after the big options token)
             Class<?> c = null;
             try {
@@ -460,7 +459,7 @@ public class RegressionScript extends Script {
 
         boolean fast = true;
         for (String arg : args) {
-            fast = fast && (arg.indexOf("${") == -1);
+            fast = fast && (!arg.contains("${"));
         }
         if (fast) {
             return args;
@@ -472,12 +471,12 @@ public class RegressionScript extends Script {
         return newArgs;
     }
 
-    private static final Pattern namePattern = Pattern.compile("\\$\\{([A-Za-z0-9._]+)\\}");
+    private static final Pattern namePattern = Pattern.compile("\\$\\{([A-Za-z0-9._]+)}");
 
     private static String evalNames(String arg, Expr.Context c, Map<String,String> testProps)
             throws Expr.Fault, ParseException {
         Matcher m = namePattern.matcher(arg);
-        StringBuffer sb = null;
+        StringBuilder sb = null;
         // Note that '\' may appear in the replacement value for paths on Windows,
         // and so, in the following loop, avoid using Matcher::appendReplacement,
         // which interprets '\' and `$' in the replacement string.
@@ -485,14 +484,14 @@ public class RegressionScript extends Script {
         int pos = 0;
         while (m.find(pos)) {
             if (sb == null) {
-                sb = new StringBuffer();
+                sb = new StringBuilder();
             }
             String name = m.group(1);
             String value = testProps.containsKey(name) ? testProps.get(name) : c.get(name);
             if ("null".equals(value)) {
                 throw new ParseException("unset property " + name);
             }
-            sb.append(arg.substring(pos, m.start()));
+            sb.append(arg, pos, m.start());
             sb.append(value);
             pos = m.end();
         }
@@ -549,8 +548,8 @@ public class RegressionScript extends Script {
                 String f = (regEnv == null ? null : regEnv.lookup("javatestTimeoutFactor")[1]);
                 if (f != null)
                     value = Float.parseFloat(f);
-            } catch (TestEnvironment.Fault e) {
-            } catch (NumberFormatException e) {
+            } catch (TestEnvironment.Fault
+                     | NumberFormatException e) {
             }
             cacheJavaTestTimeoutFactor = value;
         }
@@ -609,7 +608,7 @@ public class RegressionScript extends Script {
      */
     private String getReason(String[] cmd) {
         String retVal;
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         String reason = cmd[0];
         switch (reason) {
             case Action.REASON_ASSUMED_ACTION:
@@ -1252,8 +1251,7 @@ public class RegressionScript extends Script {
             }
         }
 
-        Map<String, String> envVars = new HashMap<>();
-        envVars.putAll(getEnvVars());
+        Map<String, String> envVars = new HashMap<>(getEnvVars());
         // some tests are inappropriately relying on the CLASSPATH environment
         // variable being set, so ensure it is set. See equivalent code in MainAction
         // and Main.execChild. Note we cannot set exactly the same classpath as


### PR DESCRIPTION
Please review a code-cleanup to use multi-catch where applicable, as well as some other cleanup suggested by an IDE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903371](https://bugs.openjdk.org/browse/CODETOOLS-7903371): Use multi-catch where applicable


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.org/jtreg pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/135.diff">https://git.openjdk.org/jtreg/pull/135.diff</a>

</details>
