### PR TITLE
7903459: Update changelog for jtreg 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-7.2+1...master)
 
+_No notewothy changes yet._
 
-## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-7.1.1+1...master)
+## [7.2+1](https://git.openjdk.org/jtreg/compare/jtreg-7.1.1+1...jtreg-7.2+1)
 
 * Improved support for JUnit Jupiter.
   * Update jtreg to bundle JUnit 5.9.2 [CODETOOLS-7903406](https://bugs.openjdk.org/browse/CODETOOLS-7903406)


### PR DESCRIPTION
Please review this commit that updates the changelog file to include a section for jtreg 7.2.

It also adds the entry to the list of noteworthy unreleased changes of the upcoming jtreg 7.3 release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903459](https://bugs.openjdk.org/browse/CODETOOLS-7903459): Update changelog for jtreg 7.2


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/jtreg.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/150.diff">https://git.openjdk.org/jtreg/pull/150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/150#issuecomment-1515844467)