### PR TITLE
CODETOOLS-7903398: Incorrect format for version in error message

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Version.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Version.java
@@ -223,7 +223,7 @@ public class Version implements Comparable<Version> {
     String getVersionBuildString() {
         return versionString != null
                 ? versionString
-                : String.format("%s b%s", version, build);
+                : String.format("%s+%s", version, build.replaceAll("^0+", ""));
     }
 
     @Override

--- a/test/testRequiredVersion.gmk
+++ b/test/testRequiredVersion.gmk
@@ -53,7 +53,7 @@ $(BUILDTESTDIR)/TestRequiredVersion.ok: \
 		-verbose:fail \
 		$(BUILDTESTDIR)/requiredversion.future/suite/ \
 		2>&1 | tee $(BUILDTESTDIR)/requiredversion.future/log.txt
-	grep -q "requires jtreg version 99.9 b01 or higher" $(BUILDTESTDIR)/requiredversion.future/log.txt
+	grep -q "requires jtreg version 99.9+1 or higher" $(BUILDTESTDIR)/requiredversion.future/log.txt
 
 	echo "$@ test passed at `date`" > $@
 


### PR DESCRIPTION
Please review a simple update to use the new format for version strings, for use in an error message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903398](https://bugs.openjdk.org/browse/CODETOOLS-7903398): Incorrect format for version in error message


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.org/jtreg pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/143.diff">https://git.openjdk.org/jtreg/pull/143.diff</a>

</details>
