### PR TITLE
7903686: jtreg Agent should use loopback address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Use SOURCE_BUILD_EPOCH to suppport reproducible builds
   [CODETOOLS-7903539](https://bugs.openjdk.org/browse/CODETOOLS-7903539)
 
+* jtreg, when communicating with the AgentServer in agentvm mode, will now bind to loopback address.
+  [CODETOOLS-7903686](https://bugs.openjdk.org/browse/CODETOOLS-7903686)
+
 ## [7.3.1](https://git.openjdk.org/jtreg/compare/jtreg-7.3+1...jtreg-7.3.1+1)
 
 * Fixed setting default environment variables on Windows

--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/AgentServer.java
@@ -154,8 +154,9 @@ public final class AgentServer implements ActionHelper.OutputHandler {
             traceOut.println("Agent.Server started");
         }
         boolean allowSetSecurityManagerFlag = false;
-        // use explicit localhost to avoid VPN issues
-        InetAddress host = InetAddress.getByName("localhost");
+        // by default use loopback address. if "-host" is specified, this will
+        // then be overridden by that value
+        InetAddress host = InetAddress.getLoopbackAddress();
         int id = 0;
         int port = -1;
         File logFile = null;
@@ -206,11 +207,12 @@ public final class AgentServer implements ActionHelper.OutputHandler {
         log("Started");
 
         if (port > 0) {
+            log("Connecting to " + host + ":" + port);
             Socket s = new Socket(host, port);
             s.setSoTimeout((int)(KeepAlive.READ_TIMEOUT * timeoutFactor));
             in = new DataInputStream(new BufferedInputStream(s.getInputStream()));
             out = new DataOutputStream(new BufferedOutputStream(s.getOutputStream()));
-            log("Listening on port " + port);
+            log("Listening for commands at " + s.getLocalSocketAddress());
         } else {
             in = new DataInputStream(new BufferedInputStream(System.in));
             out = new DataOutputStream(new BufferedOutputStream(System.out));

--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -145,7 +146,8 @@ public class Agent {
             // using a fixed port.) The default setting for SO_REUSEADDR
             // is platform-specific, and Solaris has it on by default.
             ss.setReuseAddress(false);
-            ss.bind(new InetSocketAddress(/*port:*/ 0), /*backlog:*/ 1);
+            InetAddress loopbackAddr = InetAddress.getLoopbackAddress();
+            ss.bind(new InetSocketAddress(loopbackAddr, /*port:*/ 0), /*backlog:*/ 1);
             final int port = ss.getLocalPort();
             cmd.add(AgentServer.PORT);
             cmd.add(String.valueOf(port));


### PR DESCRIPTION
Can I please get a review of this change which proposes to address https://bugs.openjdk.org/browse/CODETOOLS-7903686?

The jtreg framework when handling "agentvm" mode, creates a `java.net.ServerSocket` in the jtreg process and then launches a JVM with `com.sun.javatest.regtest.agent.AgentServer` as the main class, passing it the port to which the `ServerSocket` is bound to. The `AgentServer` is then responsible for creating a `java.net.Socket` and connecting against the jtreg process' `ServerSocket`. In its current form, the `ServerSocket` is bound to "any address" which means that it can `accept()` a connection from not just the current host on which `jtreg` is running but from any other host on the network from which this host is accessible. If such a connection is established, then such an unexpected connection then interferes with the semantics of jtreg and the AgentServer and leads to test failures. We have noticed such failures in our CI environment, when running the JDK tests.

The change in this PR proposes to bind the `ServerSocket` to loopback address to reduce the changes of such interference. This doesn't completely rule out interference from unexpected/rogue processes connecting from within the same host to this `ServerSocket`, but given that the processes running on the current host are much more controlled and managed, then that should not be too much of a problem.

A custom built jtreg was used with these changes and the JDK mainline's tier1, tier2, tier3 testing was done. All tests have passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903686](https://bugs.openjdk.org/browse/CODETOOLS-7903686): jtreg Agent should use loopback address (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [cf29d4f9](https://git.openjdk.org/jtreg/pull/185/files/cf29d4f9e38d31ca26059bc7a7f966e85eb76d02)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/jtreg.git pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/185.diff">https://git.openjdk.org/jtreg/pull/185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/185#issuecomment-1973069747)