### PR TITLE
7903581: Typo in make file in pandoc binary detection

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -150,7 +150,7 @@ PANDOC  := $(shell if [ -r /usr/bin/pandoc ]; then \
 		echo /usr/bin/pandoc ; \
 	elif [ -r /usr/local/bin/pandoc ]; then \
 		echo /usr/local/bin/pandoc ; \
-	elif [ -r /opt/homebrew/bin/tidy ]; then \
+	elif [ -r /opt/homebrew/bin/pandoc ]; then \
 		echo /opt/homebrew/bin/pandoc ; \
 	else \
 		echo /bin/echo "pandoc not available" ; \

--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Can I please get a review of this change which fixes a in typo in `pandoc` binary detection in the make file? This addresses https://bugs.openjdk.org/browse/CODETOOLS-7903581

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903581](https://bugs.openjdk.org/browse/CODETOOLS-7903581): Typo in make file in pandoc binary detection (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - no project role)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - no project role)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/jtreg.git pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/174.diff">https://git.openjdk.org/jtreg/pull/174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/174#issuecomment-1809628228)