### PR TITLE
7903553: Update GitHub checkout action to v4

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,5 +10,5 @@ jobs:
     name: 'Validation'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 1
 
     - name: 'Set up Java Development Kit'
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'oracle'
         java-version: '17'


### PR DESCRIPTION
Please review this change to update to use `actions/checkout@v4` in jtreg's GHA workflows.

Find the associated release notes here: https://github.com/actions/checkout/releases/tag/v4.0.0