### PR TITLE
CODETOOLS-7903393: Compile jtreg with -g

### DIFF
--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -27,6 +27,11 @@
 #
 # compile com.sun.javatest.regtest
 
+DEFAULT_DEBUG_FLAGS = -g
+AGENT_DEBUG_FLAGS = $(DEFAULT_DEBUG_FLAGS)
+TOOL_DEBUG_FLAGS = $(DEFAULT_DEBUG_FLAGS)
+JAVA_LANG_DEBUG_FLAGS = $(DEFAULT_DEBUG_FLAGS)
+
 ### The following files are required to run agentvm and othervm tests, as far back as JDK 8
 
 JUNIT_CLASSPATH = $(call AS_CLASSPATH,$(JUNIT_JARS))
@@ -42,6 +47,7 @@ $(BUILDDIR)/classes.com.sun.javatest.regtest.agent.ok: \
 	    $(REGTEST_AGENT_JAVAC) $(REGTEST_AGENT_JAVAC_OPTIONS) \
 		-d $(CLASSDIR) \
 		-encoding ASCII \
+		$(AGENT_DEBUG_FLAGS) \
 		$(JAVAFILES.com.sun.javatest.regtest-agentvm)
 	echo "classes built at `date`" > $@
 
@@ -57,6 +63,7 @@ $(BUILDDIR)/classes.com.sun.javatest.regtest.ok: \
 	    $(REGTEST_TOOL_JAVAC) $(REGTEST_TOOL_JAVAC_OPTIONS) \
 		-d $(CLASSDIR) \
 		-encoding ASCII \
+		$(TOOL_DEBUG_FLAGS) \
 		$(JAVAFILES.com.sun.javatest.regtest-tools)
 	echo "classes built at `date`" > $@
 
@@ -73,6 +80,7 @@ $(BUILDDIR)/classes.java.lang.ok: \
 	    $(REGTEST_TOOL_JAVAC) $(REGTEST_TOOL_JAVAC_OPTIONS) --release 9 $(REGTEST_TOOL_PATCH_JAVA_BASE_OPTIONS) \
 		-d $(CLASSDIR) \
 		-encoding ASCII \
+		$(JAVA_LANG_DEBUG_FLAGS) \
 		$(JAVAFILES.java.lang)
 	echo "classes built at `date`" > $@
 


### PR DESCRIPTION
Please review a simple makefile change to compile jtreg with `-g`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903393](https://bugs.openjdk.org/browse/CODETOOLS-7903393): Compile jtreg with -g


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.org/jtreg pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/140.diff">https://git.openjdk.org/jtreg/pull/140.diff</a>

</details>
