### PR TITLE
7903736: Update GitHub actions used in jtreg's workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
         fetch-depth: 1
 
     - name: 'Set up Java Development Kit'
-      uses: actions/setup-java@v3
+      uses: oracle-actions/setup-java@v1
       with:
-        distribution: 'oracle'
-        java-version: '17'
+        website: oracle.com
+        release: 17
 
     - name: 'Build JTReg'
       shell: bash


### PR DESCRIPTION
Please review this change to use Oracle's `setup-java` action in `jtreg` workflows. The `oracle-actions/setup-java` action will take care of delegating to up-to-date actions, such as `actions/setup-java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903736](https://bugs.openjdk.org/browse/CODETOOLS-7903736): Update GitHub actions used in jtreg's workflows (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/197/head:pull/197` \
`$ git checkout pull/197`

Update a local copy of the PR: \
`$ git checkout pull/197` \
`$ git pull https://git.openjdk.org/jtreg.git pull/197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 197`

View PR using the GUI difftool: \
`$ git pr show -t 197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/197.diff">https://git.openjdk.org/jtreg/pull/197.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/197#issuecomment-2129244816)