### PR TITLE
7903692: JTREG_HOME and JT_HOME can interfere with jtreg self tests

### DIFF
--- a/make/build.sh
+++ b/make/build.sh
@@ -770,7 +770,9 @@ cat > ${BUILD_DIR}/make.sh << EOF
 #!/bin/sh
 
 cd "${ROOT}/make"
-make ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
+make JT_HOME=""                                               \\
+     JTREG_HOME=""                                            \\
+     ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
      ASMTOOLS_NOTICES="${ASMTOOLS_NOTICES}"                   \\
      BUILDDIR="${BUILD_DIR}"                                  \\
      BUILD_MILESTONE="${JTREG_BUILD_MILESTONE}"               \\

--- a/make/build.sh
+++ b/make/build.sh
@@ -770,9 +770,7 @@ cat > ${BUILD_DIR}/make.sh << EOF
 #!/bin/sh
 
 cd "${ROOT}/make"
-make JT_HOME=""                                               \\
-     JTREG_HOME=""                                            \\
-     ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
+make ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
      ASMTOOLS_NOTICES="${ASMTOOLS_NOTICES}"                   \\
      BUILDDIR="${BUILD_DIR}"                                  \\
      BUILD_MILESTONE="${JTREG_BUILD_MILESTONE}"               \\
@@ -782,6 +780,8 @@ make JT_HOME=""                                               \\
      JAVATEST_JAR="$(mixed_path "${JTHARNESS_JAVATEST_JAR}")" \\
      JDKHOME="$(mixed_path ${JAVA_HOME})"                     \\
      JTHARNESS_NOTICES="${JTHARNESS_NOTICES}"                 \\
+     JTREG_HOME=""                                            \\
+     JT_HOME=""                                               \\
      JUNIT_JARS="${JUNIT_JARS}"                               \\
      JUNIT_NOTICES="${JUNIT_NOTICES}"                         \\
      TESTNG_JARS="${TESTNG_JARS}"                             \\


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/CODETOOLS-7903692?

As noted in that issue, when running the jtreg self tests for the project, if `JT_HOME` (or `JTREG_HOME`) have been configured to point to some specific jtreg installation, then the self tests instead of running against the locally built/changed jtreg will end up running against the jtreg installation pointed to by that environment variable. That effectively means that the changes being tested aren't tested against the actual changed code in jtreg and the test results can be misleading.

The commit in this PR generates a `make.sh` which resets the `JT_HOME` and `JTREG_HOME` environment variables to be empty so that the `jtreg` script that's launched from the locally built jtreg image will then pick up the correct locally built jtreg image.

I have run the jtreg self tests locally with this change and they continue to pass. Without this change, some of the tests fail because they end up picking a jtreg installation which doesn't have some recent changes that are available in this git repo (that's what prompted me to investigate this issue).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903692](https://bugs.openjdk.org/browse/CODETOOLS-7903692): JTREG_HOME and JT_HOME can interfere with jtreg self tests (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [007af370](https://git.openjdk.org/jtreg/pull/189/files/007af3705a946a29ebdf20385d179a5bb9d8c847)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [007af370](https://git.openjdk.org/jtreg/pull/189/files/007af3705a946a29ebdf20385d179a5bb9d8c847)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/jtreg.git pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/189.diff">https://git.openjdk.org/jtreg/pull/189.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/189#issuecomment-1982825502)