### PR TITLE
CODETOOLS-7903453: Fix regex for tags in jtreg jcheck.conf

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -7,7 +7,7 @@ jbs=CODETOOLS
 error=author,committer,reviewers,merge,issues,executable,symlink,message,whitespace
 
 [repository]
-tags=jtreg(?:4\.1-b[0-9]{2}|5\.[01]-b[0-9]{2}|6|-[6789](?:\.[0-9]+)?+[0-9]+)
+tags=jtreg(?:4\.1-b[0-9]{2}|5\.[01]-b[0-9]{2}|6|-[6789](?:\.[0-9]+)?\+[0-9]+)
 branches=
 
 [census]


### PR DESCRIPTION
Please review a fix for the regex for valid tag names

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903453](https://bugs.openjdk.org/browse/CODETOOLS-7903453): Fix regex for tags in jtreg jcheck.conf


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/jtreg.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/149.diff">https://git.openjdk.org/jtreg/pull/149.diff</a>

</details>
