### PR TITLE
7903390: Summary reporter getter not thread-safe

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/report/SummaryReporter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/SummaryReporter.java
@@ -56,7 +56,7 @@ public abstract class SummaryReporter {
      * @param wd the work directory for the test run
      * @return the summary reporter
      */
-    public static SummaryReporter forTestNG(WorkDirectory wd) {
+    public static synchronized SummaryReporter forTestNG(WorkDirectory wd) {
         return instanceMap.computeIfAbsent(wd, wd_ -> new HashMap<>())
                 .computeIfAbsent(TestNGSummaryReporter.class, c_ -> new TestNGSummaryReporter());
     }
@@ -68,7 +68,7 @@ public abstract class SummaryReporter {
      * @param wd the work directory for the test run
      * @return the summary reporter
      */
-    public static SummaryReporter forJUnit(WorkDirectory wd) {
+    public static synchronized SummaryReporter forJUnit(WorkDirectory wd) {
         return instanceMap.computeIfAbsent(wd, wd_ -> new HashMap<>())
                 .computeIfAbsent(JUnitSummaryReporter.class, c_ -> new JUnitSummaryReporter());
     }


### PR DESCRIPTION
Prevent `ConcurrentModificationException` by making the two static methods that populate the instance map `synchronized`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903390](https://bugs.openjdk.org/browse/CODETOOLS-7903390): Summary reporter getter not thread-safe


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - no project role)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - no project role)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/jtreg pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/139.diff">https://git.openjdk.org/jtreg/pull/139.diff</a>

</details>
