### PR TITLE
CODETOOLS-7903516: work around `this-escape` warnings

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
 
 
 @SuppressWarnings("removal") // Security Manager and related APIs
-public class AgentServer implements ActionHelper.OutputHandler {
+public final class AgentServer implements ActionHelper.OutputHandler {
 
     /**
      * Main program used to invoke and run the server in child JVMs

--- a/src/share/classes/com/sun/javatest/regtest/agent/SearchPath.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/SearchPath.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
  * A search path, as in an ordered set of file system locations,
  * such as directories, zip files and jar files.
  */
-public class SearchPath {
+public final class SearchPath {
     /**
      * Creates an empty search path.
      */

--- a/src/share/classes/com/sun/javatest/regtest/config/Locations.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/Locations.java
@@ -47,7 +47,7 @@ import com.sun.javatest.regtest.util.StringUtils;
 /**
  * Utilities to locate source and class files used by a test.
  */
-public class Locations {
+public final class Locations {
     /**
      * Used to report problems that are found.
      */

--- a/src/share/classes/com/sun/javatest/regtest/config/ParseException.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/ParseException.java
@@ -32,7 +32,7 @@ import com.sun.javatest.regtest.exec.TestRunException;
  * parsing error may occur either during initial examination of the tags in
  * the finder or during more extensive verification of the run action.
  */
-public class ParseException extends TestRunException
+public final class ParseException extends TestRunException
 {
     static final long serialVersionUID = 5598548899306920122L;
     public ParseException(String msg) {
@@ -42,7 +42,7 @@ public class ParseException extends TestRunException
     public ParseException(Throwable t) {
         super(PARSE_EXCEPTION + t.getMessage());
         initCause(t);
-    } // ParseExeptionException()
+    }
 
     //----------misc statics----------------------------------------------------
 

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
@@ -72,7 +72,7 @@ import com.sun.javatest.util.I18NResourceBundle;
 import static com.sun.javatest.regtest.util.StringUtils.join;
 
 
-public class RegressionParameters
+public final class RegressionParameters
     extends BasicInterviewParameters
     implements Parameters.EnvParameters
 {

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionTestFinder.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionTestFinder.java
@@ -66,7 +66,7 @@ import com.sun.javatest.util.I18NResourceBundle;
   * @see com.sun.javatest.TestFinder
   * @see com.sun.javatest.finder.TagTestFinder
   */
-public class RegressionTestFinder extends TagTestFinder
+public final class RegressionTestFinder extends TagTestFinder
 {
     /**
      * Constructs the list of file names to exclude for pruning in the search
@@ -1014,7 +1014,7 @@ public class RegressionTestFinder extends TagTestFinder
     static final String[] excludeNames = { ".hg", ".git" };
 
     // These are all the error messages used in the finder.
-    protected static final String
+    static final String
         PARSE_TAG_BAD         = "Invalid tag: ",
         PARSE_BUG_EMPTY       = "No value provided for `@bug'",
         PARSE_BUG_INVALID     = "Invalid or unrecognized bugid: ",

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionTestSuite.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionTestSuite.java
@@ -51,7 +51,7 @@ import com.sun.javatest.util.I18NResourceBundle;
 import com.sun.javatest.regtest.tool.RegressionContextManager;
 
 
-public class RegressionTestSuite extends TestSuite
+public final class RegressionTestSuite extends TestSuite
 {
     static Map<File, SoftReference<RegressionTestSuite>> cache;
 

--- a/src/share/classes/com/sun/javatest/regtest/util/StreamCopier.java
+++ b/src/share/classes/com/sun/javatest/regtest/util/StreamCopier.java
@@ -34,7 +34,7 @@ import java.io.PrintWriter;
 /**
  * A thread to copy an input stream/reader to an output stream/writer.
  */
-public class StreamCopier extends Thread {
+public final class StreamCopier extends Thread {
 
     public StreamCopier(InputStream in, PrintWriter out, LineScanner scanner) {
         super(Thread.currentThread().getName() + "_StreamCopier_" + (serial++));


### PR DESCRIPTION
Please review changes to make some classes final, to avoid effectively false-positive `this-escape` warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903516](https://bugs.openjdk.org/browse/CODETOOLS-7903516): work around `this-escape` warnings (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/165/head:pull/165` \
`$ git checkout pull/165`

Update a local copy of the PR: \
`$ git checkout pull/165` \
`$ git pull https://git.openjdk.org/jtreg.git pull/165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 165`

View PR using the GUI difftool: \
`$ git pr show -t 165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/165.diff">https://git.openjdk.org/jtreg/pull/165.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/165#issuecomment-1670159093)