### PR TITLE
7903517: jtreg.jar built with ant misses jtreg-VersionString

### DIFF
--- a/make/build.xml
+++ b/make/build.xml
@@ -150,6 +150,7 @@
                 <attribute name="jtreg-Milestone" value="${build.milestone}"/>
                 <attribute name="jtreg-Build" value="${build.number}"/>
                 <attribute name="jtreg-BuildJavaVersion" value="${java.version}"/>
+                <attribute name="jtreg-VersionString" value="${build.version}+${build.number}"/>
                 <attribute name="jtreg-BuildDate" value="${build.date.time}"/>
             </manifest>
             <include name="COPYRIGHT"/>

--- a/make/build.xml
+++ b/make/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903517](https://bugs.openjdk.org/browse/CODETOOLS-7903517): jtreg.jar built with ant misses jtreg-VersionString (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.org/jtreg.git pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/167.diff">https://git.openjdk.org/jtreg/pull/167.diff</a>

</details>
