### PR TITLE
7903580: Allow for re-attempting agent creation when an attempt fails

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -808,6 +808,7 @@ public class Agent {
                        String testThreadFactoryPath)
                 throws Fault {
             final int numAttempts = this.numAgentSelectionAttempts;
+            assert numAttempts > 0 : "unexpected agent selection attempts: " + numAttempts;
             Agent.Fault toThrow = null;
             for (int i = 1; i <= numAttempts; i++) {
                 try {
@@ -1022,8 +1023,7 @@ public class Agent {
         private float timeoutFactor = 1.0f;
         private int maxPoolSize;
         private Duration idleTimeout;
-        // default is 1 i.e. we don't re-attempt a failed agent selection
-        private int numAgentSelectionAttempts = 1;
+        private int numAgentSelectionAttempts;
     }
 
     static class Stats {

--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -91,6 +91,11 @@ public class Agent {
     static final boolean showAgent = Flags.get("showAgent");
     static final boolean traceAgent = Flags.get("traceAgent");
 
+    // the following code here allows us to run jtreg on older
+    // JDKs where the pid() method is unavailable on the
+    // Process class. we use PID only for debug purposes and
+    // the inability to get the PID of a launched AgentServer
+    // is OK.
     private static final long UNKNOWN_PID = -1;
     private static final Method PID_METHOD;
     static {

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -26,7 +26,6 @@
 package com.sun.javatest.regtest.exec;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
@@ -1230,39 +1229,10 @@ public class RegressionScript extends Script {
         envVars.put("CLASSPATH", cp.toString());
 
         Agent.Pool p = Agent.Pool.instance(params);
-        final int numAttempts = p.getNumAgentSelectionAttempts();
-        assert numAttempts >= 1 : "invalid agent selection attempts: " + numAttempts;
-        Agent.Fault toThrow = null;
-        for (int i = 1; i <= numAttempts; i++) {
-            try {
-                if (i != 1) {
-                    p.log("Re-attempting agent creation, attempt number " + i);
-                }
-                Agent agent = p.getAgent(absTestScratchDir().toFile(), jdk, vmOpts.toList(),
-                        envVars, testThreadFactory, testThreadFactoryPath);
-                agents.add(agent);
-                return agent;
-            } catch (Agent.Fault f) {
-                // keep track of the fault and reattempt to get an agent if within limit
-                if (toThrow == null) {
-                    toThrow = f;
-                } else {
-                    // add the previous exception as a suppressed exception
-                    // of the current one
-                    if (toThrow.getCause() != null) {
-                        f.addSuppressed(toThrow.getCause());
-                    }
-                    toThrow = f;
-                }
-                if (i == numAttempts || !(f.getCause() instanceof IOException)) {
-                    // we either made enough attempts or we failed due to a non IOException.
-                    // In either case we don't attempt to create an agent again and instead throw
-                    // the captured failure(s)
-                    throw toThrow;
-                }
-            }
-        }
-        throw new AssertionError("should not reach here");
+        Agent agent = p.getAgent(absTestScratchDir().toFile(), jdk, vmOpts.toList(), envVars,
+                testThreadFactory, testThreadFactoryPath);
+        agents.add(agent);
+        return agent;
     }
 
     /**

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2330,9 +2330,8 @@ public class Tool {
     private String testThreadFactoryPathArg;
     private int maxPoolSize = -1;
     private Duration poolIdleTimeout = Duration.ofSeconds(30);
-    // number of attempts to get an agent for an action. we default to 1, which implies
-    // by default we don't re-attempt on a failure
-    private int numAgentSelectionAttempt = 1;
+    // number of attempts to get an agent for an action
+    private int numAgentSelectionAttempt = DEFAULT_NUM_AGENT_SEL_ATTEMPT;
     private List<String> testCompilerOpts = new ArrayList<>();
     private List<String> testJavaOpts = new ArrayList<>();
     private List<String> testVMOpts = new ArrayList<>();
@@ -2380,6 +2379,10 @@ public class Tool {
             "TMP", "TEMP", "TZ",
             "windir"
     };
+
+    // default value for agent selection attempts. we default to 1, which implies
+    // by default we don't re-attempt on a failure
+    private static final int DEFAULT_NUM_AGENT_SEL_ATTEMPT = 1;
 
     private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Tool.class);
 }

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2330,9 +2330,9 @@ public class Tool {
     private String testThreadFactoryPathArg;
     private int maxPoolSize = -1;
     private Duration poolIdleTimeout = Duration.ofSeconds(30);
-    // number of attempts to get an agent for an action. we default to 2, to allow
-    // for retrying a failed attempt once
-    private int numAgentSelectionAttempt = 2;
+    // number of attempts to get an agent for an action. we default to 1, which implies
+    // by default we don't re-attempt on a failure
+    private int numAgentSelectionAttempt = 1;
     private List<String> testCompilerOpts = new ArrayList<>();
     private List<String> testJavaOpts = new ArrayList<>();
     private List<String> testVMOpts = new ArrayList<>();

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -459,6 +459,22 @@ public class Tool {
             }
         },
 
+        new Option(GNU, AGENT_POOL, null, "--agent-attempts") {
+            @Override
+            public void process(String opt, String arg) throws BadArgs {
+                int numTimes;
+                try {
+                    numTimes = Integer.parseInt(arg);
+                } catch (NumberFormatException e) {
+                    throw new BadArgs(i18n, "main.badAgentSelAttempt", arg);
+                }
+                if (numTimes < 1) {
+                    throw new BadArgs(i18n, "main.badAgentSelAttempt", numTimes);
+                }
+                numAgentSelectionAttempt = numTimes;
+            }
+        },
+
         new Option(STD, MAIN, "", "-conc", "-concurrency") {
             @Override
             public void process(String opt, String arg) {
@@ -1311,6 +1327,7 @@ public class Tool {
                     }
                     p.setMaxPoolSize(maxPoolSize);
                     p.setIdleTimeout(poolIdleTimeout);
+                    p.setNumAgentSelectionAttempts(numAgentSelectionAttempt);
                     break;
                 case OTHERVM:
                     break;
@@ -2313,6 +2330,9 @@ public class Tool {
     private String testThreadFactoryPathArg;
     private int maxPoolSize = -1;
     private Duration poolIdleTimeout = Duration.ofSeconds(30);
+    // number of attempts to get an agent for an action. we default to 2, to allow
+    // for retrying a failed attempt once
+    private int numAgentSelectionAttempt = 2;
     private List<String> testCompilerOpts = new ArrayList<>();
     private List<String> testJavaOpts = new ArrayList<>();
     private List<String> testVMOpts = new ArrayList<>();

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -296,13 +296,10 @@ help.pool.pool_idle_timeout.desc=\
      automatically closed.
 help.pool.agent_attempts.arg=<number>
 help.pool.agent_attempts.desc=\
-    The maximum number of times the pool will be queried for a agent VM \
-    when running an action. A value of 1 will mean that no retry will be \
-    attempted if either a new agent VM creation fails or an existing one \
-    couldn't be obtained from the pool. Similarly, a value of 2 will imply \
-    that if the agent VM creation fails or an existing one couldn't be \
-    obtained from the pool, then 1 retry will be attempted. \
-    Accepts a integer value; any value lesser than 1 is rejected.
+    The number of attempts jtreg will make to access an agent \
+    with the desired characteristics, either by creating a new one, \
+    or obtaining one from the pool of reusable VMs. The minimum value, \
+    and the default value, is 1.
 
 help.select.name=Test Selection Options
 help.select.desc=These options can be used to refine the set of tests to \

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -294,6 +294,15 @@ help.pool.pool_idle_timeout.arg=<number>
 help.pool.pool_idle_timeout.desc=\
      The time, in seconds, before an idle VM in the pool is \
      automatically closed.
+help.pool.agent_attempts.arg=<number>
+help.pool.agent_attempts.desc=\
+    The maximum number of times the pool will be queried for a agent VM \
+    when running an action. A value of 1 will mean that no retry will be \
+    attempted if either a new agent VM creation fails or an existing one \
+    couldn't be obtained from the pool. Similarly, a value of 2 will imply \
+    that if the agent VM creation fails or an existing one couldn't be \
+    obtained from the pool, then 1 retry will be attempted. \
+    Accepts a integer value; any value lesser than 1 is rejected.
 
 help.select.name=Test Selection Options
 help.select.desc=These options can be used to refine the set of tests to \
@@ -446,6 +455,7 @@ help.version.txt={0} {1}\nInstalled in {2}\nRunning on platform version {3} from
 help.version.unknown=(unknown)
 
 main.badArgs=Error: {0}
+main.badAgentSelAttempt=Bad value for agent selection attempts: {0}
 main.badConcurrency=Bad use of -concurrency
 main.badKeywords=Bad keyword expression: {0}
 main.badLockFile=Bad lock file: {0}

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -711,11 +711,11 @@ that action gets reported as a failed.
 
 This default behaviour can be overridden by passing the `--agent-attempts` option
 to `jtreg` command. This option takes an integer value which represents the number
-of attempts JTReg is allowed to make when attempting to get a agent for a test
-action. By default, the value of this option is `1`, implying JTReg will not
-re-attempt a failed attempt. Passing a higher value for this option will allow
-JTReg to re-attempt a failed attempt. For example, a value of `2` will allow JTReg
-to re-attempt once for each failed attempt.
+of attempts to make when attempting to get an agent for a test action. By default,
+the value of this option is `1`, implying JTReg will not re-attempt a failed
+attempt. Passing a higher value for this option will allow JTReg to re-attempt a
+failed attempt. For example, a value of `2` will allow JTReg to re-attempt once
+for each failed attempt.
 
 ### How do I specify whether to run tests concurrently?
 

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -701,20 +701,20 @@ if the default mode was not used.  For example,
 
 #### jtreg has trouble starting agents; what can I do?
 
-When running in agent mode, jtreg creates agent VMs as and when necessary.
+When running in agent mode, JTReg creates agent VMs as and when necessary.
 Agent VM creation involves launching a process and communicating with it over
-a socket. The initial handshake between the newly launched process and jtreg
+a socket. The initial handshake between the newly launched process and JTReg
 can sometimes timeout if the system is under heavy load. This then causes the
-agent creation to fail. By default, jtreg does not re-attempt creation of the
+agent creation to fail. By default, JTReg does not re-attempt creation of the
 agent VM and instead the failure is propagated as a test action failure and
 that action gets reported as a failed.
 
 This default behaviour can be overridden by passing the `--agent-attempts` option
 to `jtreg` command. This option takes an integer value which represents the number
-of attempts jtreg is allowed to make when attempting to get a agent for a test
-action. By default, the value of this option is `1`, implying jtreg will not
+of attempts JTReg is allowed to make when attempting to get a agent for a test
+action. By default, the value of this option is `1`, implying JTReg will not
 re-attempt a failed attempt. Passing a higher value for this option will allow
-jtreg to re-attempt a failed attempt. For example, a value of `2` will allow jtreg
+JTReg to re-attempt a failed attempt. For example, a value of `2` will allow JTReg
 to re-attempt once for each failed attempt.
 
 ### How do I specify whether to run tests concurrently?

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -699,6 +699,24 @@ if the default mode was not used.  For example,
     elapsed time (seconds): 0.141
 ````
 
+#### jtreg has trouble starting agents; what can I do?
+
+When running in agent mode, jtreg creates agent VMs as and when necessary.
+Agent VM creation involves launching a process and communicating with it over
+a socket. The initial handshake between the newly launched process and jtreg
+can sometimes timeout if the system is under heavy load. This then causes the
+agent creation to fail. By default, jtreg does not re-attempt creation of the
+agent VM and instead the failure is propagated as a test action failure and
+that action gets reported as a failed.
+
+This default behaviour can be overridden by passing the `--agent-attempts` option
+to `jtreg` command. This option takes an integer value which represents the number
+of attempts jtreg is allowed to make when attempting to get a agent for a test
+action. By default, the value of this option is `1`, implying jtreg will not
+re-attempt a failed attempt. Passing a higher value for this option will allow
+jtreg to re-attempt a failed attempt. For example, a value of `2` will allow jtreg
+to re-attempt once for each failed attempt.
+
 ### How do I specify whether to run tests concurrently?
 
 jtreg provides the ability to run tests in parallel, using multiple

--- a/test/badtests/BadTests.gmk
+++ b/test/badtests/BadTests.gmk
@@ -68,7 +68,7 @@ $(BUILDTESTDIR)/BadTests.agentvm.ok: \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
 	$(GREP) -s 'Test results: passed: 17; failed: 1; error: 2' $(@:%.ok=%/jt.log)  > /dev/null
-	agents=`$(GREP) '^\[[-0-9 :,]*\] Agent\[[0-9][0-9]*\]: Started' $(@:%.ok=%/jt.log) | wc -l` ; \
+	agents=`$(GREP) '^\[[-0-9 :,]*\] Agent\[[0-9][0-9]*\]: Launching' $(@:%.ok=%/jt.log) | wc -l` ; \
 	if [ $${agents} -ne 4 ]; then echo "Unexpected number of agents used: $${agents}" ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 

--- a/test/debug/DebugTest.gmk
+++ b/test/debug/DebugTest.gmk
@@ -62,10 +62,10 @@ $(BUILDTESTDIR)/DebugTest.agentvm.ok: \
 		-debug:-Ddebug=true \
 		$(TESTDIR)/debug \
 			> $(@:%.ok=%/jt.log) 2>&1 ; rc=$$?
-	agents=`$(GREP) '^\[[-0-9 :,]*\] Agent...: Started' $(@:%.ok=%)/jt.log | wc -l | tr -d ' '` ; \
- 	debugAgents=`$(GREP) '^\[[-0-9 :,]*\] Agent...: Started.*-Ddebug=true' $(@:%.ok=%)/jt.log | wc -l | tr -d ' '` ; \
+	agents=`$(GREP) '^\[[-0-9 :,]*\] Agent...: Launching' $(@:%.ok=%)/jt.log | wc -l | tr -d ' '` ; \
+	debugAgents=`$(GREP) '^\[[-0-9 :,]*\] Agent...: Launching.*-Ddebug=true' $(@:%.ok=%)/jt.log | wc -l | tr -d ' '` ; \
 	if [ "$$agents" != 2 -o "$$debugAgents" != 1 ]; then \
-	    $(GREP) '^\[[-0-9 :,]*\] Agent...: Started' $(@:%.ok=%)/jt.log ; \
+	    $(GREP) '^\[[-0-9 :,]*\] Agent...: Launching' $(@:%.ok=%)/jt.log ; \
 	    echo "unexpected use of -debug options"; exit 1; \
 	fi
 	echo "test passed at `date`" > $@


### PR DESCRIPTION
Can I please get a review of this change which proposes to implement the enhancement request noted in https://bugs.openjdk.org/browse/CODETOOLS-7903580?

Several times in our CI instances we have noticed that a test (action) fails because it is unable to create an `Agent` instance due to the socket connection not being established between the `AgentServer` and the `ServerSocket` running within the jtreg process. This causes the test itself to fail with `Error. Cannot get VM for test: java.net.SocketTimeoutException: Accept timed out`. It has also been noticed that most of the times this is intermittent and subsequent attempt for a different test (action) passes. 

The proposed change here introduces a new configuration parameter `--agent-attempts` under "Agent Pool Options", which allows for configuring the maximum number of attempts that are allowed for getting an agent for an action. This is an optional parameter and by default it has been set to a value of `2`, which by default then allows the agent creation to be retried once if the previous attempt fails. This then means that existing installations/usages of jtreg need not set a value for `--agent-attempts` to enroll for this feature. A value of `1` for this parameter implies that the agent creation attempt will be done only once, which is what currently happens in the absence of this proposed feature.

Inability to obtain an agent, for whatever reason, after attempting `--agent-attempts` times continues to result in test (action) failure, like it does today.

Some additional minor logging related changes have been done too, to help debugging some of the current observed failures.

This change has been tested in the following manners:

1. This modified build of jtreg has been used to run tier1, tier2 and tier3 of JDK mainline and it has been verified that nothing regresses with this change. That however doesn't mean that agent creation re-attempt logic was tested in these runs (since the first attempt never failed).
2. Locally this build was jtreg was additionally modified to selectively not connect to the `ServerSocket`'s port thus simulating a "Accept timed out" exception. That change then verified that the re-attempt logic does indeed correctly kick in and the test action passes after picking up the newly created agent.
3. `--agent-attempts 1` was passed to the above modified build (from step 2) to verify that the re-attempt isn't attempted when `--agent-attempts 1` and the test fails as currently with "test result: Error. Cannot get VM for test: java.net.SocketTimeoutException: Accept timed out"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903580](https://bugs.openjdk.org/browse/CODETOOLS-7903580): Allow for re-attempting agent creation when an attempt fails (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [3d08cdfe](https://git.openjdk.org/jtreg/pull/173/files/3d08cdfe4bcce041e37cca0222cf00feb4512067)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jtreg.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/173.diff">https://git.openjdk.org/jtreg/pull/173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/173#issuecomment-1808217547)