### PR TITLE
7903524: Permit more segments in jtreg tags

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -7,7 +7,7 @@ jbs=CODETOOLS
 error=author,committer,reviewers,merge,issues,executable,symlink,message,whitespace
 
 [repository]
-tags=jtreg(?:4\.1-b[0-9]{2}|5\.[01]-b[0-9]{2}|6|-[6789](?:\.[0-9]+)?\+[0-9]+)
+tags=jtreg(?:4\.1-b[0-9]{2}|5\.[01]-b[0-9]{2}|6|-[6789](?:\.[0-9]+)*\+[0-9]+)
 branches=
 
 [census]


### PR DESCRIPTION
Please review this change to permit more segments in jtreg tags, for example: `jtreg-7.3.1+1`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903524](https://bugs.openjdk.org/browse/CODETOOLS-7903524): Permit more segments in jtreg tags (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/jtreg.git pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/169.diff">https://git.openjdk.org/jtreg/pull/169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/169#issuecomment-1680073315)