### PR TITLE
7903621: jtreg ignores VM exit code when test process reports status with "STATUS: " line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 * Use SOURCE_BUILD_EPOCH to suppport reproducible builds
   [CODETOOLS-7903539](https://bugs.openjdk.org/browse/CODETOOLS-7903539)
+
 * Updated jtreg to bundle JUnit 5.10.2 [CODETOOLS-7903578](https://bugs.openjdk.org/browse/CODETOOLS-7903578)
 
 * jtreg, when communicating with the AgentServer in agentvm mode, will now bind to loopback address.
   [CODETOOLS-7903686](https://bugs.openjdk.org/browse/CODETOOLS-7903686)
+
+* jtreg, in certain cases, would incorrectly report a test as PASSED when the test process would exit with a non-zero exit code.
+  [CODETOOLS-7903621](https://bugs.openjdk.org/browse/CODETOOLS-7903621)
 
 ## [7.3.1](https://git.openjdk.org/jtreg/compare/jtreg-7.3+1...jtreg-7.3.1+1)
 

--- a/test/exitCodes/ErrorAfterPass.java
+++ b/test/exitCodes/ErrorAfterPass.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ */
+public class ErrorAfterPass {
+
+    public static void main(final String[] args) {
+        // a shutdown hook which calls Runtime.halt() with a non-zero exit code
+        final Thread shutdownHook = new Thread(() -> {
+            final int shutdownHookExitCode = 211; // just some "unique" exit code
+            System.err.println("Calling Runtime.halt(" + shutdownHookExitCode
+                    + ") from shutdown hook");
+            Runtime.getRuntime().halt(shutdownHookExitCode);
+        }, "ErrorAfterPass-shutdown-hook");
+        // register the shutdown hook
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        // finish the test successfully
+        System.err.println("ErrorAfterPass.main() completed successfully");
+    }
+}

--- a/test/exitCodes/ExitCodeTest.gmk
+++ b/test/exitCodes/ExitCodeTest.gmk
@@ -97,7 +97,7 @@ $(BUILDTESTDIR)/ExitCodeTest.Fault.ok: \
         if [ "$$rc" != 5 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
-EXPECTED_ERR_MSG := "test result: Error. unexpected exit code: 211, doesn't match exit status: \"Passed.\" which was logged by the test process"
+EXPECTED_ERR_MSG := "test result: Error. unexpected exit code: 211, doesn't match exit status: \"Passed.\" which was reported by the test process"
 $(BUILDTESTDIR)/ExitCodeTest.ErrorAfterPass.ok: \
 	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	$(JTREG_IMAGEDIR)/bin/jtreg

--- a/test/exitCodes/ExitCodeTest.gmk
+++ b/test/exitCodes/ExitCodeTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -97,10 +97,25 @@ $(BUILDTESTDIR)/ExitCodeTest.Fault.ok: \
         if [ "$$rc" != 5 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi
 	echo "test passed at `date`" > $@
 
+EXPECTED_ERR_MSG := "test result: Error. unexpected exit code: 211, doesn't match exit status: \"Passed.\" which was logged by the test process"
+$(BUILDTESTDIR)/ExitCodeTest.ErrorAfterPass.ok: \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/exitCodes/ErrorAfterPass.java \
+			> $(@:%.ok=%/jt.log) 2>&1 ; rc=$$? ; \
+        if [ "$$rc" != 3 ]; then echo "unexpected exit code: " $$rc ; exit 1 ; fi ; \
+		$(GREP) $(EXPECTED_ERR_MSG) $(@:%.ok=%)/work/ErrorAfterPass.jtr > /dev/null
+	echo "test passed at `date`" > $@
+
 TESTS.jtreg += \
 	$(BUILDTESTDIR)/ExitCodeTest.OK.ok \
 	$(BUILDTESTDIR)/ExitCodeTest.NoTest.ok \
 	$(BUILDTESTDIR)/ExitCodeTest.Fail.ok \
 	$(BUILDTESTDIR)/ExitCodeTest.Error.ok \
 	$(BUILDTESTDIR)/ExitCodeTest.BadArgs.ok \
-	$(BUILDTESTDIR)/ExitCodeTest.Fault.ok
+	$(BUILDTESTDIR)/ExitCodeTest.Fault.ok \
+	$(BUILDTESTDIR)/ExitCodeTest.ErrorAfterPass.ok


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the issue reported in https://bugs.openjdk.org/browse/CODETOOLS-7903621?

When jtreg launches a new java process for the test (like for running a `othervm` test), it uses an internal main class which among other things reports back a status when the test completes. This it does by writing out a status line to `System.err` before calling `System.exit()` with the appropriate code that represents the execution status of the test.

In the case where the test passes, this main class writes out a status line which represents a passed test and then calls `System.exit()` with an exit code that too represents a passed test. However, there are cases where the JVM process might exit with a different error code due to errors/exceptions/VM crash, during the shutdown sequence. This effectively implies that the test did not really complete successfully. In its current form, jtreg notices the status line which was written out as "PASSED" and then completely ignores the exit code of the process, which may not be representing a passed test. Such tests are incorrectly marked as a PASSED and any issue that happened during the JVM exit aren't reported or drawn attention to.

The commit in this PR proposes to address that by verifying the exit code of the test process matches the status line it reported. In case of a mismatch, the test is marked as "error" and the mismatch is now reported back as an error, which should now draw attention to the cause of such errors.

A new self test has been introduced which reproduces the issue with the source change and verifies the fix. All existing self tests and this new test pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903621](https://bugs.openjdk.org/browse/CODETOOLS-7903621): jtreg ignores VM exit code when test process reports status with "STATUS: " line (**Bug** - P2)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - no project role)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/jtreg.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/191.diff">https://git.openjdk.org/jtreg/pull/191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/191#issuecomment-1987604280)