### PR TITLE
7903470 jtreg AgentServer log() does not flush

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -376,7 +376,7 @@ public class AgentServer implements ActionHelper.OutputHandler {
                 AgentServer.logDateFormat.format(new Date()),
                 id,
                 message);
-		logWriter.flush();
+        logWriter.flush();
     }
 
     private final KeepAlive keepAlive;

--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -376,7 +376,7 @@ public class AgentServer implements ActionHelper.OutputHandler {
                 AgentServer.logDateFormat.format(new Date()),
                 id,
                 message);
-
+		logWriter.flush();
     }
 
     private final KeepAlive keepAlive;


### PR DESCRIPTION
Please review this change to start flushing logs on every message in AgentServer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903470](https://bugs.openjdk.org/browse/CODETOOLS-7903470): jtreg AgentServer log() does not flush


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.org/jtreg.git pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/156.diff">https://git.openjdk.org/jtreg/pull/156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/156#issuecomment-1542246094)