### PR TITLE
CODETOOLS-7903661: Defer evaluation of MAKE_ARGS in `make/build.sh`

### DIFF
--- a/make/build.sh
+++ b/make/build.sh
@@ -784,7 +784,7 @@ make ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
      JUNIT_NOTICES="${JUNIT_NOTICES}"                         \\
      TESTNG_JARS="${TESTNG_JARS}"                             \\
      TESTNG_NOTICES="${TESTNG_NOTICES}"                       \\
-   ${MAKE_ARGS:-}
+   "\$@"
 EOF
 
-sh ${BUILD_DIR}/make.sh
+sh ${BUILD_DIR}/make.sh ${MAKE_ARGS:-}


### PR DESCRIPTION
Please review a simple script change to allow MAKE_ARGS to be re-specified when invoking the `build/make.sh` file generated when running `make/build.sh`. (Invoking `build/make.sh` directly is a convenient way to bypass downloading and building the dependencies any time you want to build and test `jtreg` itself.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903661](https://bugs.openjdk.org/browse/CODETOOLS-7903661): Defer evaluation of MAKE_ARGS in `make/build.sh` (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/183/head:pull/183` \
`$ git checkout pull/183`

Update a local copy of the PR: \
`$ git checkout pull/183` \
`$ git pull https://git.openjdk.org/jtreg.git pull/183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 183`

View PR using the GUI difftool: \
`$ git pr show -t 183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/183.diff">https://git.openjdk.org/jtreg/pull/183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/183#issuecomment-1939955424)