### PR TITLE
7903624: Use openjdk.org instead of openjdk.java.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## [7.3](https://git.openjdk.org/jtreg/compare/jtreg-7.2+1...jtreg-7.3+1)
 
 * Updated set of default environment variables set for tests on Unix-like platforms.
-  * Includes `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, and `XDG-*` 
+  * Includes `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, and `XDG-*`
     [CODETOOLS-7903400](https://bugs.openjdk.org/browse/CODETOOLS-7903400)
 
 * Updated external dependencies.
@@ -22,7 +22,7 @@
   * AgentServer log() does not flush [CODETOOLS-7903470](https://bugs.openjdk.org/browse/CODETOOLS-7903470)
   * System.out and System.err messages are missing in jtr file when a test times out in agentvm mode [CODETOOLS-7903441](https://bugs.openjdk.org/browse/CODETOOLS-7903441)
   * Timeout refired %s times message confusing [CODETOOLS-7902485](https://bugs.openjdk.org/browse/CODETOOLS-7902485)
- 
+
 * Fixed race-condition when running tests with a multi-module setup
   * [CODETOOLS-7903507](https://bugs.openjdk.org/browse/CODETOOLS-7903507)
 
@@ -197,7 +197,7 @@
 * Support `@enablePreview`.
   * [CODETOOLS-7902654](https://bugs.openjdk.org/browse/CODETOOLS-7902654)
 
-* Use https://git.openjdk.java.net for CODE_TOOLS_URL.
+* Use https://git.openjdk.org for CODE_TOOLS_URL.
   * [CODETOOLS-7902637](https://bugs.openjdk.org/browse/CODETOOLS-7902637)
 
 * Ignore specified lines in `@compile/fail/ref=<file>`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 JTReg is part of the OpenJDK [CodeTools] Project.
 
-Please see <https://openjdk.java.net/contribute/> for how to contribute.
+Please see <https://openjdk.org/contribute/> for how to contribute.
 
 
-[CodeTools]: https://openjdk.java.net/projects/code-tools
+[CodeTools]: https://openjdk.org/projects/code-tools

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 * For details on running JDK tests using the JDK _make test_ framework, see
   [Using "make test" (the run-test framework)][make-test].
 
-[faq]: https://openjdk.java.net/jtreg/faq.html
-[tagspec]: https://openjdk.java.net/jtreg/tag-spec.html
+[faq]: https://openjdk.org/jtreg/faq.html
+[tagspec]: https://openjdk.org/jtreg/tag-spec.html
 [make-test]: https://github.com/openjdk/jdk/blob/master/doc/testing.md
 
 ## Using IntelliJ IDEA

--- a/doc/building.md
+++ b/doc/building.md
@@ -1,6 +1,6 @@
 # Building The Regression Test Harness for the OpenJDK platform: `jtreg`
 
-(This information is also available at <http://openjdk.java.net/jtreg/build.html>)
+(This information is also available at <http://openjdk.org/jtreg/build.html>)
 
 `jtreg` depends on a number of external components:
     JT Harness, TestNG, JUnit, AsmTools, and JCov.

--- a/make/CheckJavaOSVersion.java
+++ b/make/CheckJavaOSVersion.java
@@ -25,7 +25,7 @@
  * Checks the value of System.getProperty("os.version") against an expected value.
  * For more info, see
  * JDK-8253702: BigSur version number reported as 10.16, should be 11.nn
- * https://bugs.openjdk.java.net/browse/JDK-8253702
+ * https://bugs.openjdk.org/browse/JDK-8253702
  */
 public class CheckJavaOSVersion {
     public static void main(String... args) {

--- a/make/build-support/build-common.sh
+++ b/make/build-support/build-common.sh
@@ -326,7 +326,7 @@ export CURL="${CURL:-$(which curl)}"
 export CURL_OPTIONS="${CURL_OPTIONS:--s -f -L}"
 
 export MAVEN_REPO_URL_BASE="${MAVEN_REPO_URL_BASE:-https://repo1.maven.org/maven2}"
-export CODE_TOOLS_URL_BASE="${CODE_TOOLS_URL_BASE:-https://git.openjdk.java.net}"
+export CODE_TOOLS_URL_BASE="${CODE_TOOLS_URL_BASE:-https://git.openjdk.org}"
 export ANT_ARCHIVE_URL_BASE="${ANT_ARCHIVE_URL_BASE:-https://archive.apache.org/dist/ant/binaries}"
 
 setup_shasum

--- a/make/build.sh
+++ b/make/build.sh
@@ -57,7 +57,7 @@
 # MAVEN_REPO_URL_BASE (e.g. "https://repo1.maven.org/maven2")
 #     The base URL for the maven central repository.
 #
-# CODE_TOOLS_URL_BASE (e.g. "https://git.openjdk.java.net")
+# CODE_TOOLS_URL_BASE (e.g. "https://git.openjdk.org")
 #     The base URL for the code tools source repositories.
 #
 # ANT_ARCHIVE_URL_BASE (e.g. "https://archive.apache.org/dist/ant/binaries")
@@ -401,7 +401,7 @@ checkJavaOSVersion() {
   # This checks that the value in the Java "os.version" system property
   # is as expected.  While it is OK to *build* jtreg with a JDK with this bug,
   # some of the `jtreg` self-tests will fail: notably, test/problemList.
-  # See https://bugs.openjdk.java.net/browse/JDK-8253702
+  # See https://bugs.openjdk.org/browse/JDK-8253702
   case `uname` in
     Darwin )
       OS_VERSION=`defaults read loginwindow SystemVersionStampAsString`

--- a/plugins/idea/README.md
+++ b/plugins/idea/README.md
@@ -19,7 +19,7 @@ The output of this folder is as follows:
        |-java (plugin sources)
        |-resources (plugin resources - the plugin.xml file lives here)
    |-build (where build files are stored)
-       |-distributions (where the plugin zip file is generated)   
+       |-distributions (where the plugin zip file is generated)
    |-build.gradle (the gradle build file)
    |-gradle.properties (contains properties required to build this project)
 ```
@@ -86,7 +86,7 @@ To run an existing configuration, simply select it from the drop down list in th
 
 Debugging works as for any other Java application. Simply set breakpoints (this can be done by left-clicking the area to the left of the code in the source editor, which will cause a red circle to appear). During a test debug, execution will stop at any given breakpoints, allowing you to see values of variables, set watch expressions, etc.
 
-> Note: debugging only works with a _single_ test action such as `@run` or `@compile`. If multiple test actions are present, debugging will not work correctly. This is a known issue. To workaround, please manually remove the test actions that do not need to be debugged. Conversely, `@build` actions can be safely ignored, as they do not have any adverse effect on the debugging process.  
+> Note: debugging only works with a _single_ test action such as `@run` or `@compile`. If multiple test actions are present, debugging will not work correctly. This is a known issue. To workaround, please manually remove the test actions that do not need to be debugged. Conversely, `@build` actions can be safely ignored, as they do not have any adverse effect on the debugging process.
 
 ### Inspecting jtreg test results
 
@@ -117,4 +117,4 @@ To select which Ant target to run before a jtreg test, simply go in the `File ->
 
 ### Dealing with bugs
 
-In the unfortunate case you run into a plugin bug, you will notice a red mark in the bottom right part of the IDE. If you click on that icon, you will have the ability to show the stack trace associated with the error (and you will also be offered the option of disabling the plugin). If you want to report a bug against the jtreg plugin, we recommend that you copy the stack trace along with the IDE log file (this can be found under `Help -> Show Log in Files`) and submit them along with a description of the experienced buggy behavior. Please forward such bug reports to `jtreg-dev@openjdk.java.net`, or `ide-support-dev@openjdk.java.net` 
+In the unfortunate case you run into a plugin bug, you will notice a red mark in the bottom right part of the IDE. If you click on that icon, you will have the ability to show the stack trace associated with the error (and you will also be offered the option of disabling the plugin). If you want to report a bug against the jtreg plugin, we recommend that you copy the stack trace along with the IDE log file (this can be found under `Help -> Show Log in Files`) and submit them along with a description of the experienced buggy behavior. Please forward such bug reports to `jtreg-dev@openjdk.org`, or `ide-support-dev@openjdk.org`

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/util/Tag.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/util/Tag.java
@@ -27,7 +27,7 @@ package com.oracle.plugin.jtreg.util;
 
 /**
  * This class models a jtreg test tag. For a full specification of jtreg tags please refer to the following
- * document: {@link "http://openjdk.java.net/jtreg/tag-spec.html"}.
+ * document: {@link "http://openjdk.org/jtreg/tag-spec.html"}.
  */
 public class Tag {
     private final int start;

--- a/plugins/idea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
     <id>jtreg</id>
     <name>jtreg Test Support</name>
     <description><![CDATA[
-      Allows execution of tests developed using the <a href="http://openjdk.java.net/jtreg/">jtreg</a> framework.
+      Allows execution of tests developed using the <a href="http://openjdk.org/jtreg/">jtreg</a> framework.
     ]]></description>
     <vendor>openjdk</vendor>
 


### PR DESCRIPTION
We should use openjdk.org instead of openjdk.java.net.

This bug was triggered by the fact that git.openjdk.java.net had problem resolving properly for GitHub Actions in the build script (and the theory is that git.openjdk.org would work better), but this should be fixed nevertheless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903624](https://bugs.openjdk.org/browse/CODETOOLS-7903624): Use openjdk.org instead of openjdk.java.net (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.org/jtreg.git pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/180.diff">https://git.openjdk.org/jtreg/pull/180.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/180#issuecomment-1889558291)