### PR TITLE
7903515: Some default env vars on Windows not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-7.3+1...master)
 
-_Nothing noteworthy, yet_
+* Fixed setting default environment variables on Windows
+  * [CODETOOLS-7903515](https://bugs.openjdk.org/browse/CODETOOLS-7903515)
 
 ## [7.3](https://git.openjdk.org/jtreg/compare/jtreg-7.2+1...jtreg-7.3+1)
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2195,9 +2195,8 @@ public class Tool {
         }
     }
 
-    // This method streams over a case-sensitive set of entries, returned by
-    // System.getenv(String); custom name filters can be implemented in a
-    // case-insensitive manner.
+    // This method streams over a case-sensitive set of entries, returned by System.getenv();
+    // Custom name filters can be implemented in a case-insensitive manner.
     private void addEnvVarsByName(Map<String, String> table, Predicate<String> nameFilter) {
         System.getenv().entrySet().stream()
                 .filter(e -> nameFilter.test(e.getKey()))

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2184,7 +2184,7 @@ public class Tool {
                 continue;
             int eq = s.indexOf("=");
             if (eq == -1) {
-                String value = getCaseInsensitiveEnvironmentVariableOrNull(s);
+                String value = getEnvironmentVariableOrNull(s);
                 if (value != null)
                     table.put(s, value);
             } else if (eq > 0) {
@@ -2204,7 +2204,7 @@ public class Tool {
     }
 
     // 7903515: Use case-insensitive System.getenv(String) here.
-    private static String getCaseInsensitiveEnvironmentVariableOrNull(String name) {
+    private static String getEnvironmentVariableOrNull(String name) {
         return System.getenv(name);
     }
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2153,29 +2153,29 @@ public class Tool {
         Map<String, String> envVars = new TreeMap<>();
         OS os = OS.current();
         if (os.family.equals("windows")) {
-            addEnvVars(envVars, sysEnv, DEFAULT_WINDOWS_ENV_VARS);
+            addEnvVars(envVars, DEFAULT_WINDOWS_ENV_VARS);
             // TODO PATH? MKS? Cygwin?
-            addEnvVars(envVars, sysEnv, "PATH"); // accept user's path, for now
+            addEnvVars(envVars, "PATH"); // accept user's path, for now
         } else {
-            addEnvVars(envVars, sysEnv, DEFAULT_UNIX_ENV_VARS);
+            addEnvVars(envVars, DEFAULT_UNIX_ENV_VARS);
             addEnvVars(envVars, sysEnv, e -> e.getKey().startsWith("XDG_"));
-            addEnvVars(envVars, sysEnv, "PATH=/bin:/usr/bin:/usr/sbin");
+            addEnvVars(envVars, "PATH=/bin:/usr/bin:/usr/sbin");
         }
-        addEnvVars(envVars, sysEnv, envVarArgs);
+        addEnvVars(envVars, envVarArgs);
         addEnvVars(envVars, sysEnv, e -> e.getKey().startsWith("JTREG_"));
 
         return envVars;
     }
 
-    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, String list) {
-        addEnvVars(table, sysEnv, list.split(","));
+    private void addEnvVars(Map<String, String> table, String list) {
+        addEnvVars(table, list.split(","));
     }
 
-    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, String[] list) {
-        addEnvVars(table, sysEnv, List.of(list));
+    private void addEnvVars(Map<String, String> table, String[] list) {
+        addEnvVars(table, List.of(list));
     }
 
-    private void addEnvVars(Map<String, String> table, Map<String, String> sysEnv, List<String> list) {
+    private void addEnvVars(Map<String, String> table, List<String> list) {
         if (list == null)
             return;
 
@@ -2185,7 +2185,7 @@ public class Tool {
                 continue;
             int eq = s.indexOf("=");
             if (eq == -1) {
-                String value = sysEnv.get(s);
+                String value = System.getenv(s);
                 if (value != null)
                     table.put(s, value);
             } else if (eq > 0) {


### PR DESCRIPTION
Please review this change to fix setting of some default environment variables on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903515](https://bugs.openjdk.org/browse/CODETOOLS-7903515): Some default env vars on Windows not set (**Bug** - P2)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/jtreg.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/166.diff">https://git.openjdk.org/jtreg/pull/166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/166#issuecomment-1671660459)