### PR TITLE
7902485 Timeout refired %s times message confusing

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
@@ -143,9 +143,9 @@ public class Alarm  {
     protected void run() {
         if (msgOut != null) {
             if (count == 0) {
-                msgOut.println(String.format("Timeout refired %s times", TimeUnit.SECONDS.convert(delay, delayUnit)));
+                msgOut.println(String.format("Timeout signalled after %d seconds", TimeUnit.SECONDS.convert(delay, delayUnit)));
             } else if (count % 100 == 0) {
-                msgOut.println(String.format("Timeout signalled after %d seconds", count));
+                msgOut.println(String.format("Timeout refired %s times", count));
             }
         }
         count++;

--- a/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
@@ -145,7 +145,7 @@ public class Alarm  {
             if (count == 0) {
                 msgOut.println(String.format("Timeout signalled after %d seconds", TimeUnit.SECONDS.convert(delay, delayUnit)));
             } else if (count % 100 == 0) {
-                msgOut.println(String.format("Timeout refired %s times", count));
+                msgOut.println(String.format("Timeout refired %d times", count));
             }
         }
         count++;

--- a/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this trivial patch that fixes the timeout messages printed by JTReg.

The messages were accidentally inverted by https://github.com/openjdk/jtreg/commit/b48573b504e9811ad3e6ced443b716446a7078e2#diff-8e1b55f85f319daa1e294289b63951c18cc3ba76247e59e15a37a3c9b772d543. This PR restores them to their proper positions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7902485](https://bugs.openjdk.org/browse/CODETOOLS-7902485): Timeout refired %s times message confusing (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [98053031](https://git.openjdk.org/jtreg/pull/158/files/98053031981625022705d003ce98261db3c5cc82)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jtreg.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/158.diff">https://git.openjdk.org/jtreg/pull/158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/158#issuecomment-1592696768)