### PR TITLE
7903418: It is not possible to build jtreg 6.1 branch using jdk 11.0.18

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -149,7 +149,7 @@ JAR = $(JDKHOME)/bin/jar
 
 # Only use -source -target, to support legacy platforms, when building with JDK 8
 # Otherwise, use default values for $JDKHOME/bin/javac
-SUPPORT_OLD_SOURCE_TARGET = $(shell $(JDKJAVAC) -version 2>&1 | grep '[8]' > /dev/null && echo true )
+SUPPORT_OLD_SOURCE_TARGET = $(shell $(JDKJAVAC) -version 2>&1 | grep '1\.8\.' > /dev/null && echo true )
 ifneq ($(SUPPORT_OLD_SOURCE_TARGET),)
     OLD_JAVAC_SOURCE_TARGET = -source 1.2 -target 1.1
     AGENT_JAVAC_SOURCE_TARGET = -source 5 -target 5


### PR DESCRIPTION
It is not possible to build the jtreg 6.X using the recently released JDK 11.0.18. The root cause is a grep command in the Defs.gmk which checks the usage of jdk8. Because of that, all GitHub actions for jdk17u-dev and jdk11u-dev are broken:
see https://github.com/mrserb/jdk11u-dev/actions/runs/4018535809/jobs/6904278681

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903418](https://bugs.openjdk.org/browse/CODETOOLS-7903418): It is not possible to build jtreg 6.1 branch using jdk 11.0.18


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Author)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/jtreg pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/146.diff">https://git.openjdk.org/jtreg/pull/146.diff</a>

</details>
