### PR TITLE
7903507: jtreg runs into race conditions for multi-modules tests

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -521,10 +521,11 @@ public abstract class Action extends ActionHelper {
         for (Path element : pp.asList()) {
             if (Files.isRegularFile(element)) {
                 getModule(element, results);
-                continue;
             }
-            for (Path file: FileUtils.listFiles(element)) {
-                getModule(file, results);
+            else if (Files.isDirectory(element)) {
+                for (Path file : FileUtils.listFiles(element)) {
+                    getModule(file, results);
+                }
             }
         }
         return results;
@@ -533,9 +534,7 @@ public abstract class Action extends ActionHelper {
     private void getModule(Path file, Set<String> results) {
         if (isModule(file)) {
             results.add(file.getFileName().toString());
-            return;
-        }
-        if (file.getFileName().toString().endsWith(".jar")) {
+        } else if (file.getFileName().toString().endsWith(".jar")) {
             results.add(getAutomaticModuleName(file));
         }
     }

--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -521,8 +521,7 @@ public abstract class Action extends ActionHelper {
         for (Path element : pp.asList()) {
             if (Files.isRegularFile(element)) {
                 getModule(element, results);
-            }
-            else if (Files.isDirectory(element)) {
+            } else if (Files.isDirectory(element)) {
                 for (Path file : FileUtils.listFiles(element)) {
                     getModule(file, results);
                 }

--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -518,19 +518,25 @@ public abstract class Action extends ActionHelper {
             return Collections.emptySet();
 
         Set<String> results = new LinkedHashSet<>();
-        for (Path dir: pp.asList()) {
-            getModules(dir, results);
+        for (Path element : pp.asList()) {
+            if (Files.isRegularFile(element)) {
+                getModule(element, results);
+                continue;
+            }
+            for (Path file: FileUtils.listFiles(element)) {
+                getModule(file, results);
+            }
         }
         return results;
     }
 
-    private void getModules(Path dir, Set<String> results) {
-        for (Path f: FileUtils.listFiles(dir)) {
-            if (isModule(f)) {
-                results.add(f.getFileName().toString());
-            } else if (f.getFileName().toString().endsWith(".jar")) {
-                results.add(getAutomaticModuleName(f));
-            }
+    private void getModule(Path file, Set<String> results) {
+        if (isModule(file)) {
+            results.add(file.getFileName().toString());
+            return;
+        }
+        if (file.getFileName().toString().endsWith(".jar")) {
+            results.add(getAutomaticModuleName(file));
         }
     }
 


### PR DESCRIPTION
This change puts the necessary JAR files onto the module path as (automatic) modules - without copying them. Therefore, no race condition can happen when multiple tests that require modules of test frameworks are compiling or executing in parallel.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903507](https://bugs.openjdk.org/browse/CODETOOLS-7903507): jtreg runs into race conditions for multi-modules tests (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [4fe4e427](https://git.openjdk.org/jtreg/pull/161/files/4fe4e427b982c2b8a4b57c1cb9b11f4f3182c0f3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jtreg.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/161.diff">https://git.openjdk.org/jtreg/pull/161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/161#issuecomment-1647955988)