### PR TITLE
7903538: NullPointerException: Cannot read the array length because "<local9>" is null

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/ScratchDirectory.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ScratchDirectory.java
@@ -208,7 +208,7 @@ abstract class ScratchDirectory {
 
         boolean ok = true;
         File[] children = dir.listFiles();
-        if (children == null) { // should always be not null, but File.listFiles() allows for it
+        if (children == null) { // should always be not null, but may be null if an error occurs
             log.println("warning: cannot list contents of directory " + dir);
             ok = false;
         } else {

--- a/src/share/classes/com/sun/javatest/regtest/exec/ScratchDirectory.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ScratchDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,11 +208,11 @@ abstract class ScratchDirectory {
 
         boolean ok = true;
         File[] children = dir.listFiles();
-        if (children == null) { // should always be not null, but sometimes it is
+        if (children == null) { // should always be not null, but File.listFiles() allows for it
             log.println("warning: cannot list contents of directory " + dir);
             ok = false;
         } else {
-            for (File file: dir.listFiles()) {
+            for (File file: children) {
                 if (isDirectory(file)) {
                     ok &= deleteFiles(file, p, match, true, badFiles, log);
                 } else {


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/CODETOOLS-7903538?

`java.io.File.listFiles()` as per its API doc says:

> ... Returns null if this abstract pathname does not denote a directory, or if an I/O error occurs.

So return values from `File.listFiles()` require a null check. It looks like this missing null check, in the `for` loop of the code being changed here, was in fact noticed previously and an attempt to address that was made almost a decade back in https://github.com/openjdk/jtreg/commit/329d3fb3dd6ab31c7133ef95383068f2de6f7735. But I think there's an oversight in that change. It does introduce a `null` check for the return value, but it still goes on to again call `dir.listFiles()` in the `for` loop. `dir` doesn't change ever in the `for` loop nor in that `else` block, so the `for` loop should just have used the `children` variable which is guaranteed to be non-null at that point.

The commit in this PR addresses that oversight. No new tests have been included given the nature of this change. Existing tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903538](https://bugs.openjdk.org/browse/CODETOOLS-7903538): NullPointerException: Cannot read the array length because "&lt;local9&gt;" is null (**Bug** - P3)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [53b143d9](https://git.openjdk.org/jtreg/pull/186/files/53b143d91f3d5702dea50cabf4420b890e2ea221)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [53b143d9](https://git.openjdk.org/jtreg/pull/186/files/53b143d91f3d5702dea50cabf4420b890e2ea221)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/jtreg.git pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/186.diff">https://git.openjdk.org/jtreg/pull/186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/186#issuecomment-1978053732)