### PR TITLE
CODETOOLS-7903623: Test may fail depending on environment.

### DIFF
--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -70,6 +70,7 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 		    -e 's|$(JDK8HOME)|%JDKHOME%|g' \
 		    -e "s|`cd $(JDK8HOME); pwd -P`|%JDKHOME%|g" \
 		    -e '/JTREG_JAVA=/d' \
+		    -e '/LC_CTYPE=/d' \
 		    -e 's|$(BUILDTESTDIR)|%BUILDTEST%|g' \
 		    -e 's|$(BUILDDIR)|%BUILD%|g' \
 		    -e 's|$(ABSTOPDIR)|%WS%|g' \


### PR DESCRIPTION
Please review a trivial patch to ignore the setting of `LC_CTYPE` (or lack thereof) when running the rerun tests.

For me, the variable is set in a terminal window in IDEA (and cannot be unset) and is not set in a normal Terminal window on macOS. The variable is not germane to the test and  is now ignored during the comparison.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903623](https://bugs.openjdk.org/browse/CODETOOLS-7903623): Test may fail depending on environment. (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.org/jtreg.git pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/179.diff">https://git.openjdk.org/jtreg/pull/179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/179#issuecomment-1888075836)