### PR TITLE
7903500: Add Gradle Wrapper Validation workflow to jtreg

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: 'Validate Gradle Wrapper'
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: 'Validation'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
This change adds a workflow to this repository to verify that any and all `gradle-wrapper.jar` files in the repository match the SHA-256 checksums of any of our official releases. See details at https://github.com/marketplace/actions/gradle-wrapper-validation