### PR TITLE
7903526: jtreg should handle all exceptions

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
@@ -61,7 +61,7 @@ public class MainActionHelper extends ActionHelper {
     private String testThreadFactoryPath;
     private OutputHandler outputHandler;
 
-    private Throwable globalUncaughtThrowable;
+    private volatile Throwable globalUncaughtThrowable;
 
     MainActionHelper(String testName) {
         this.testName = testName;


### PR DESCRIPTION
Currently, jtreg executes a test in MainThreadGroup and checks uncaught exceptions for this group. So it handles all exceptions if the test doesn't create new thread groups.
However, the virtual threads don't belong to MainThreadGroup and jtreg silently ignores all exceptions thrown by virtual threads.

The testing shows that we have already some problems in jdk/jdk and probably in UR releases. There are 13 test failures in tier1 and several tens in the execution of tests that use secutiry-manager and run with a virtual thread.

It wonder if it makes sense to have this check conditional using some java property and start fixing tests after jtreg is release and smoothly switch execution to the new version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903526](https://bugs.openjdk.org/browse/CODETOOLS-7903526): jtreg should handle all exceptions (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/jtreg.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/172.diff">https://git.openjdk.org/jtreg/pull/172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/172#issuecomment-1756242348)