### PR TITLE
7903732: Verify that the java executable exists

### DIFF
--- a/src/share/bin/jtreg.sh
+++ b/src/share/bin/jtreg.sh
@@ -138,6 +138,11 @@ elif [ -n "$wsl" -a -x "$JTREG_JAVA".exe ]; then
     driveDir=mnt
 fi
 
+if [ ! -e "$JTREG_JAVA" ]; then
+    echo "No java executable at $JTREG_JAVA"
+    exit 1;
+fi
+
 # Verify java version 11 or newer used to run jtreg
 version=`"$JTREG_JAVA" -classpath "${JTREG_HOME}/lib/jtreg.jar" com.sun.javatest.regtest.agent.GetSystemProperty java.version 2>&1 |
         grep 'java.version=' | sed -e 's/^.*=//' -e 's/^1\.//' -e 's/\([1-9][0-9]*\).*/\1/'`


### PR DESCRIPTION
I want to add a small check in `src/share/bin/jtreg.sh` to have jtreg see if the java it wants to run even exists, before proceeding to verify the version. This would make it easier for the user to notice tha they have mistyped the -jdk parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903732](https://bugs.openjdk.org/browse/CODETOOLS-7903732): Verify that the java executable exists (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/196/head:pull/196` \
`$ git checkout pull/196`

Update a local copy of the PR: \
`$ git checkout pull/196` \
`$ git pull https://git.openjdk.org/jtreg.git pull/196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 196`

View PR using the GUI difftool: \
`$ git pr show -t 196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/196.diff">https://git.openjdk.org/jtreg/pull/196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/196#issuecomment-2124736057)