### PR TITLE
7903430: Improve reporting for errors in JUnit's lifecycle methods

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,7 +232,7 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void executionFinished(TestIdentifier identifier, TestExecutionResult result) {
-            if (identifier.isTest()) {
+            /* if (identifier.isTest()) */ {
                 lock.lock();
                 try {
                     TestExecutionResult.Status status = result.getStatus();
@@ -242,9 +242,11 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
                     if (status == TestExecutionResult.Status.FAILED) {
                         result.getThrowable().ifPresent(throwable -> throwable.printStackTrace(printer));
                     }
-                    String source = toSourceString(identifier);
-                    String name = identifier.getDisplayName();
-                    printer.printf("%-10s %s '%s'%n", status, source, name);
+                    if (identifier.isTest()) {
+                        String source = toSourceString(identifier);
+                        String name = identifier.getDisplayName();
+                        printer.printf("%-10s %s '%s'%n", status, source, name);
+                    }
                 }
                 finally {
                     lock.unlock();

--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -30,7 +30,6 @@ import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.MethodSource;
-import org.junit.platform.launcher.LauncherConstants;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -232,25 +231,23 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void executionFinished(TestIdentifier identifier, TestExecutionResult result) {
-            /* if (identifier.isTest()) */ {
-                lock.lock();
-                try {
-                    TestExecutionResult.Status status = result.getStatus();
-                    if (status == TestExecutionResult.Status.ABORTED) {
-                        result.getThrowable().ifPresent(printer::println); // not the entire stack trace
-                    }
-                    if (status == TestExecutionResult.Status.FAILED) {
-                        result.getThrowable().ifPresent(throwable -> throwable.printStackTrace(printer));
-                    }
-                    if (identifier.isTest()) {
-                        String source = toSourceString(identifier);
-                        String name = identifier.getDisplayName();
-                        printer.printf("%-10s %s '%s'%n", status, source, name);
-                    }
+            lock.lock();
+            try {
+                TestExecutionResult.Status status = result.getStatus();
+                if (status == TestExecutionResult.Status.ABORTED) {
+                    result.getThrowable().ifPresent(printer::println); // not the entire stack trace
                 }
-                finally {
-                    lock.unlock();
+                if (status == TestExecutionResult.Status.FAILED) {
+                    result.getThrowable().ifPresent(throwable -> throwable.printStackTrace(printer));
                 }
+                if (identifier.isTest()) {
+                    String source = toSourceString(identifier);
+                    String name = identifier.getDisplayName();
+                    printer.printf("%-10s %s '%s'%n", status, source, name);
+                }
+            }
+            finally {
+                lock.unlock();
             }
         }
 

--- a/test/junitTrace/JUnitTrace.gmk
+++ b/test/junitTrace/JUnitTrace.gmk
@@ -39,8 +39,8 @@ $(BUILDTESTDIR)/JUnitTrace.othervm.ok: \
 			true "non-zero exit code from JavaTest intentionally ignored"
 	$(GREP) -s 'Test results: passed: 2; failed: 2' $(@:%.ok=%/jt.log)  > /dev/null
 	$(GREP) -s "java.lang.NullPointerException: NPE" $(@:%.ok=%/work/NPE.jtr) > /dev/null
-	$(GREP) -s "Intentionally thrown before all" $(@:%.ok=%/work/JupiterLifecycle.jtr.jtr) > /dev/null
-	$(GREP) -s "Intentionally thrown after all" $(@:%.ok=%/work/JupiterLifecycle.jtr.jtr) > /dev/null
+	$(GREP) -s "Intentionally thrown before all" $(@:%.ok=%/work/JupiterLifecycle.jtr) > /dev/null
+	$(GREP) -s "Intentionally thrown after all" $(@:%.ok=%/work/JupiterLifecycle.jtr) > /dev/null
 	if $(GREP) -s "^\s\s*at " $(@:%.ok=%/work/Pass.jtr) > /dev/null ; then \
 		echo "unexpected text"; exit 1; \
 	fi

--- a/test/junitTrace/JUnitTrace.gmk
+++ b/test/junitTrace/JUnitTrace.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,10 @@ $(BUILDTESTDIR)/JUnitTrace.othervm.ok: \
 		$(TESTDIR)/junitTrace/  \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 			true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: 2; failed: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: 2; failed: 2' $(@:%.ok=%/jt.log)  > /dev/null
 	$(GREP) -s "java.lang.NullPointerException: NPE" $(@:%.ok=%/work/NPE.jtr) > /dev/null
+	$(GREP) -s "Intentionally thrown before all" $(@:%.ok=%/work/JupiterLifecycle.jtr.jtr) > /dev/null
+	$(GREP) -s "Intentionally thrown after all" $(@:%.ok=%/work/JupiterLifecycle.jtr.jtr) > /dev/null
 	if $(GREP) -s "^\s\s*at " $(@:%.ok=%/work/Pass.jtr) > /dev/null ; then \
 		echo "unexpected text"; exit 1; \
 	fi

--- a/test/junitTrace/JupiterLifecycle.java
+++ b/test/junitTrace/JupiterLifecycle.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.*;
+
+/*
+ * @test
+ * @bug 7903430
+ * @run junit JupiterLifecycle
+ */
+class JupiterLifecycle {
+
+    @BeforeAll
+    static void failBeforeAll(TestInfo info) {
+        System.out.println("out");
+        System.err.println("err");
+        throw new RuntimeException("Intentionally thrown before all: " + info);
+    }
+
+    @AfterAll
+    static void failAfterAll(TestInfo info) {
+        System.out.println("out");
+        System.err.println("err");
+        throw new RuntimeException("Intentionally thrown after all: " + info);
+    }
+
+    @Test
+    void test() {
+        Assertions.fail("This method should never run, due to the error in a lifecycle method");
+    }
+}


### PR DESCRIPTION
Please review this change set ensuring that all exceptions thrown in JUnit's lifecycle methods are reported.

Prior to this PR, only exceptions thrown by "test identifiers" were reported.
Now all kinds of identifiers, which include "container identifiers", are generating a report when the execution result is in `ABORTED` or `FAILED` state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903430](https://bugs.openjdk.org/browse/CODETOOLS-7903430): Improve reporting for errors in JUnit's lifecycle methods


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.org/jtreg pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/147.diff">https://git.openjdk.org/jtreg/pull/147.diff</a>

</details>
