### PR TITLE
7903431: Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,17 @@ jobs:
       with:
         fetch-depth: 1
 
+    - name: 'Set up Java Development Kit'
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'oracle'
+        java-version: '17'
+
     - name: 'Build JTReg'
       shell: bash
       run: |
         java --version
-        bash make/build.sh --jdk ${JAVA_HOME_11_X64}
+        bash make/build.sh
 
     - name: 'Run initial tests (goal: quick-test)'
       shell: bash
@@ -29,7 +35,7 @@ jobs:
         MAKE_ARGS: quick-test
         HEADLESS: 1
       run: |
-        bash make/build.sh --jdk ${JAVA_HOME_11_X64} --skip-download
+        bash make/build.sh --skip-download
 
     - name: 'Run all tests (goal: test)'
       shell: bash
@@ -37,4 +43,4 @@ jobs:
         MAKE_ARGS: test
         HEADLESS: 1
       run: |
-        bash make/build.sh --jdk ${JAVA_HOME_11_X64} --skip-download
+        bash make/build.sh --skip-download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: 'Check out repository'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
 


### PR DESCRIPTION
Update workflow to use `actions/checkout@v3` and set up latest Oracle's JDK 17 to build `jtreg`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903431](https://bugs.openjdk.org/browse/CODETOOLS-7903431): Update GitHub Actions workflow


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/jtreg pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/148.diff">https://git.openjdk.org/jtreg/pull/148.diff</a>

</details>
