### PR TITLE
CODETOOLS-7903400: DEFAULT_UNIX_ENV_VARS needs to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-7.2+1...master)
 
-_No notewothy changes yet._
+* Updated set of default environment variables set for tests on Unix-like platforms.
+  * Includes `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, and `XDG-*` 
+    [CODETOOLS-7903400](https://bugs.openjdk.org/browse/CODETOOLS-7903400)
 
 ## [7.2+1](https://git.openjdk.org/jtreg/compare/jtreg-7.1.1+1...jtreg-7.2+1)
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2153,29 +2153,29 @@ public class Tool {
         Map<String, String> envVars = new TreeMap<>();
         OS os = OS.current();
         if (os.family.equals("windows")) {
-            addEnvVars(envVars, DEFAULT_WINDOWS_ENV_VARS);
+            addEnvVars(envVars, sysEnv, DEFAULT_WINDOWS_ENV_VARS);
             // TODO PATH? MKS? Cygwin?
-            addEnvVars(envVars, "PATH"); // accept user's path, for now
+            addEnvVars(envVars, sysEnv, "PATH"); // accept user's path, for now
         } else {
-            addEnvVars(envVars, DEFAULT_UNIX_ENV_VARS);
+            addEnvVars(envVars, sysEnv, DEFAULT_UNIX_ENV_VARS);
             addEnvVars(envVars, sysEnv, e -> e.getKey().startsWith("XDG_"));
-            addEnvVars(envVars, "PATH=/bin:/usr/bin:/usr/sbin");
+            addEnvVars(envVars, sysEnv, "PATH=/bin:/usr/bin:/usr/sbin");
         }
-        addEnvVars(envVars, envVarArgs);
+        addEnvVars(envVars, sysEnv, envVarArgs);
         addEnvVars(envVars, sysEnv, e -> e.getKey().startsWith("JTREG_"));
 
         return envVars;
     }
 
-    private void addEnvVars(Map<String, String> table, String list) {
-        addEnvVars(table, list.split(","));
+    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, String list) {
+        addEnvVars(table, sysEnv, list.split(","));
     }
 
-    private void addEnvVars(Map<String, String> table, String[] list) {
-        addEnvVars(table, List.of(list));
+    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, String[] list) {
+        addEnvVars(table, sysEnv, List.of(list));
     }
 
-    private void addEnvVars(Map<String, String> table, List<String> list) {
+    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, List<String> list) {
         if (list == null)
             return;
 
@@ -2185,7 +2185,7 @@ public class Tool {
                 continue;
             int eq = s.indexOf("=");
             if (eq == -1) {
-                String value = System.getenv(s);
+                String value = sysEnv.get(s);
                 if (value != null)
                     table.put(s, value);
             } else if (eq > 0) {
@@ -2197,7 +2197,7 @@ public class Tool {
     }
 
     private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, Predicate<Map.Entry<String, String>> filter) {
-        System.getenv().entrySet().stream()
+        sysEnv.entrySet().stream()
                 .filter(filter)
                 .forEach(e -> table.put(e.getKey(), e.getValue()));
     }
@@ -2339,8 +2339,8 @@ public class Tool {
     private static final String MANUAL    = "manual";
 
     private static final String[] DEFAULT_UNIX_ENV_VARS = {
-            "DBUS_SESSION_BUS_ADDRESS", "DISPLAY",
-            "GNOME_DESKTOP_SESSION_ID",
+            "DBUS_SESSION_BUS_ADDRESS", "DESKTOP_SESSION", "DISPLAY",
+            "GDM_SESSION", "GNOME_DESKTOP_SESSION_ID", "GNOME_SHELL_SESSION_MODE",
             "HOME",
             "LANG", "LC_ALL", "LC_CTYPE", "LPDEST",
             "PRINTER",

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2340,7 +2340,7 @@ public class Tool {
 
     private static final String[] DEFAULT_UNIX_ENV_VARS = {
             "DBUS_SESSION_BUS_ADDRESS", "DESKTOP_SESSION", "DISPLAY",
-            "GDM_SESSION", "GNOME_DESKTOP_SESSION_ID", "GNOME_SHELL_SESSION_MODE",
+            "GDMSESSION", "GNOME_DESKTOP_SESSION_ID", "GNOME_SHELL_SESSION_MODE",
             "HOME",
             "LANG", "LC_ALL", "LC_CTYPE", "LPDEST",
             "PRINTER",

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2158,11 +2158,11 @@ public class Tool {
             addEnvVars(envVars, "PATH"); // accept user's path, for now
         } else {
             addEnvVars(envVars, DEFAULT_UNIX_ENV_VARS);
-            addEnvVars(envVars, sysEnv, k -> k.startsWith("XDG_"));
+            addEnvVars(envVars, sysEnv, e -> e.getKey().startsWith("XDG_"));
             addEnvVars(envVars, "PATH=/bin:/usr/bin:/usr/sbin");
         }
         addEnvVars(envVars, envVarArgs);
-        addEnvVars(envVars, sysEnv, k -> k.startsWith("JTREG_"));
+        addEnvVars(envVars, sysEnv, e -> e.getKey().startsWith("JTREG_"));
 
         return envVars;
     }
@@ -2196,9 +2196,9 @@ public class Tool {
         }
     }
 
-    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, Predicate<String> filter) {
+    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, Predicate<Map.Entry<String, String>> filter) {
         System.getenv().entrySet().stream()
-                .filter(e -> e.getKey().startsWith("JTREG_"))
+                .filter(filter)
                 .forEach(e -> table.put(e.getKey(), e.getValue()));
     }
 


### PR DESCRIPTION
Please review a small change to add additional environment variables that may be required on some Unix-like platforms.

The additions include:
* `DBUS_SESSION_BUS_ADDRESS`
* `WAYLAND_DISPLAY`
* all `XDG_*` variables

There is some related additional cleanup in this area as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903400](https://bugs.openjdk.org/browse/CODETOOLS-7903400): DEFAULT_UNIX_ENV_VARS needs to be updated


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [45f761b0](https://git.openjdk.org/jtreg/pull/152/files/45f761b0d0879b5bbf0840ecd674ed4f8e4a441c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.org/jtreg.git pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/152.diff">https://git.openjdk.org/jtreg/pull/152.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/152#issuecomment-1526245211)