### PR TITLE
7903601 : jtr.xml logs produced with -xml argument do not contain failure justification

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
@@ -178,14 +178,12 @@ public class XMLWriter {
 
     private String getOutput(String name) throws TestResult.Fault {
         String[] titles = tr.getSectionTitles();
-        //first we are looking for a "main" section in jtr log.. if none is found it is usually cuz the test is executed via script, hence under "shell" section
-        for (String section : Arrays.asList("main", "shell")){
-            for (int i = 0; i < titles.length; i++) {
-                if (titles[i].equals(section)) {
-                    Section s = tr.getSection(i);
-                    for (String x : s.getOutputNames()) {
-                        return s.getOutput(name);
-                    }
+        //we are looking for either a "main" section or "shell" section in jtr log
+        for (int i = 0; i < titles.length; i++) {
+            if (titles[i].equals("main") || titles[i].equals("shell")) {
+                Section s = tr.getSection(i);
+                for (String x : s.getOutputNames()) {
+                    return s.getOutput(name);
                 }
             }
         }

--- a/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
@@ -40,6 +40,7 @@ import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
@@ -177,11 +178,14 @@ public class XMLWriter {
 
     private String getOutput(String name) throws TestResult.Fault {
         String[] titles = tr.getSectionTitles();
-        for (int i = 0; i < titles.length; i++) {
-            if (titles[i].equals("main")) {
-                Section s = tr.getSection(i);
-                for (String x : s.getOutputNames()) {
-                    return s.getOutput(name);
+        //first we are looking for a "main" section in jtr log.. if none is found it is usually cuz the test is executed via script, hence under "shell" section
+        for (String section : Arrays.asList("main", "shell")){
+            for (int i = 0; i < titles.length; i++) {
+                if (titles[i].equals(section)) {
+                    Section s = tr.getSection(i);
+                    for (String x : s.getOutputNames()) {
+                        return s.getOutput(name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
issue:
https://bugs.openjdk.org/browse/CODETOOLS-7903601

with "-xml" argument when a shell driven test fails, the only thing you are getting in jtr.xml file as an explanation is the exit code which is not very helpful.. this is a fix for that which aligns the behavior of shell tests with that of java tests. The solution is up for a discussion, I just did the simplest and sturdiest solution I could think of.. in case there is no "main" section in the original jtr file, the xmlwriter in jtreg tries to iterate the sections again for "shell" section and writes the failure it finds there to the jtr.xml log

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903601](https://bugs.openjdk.org/browse/CODETOOLS-7903601): jtr.xml logs produced with -xml argument do not contain failure justification (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/jtreg.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/175.diff">https://git.openjdk.org/jtreg/pull/175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/175#issuecomment-1842773253)