### PR TITLE
7903441: System.out and System.err messages are missing in jtr file when a test times out in agentvm mode

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -488,7 +488,7 @@ public class AgentServer implements ActionHelper.OutputHandler {
             @Override
             public void flush() throws IOException {
                 decode();
-                // let any content, that has been decoded into the charBuffer, be written out
+                // let any content that has been decoded into the charBuffer be written out
                 // to the writer so that the writer can then flush it to underlying stream
                 writeCharBuffer();
                 w.flush();

--- a/src/share/classes/com/sun/javatest/regtest/agent/CompileActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/CompileActionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class CompileActionHelper extends ActionHelper {
         // RUN THE COMPILER
         // Setup streams for the test:
         // ... to catch sysout and syserr
-        PrintStream sysOut = outputHandler.getPrintStream(OutputHandler.OutputKind.STDOUT, false);
+        PrintStream sysOut = outputHandler.getPrintStream(OutputHandler.OutputKind.STDOUT, true);
         PrintStream sysErr = outputHandler.getPrintStream(OutputHandler.OutputKind.STDERR, true);
 
         // ... for direct use with RegressionCompileCommand

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
@@ -146,7 +146,7 @@ public class MainActionHelper extends ActionHelper {
         }
         System.setProperties(p);
 
-        PrintStream out = outputHandler.getPrintStream(OutputHandler.OutputKind.STDOUT, false);
+        PrintStream out = outputHandler.getPrintStream(OutputHandler.OutputKind.STDOUT, true);
         PrintStream err = outputHandler.getPrintStream(OutputHandler.OutputKind.STDERR, true);
 
         AStatus status = passed(EXEC_PASS);


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue reported in https://bugs.openjdk.org/browse/CODETOOLS-7903441?

As noted in that issue, when a test timeouts when run in the agent vm mode, it has been noticed that the System.out/System.err messages that were written by the test are lost and not present in the .jtr file of that test.

There are 2 parts to this issue and this PR thus has 2 separate commits to help review this.

Agent VM test execution involves communicating between processes - the jtreg process (a.k.a `Agent`) and the process that is executing the test case (a.k.a `AgentServer`), through sockets. One part of this communication involves sending across the System.out and System.err generated messages from the `AgentServer` VM to the `Agent`. As part of https://bugs.openjdk.org/browse/CODETOOLS-7902198, work was done to help send across these messages in a timely fashion. One part of that change involves converting the byte oriented messages into characters. This is done using a `CharsetDecoder` which decodes `ByteBuffer` contents to a `CharBuffer`. Once the decoded content lands into the `charBuffer` it stays in that buffer until either the OutputStream is closed or the `charBuffer` capacity has been reached. Even a `flush()` call doesn't push out these decoded characters into the target/underlying OutputStream and that results in lost messages. The commit https://github.com/openjdk/jtreg/commit/578e103dcb911c07c59007138e62a78c3abba6d7 in this PR addresses that by making sure `flush()` operation on the `OutputStream` does indeed flush the decoded characters to the underlying stream, thus allowing it to reach the other process.

In the current jtreg code, the compile action and main action implementation on the `AgentServer` side both use `autoFlush=true` for `System.err` but not for `System.out`, I couldn't find an explanation why `System.out` explicitly sets `autoFlush=false`. The additional commit https://github.com/openjdk/jtreg/commit/1d08b7656d46c124730c6844fefc595804266d36 in this PR addresses this by setting `System.out` as `autoFlush=true`. Auto-flush is defined by `java.io.PrintStream` as:

> Optionally, a {@code PrintStream} can be created so as to flush automatically; this means that the {@code flush} method of the underlying output stream is automatically invoked after a byte array is written, one of the {@code println} methods is invoked, or a newline character or byte ({@code '\n'}) is written.

This change should reduce the chances of a message being lost when written to `System.out` in agent VM mode. In my opinion, tests that use `System.out` (and `System.err`) would ideally want this auto-flush behaviour to match what they get out of regular `System.out` instance when running as a regular application. Plus, using auto-flush for System.out would mean that these messages will now be delivered in a more timely fashion.

I tested these changes against the reproducer that's attached to the JBS issue and it now correctly logs the System.out and System.err messages and are available in the .jtr file on timeout. I've run `tier1`, `tier2` and `tier3` tests with a jtreg version which contains this fix and the tests completed without any related failures/regressions. I'm in the process of trying to trigger a test that is known to timeout (like the reproducer in the JBS issue) on our CI system to make sure the logs are indeed now available in the .jtr file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903441](https://bugs.openjdk.org/browse/CODETOOLS-7903441): System.out and System.err messages are missing in jtr file when a test times out in agentvm mode


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [1d08b765](https://git.openjdk.org/jtreg/pull/155/files/1d08b7656d46c124730c6844fefc595804266d36)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.org/jtreg.git pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/155.diff">https://git.openjdk.org/jtreg/pull/155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/155#issuecomment-1542072594)