### PR TITLE
7903539: Please make jtreg build date reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-7.3.1+1...master)
 
-_nothing noteworthy, yet_
+* Use SOURCE_BUILD_EPOCH to suppport reproducible builds
+  [CODETOOLS-7903539](https://bugs.openjdk.org/browse/CODETOOLS-7903539)
 
 ## [7.3.1](https://git.openjdk.org/jtreg/compare/jtreg-7.3+1...jtreg-7.3.1+1)
 

--- a/make/Rules.gmk
+++ b/make/Rules.gmk
@@ -60,6 +60,13 @@ $(CLASSDIR) $(BUILDDIR) $(BUILDDIR)/testClasses $(BUILDDIR)/testWork $(BUILDDIR)
 # default copyright; override as necessary
 JAR_COPYRIGHT = -C $(TOPDIR) COPYRIGHT
 
+DATE_FMT = +%B %d, %Y
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell LC_ALL=C date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || LC_ALL=C date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+
 $(IMAGES_DIR)/%.jar: pkgsToFiles.sh
 	$(RM) $@ $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%)
 	$(MKDIR) -p $(@D)
@@ -73,7 +80,7 @@ $(IMAGES_DIR)/%.jar: pkgsToFiles.sh
 	  echo "$(@F:%.jar=%)-Build: $(BUILD_NUMBER)" ; \
 	  echo "$(@F:%.jar=%)-BuildJavaVersion: `$(JDKJAVA) -fullversion 2>&1 | awk '{print $$NF}'  | \
 		sed -e 's|^"\(.*\)"$$|Java(TM) 2 SDK, Version \1|'`" ; \
-	  echo "$(@F:%.jar=%)-BuildDate: `/bin/date +'%B %d, %Y'`" ; \
+	  echo "$(@F:%.jar=%)-BuildDate: $(BUILD_DATE)" ; \
 	) \
 		> $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%/manifest.txt)
 	sh pkgsToFiles.sh $(CLASSDIR) $($(@F:%.jar=PKGS.JAR.%)) > $(@:$(IMAGES_DIR)/%.jar=$(BUILDDIR)/jarData/%/includes.txt)


### PR DESCRIPTION
This PR is an upstream of the patch by Chris Lamb (lamby@debian.org)[1].

Testing:
```
$ export SOURCE_DATE_EPOCH=1
$ bash make/build.sh 
...
$ cp build/images/jtreg/lib/jtreg.jar 1.jar
$ bash make/build.sh 
...
$ strip-nondeterminism build/images/jtreg/lib/jtreg.jar 
$ strip-nondeterminism 1.jar 
$ diff 1.jar build/images/jtreg/lib/jtreg.jar 
$ jar xvf 1.jar
$ cat META-INF/MANIFEST.MF 
Manifest-Version: 1.0
Main-class: com.sun.javatest.regtest.Main
Class-Path: javatest.jar asmtools.jar
jtreg-Name: jtreg
jtreg-VersionString: 7.3.1-dev+0
jtreg-Version: 7.3.1
jtreg-Milestone: dev
jtreg-Build: 0
jtreg-BuildJavaVersion: Java(TM) 2 SDK, Version 17.0.8+7-Ubuntu-123.04
jtreg-BuildDate: January 01, 1970
Created-By: 17.0.8 (Private Build)

```

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038957

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903539](https://bugs.openjdk.org/browse/CODETOOLS-7903539): Please make jtreg build date reproducible (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/jtreg.git pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/170.diff">https://git.openjdk.org/jtreg/pull/170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/170#issuecomment-1702357777)