### PR TITLE
7903738 : jtr.xml logs produced with -xml argument do not contain compilation failure justification

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
@@ -177,14 +177,13 @@ public class XMLWriter {
     }
 
     private String getOutput(String name) throws TestResult.Fault {
-        String[] titles = tr.getSectionTitles();
-        List<String> ttles = Arrays.asList(titles);
-        //we are looking primarily for either a "main" section or "shell" section in jtr log
-        //if neither "main" or "shell" sections are not found, we try searching for compile section
+        List<String> titles = Arrays.asList(tr.getSectionTitles());
+        // we are looking primarily for either a "main" section or a "shell" section in jtr log
+        // if neither "main" or "shell" sections are found, we try searching for a "compile" section
         String [] sections = {"main","shell","compile"};
         for (String section : sections){
-            if (ttles.contains(section)) {
-                return getOutputOfSection(name, ttles.indexOf(section));
+            if (titles.contains(section)) {
+                return getOutputOfSection(name, titles.indexOf(section));
             }
         }
         return "";

--- a/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
@@ -40,7 +40,6 @@ import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
@@ -177,22 +176,15 @@ public class XMLWriter {
     }
 
     private String getOutput(String name) throws TestResult.Fault {
-        List<String> titles = Arrays.asList(tr.getSectionTitles());
-        // we are looking primarily for either a "main" section or a "shell" section in jtr log
-        // if neither "main" or "shell" sections are found, we try searching for a "compile" section
-        String [] sections = {"main","shell","compile"};
-        for (String section : sections){
-            if (titles.contains(section)) {
-                return getOutputOfSection(name, titles.indexOf(section));
+        String[] titles = tr.getSectionTitles();
+        // try to find and return first output from the following sequence of title names
+        for (int i = 0; i < titles.length; i++) {
+            if (titles[i].equals("main") || titles[i].equals("shell") || titles[i].equals("compile")) {
+                Section s = tr.getSection(i);
+                for (String x : s.getOutputNames()) {
+                    return s.getOutput(name);
+                }
             }
-        }
-        return "";
-    }
-
-    private String getOutputOfSection(String name, int sectionNum) throws TestResult.Fault {
-        Section s = tr.getSection(sectionNum);
-        for (String x : s.getOutputNames()) {
-            return s.getOutput(name);
         }
         return "";
     }

--- a/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
@@ -178,14 +178,22 @@ public class XMLWriter {
 
     private String getOutput(String name) throws TestResult.Fault {
         String[] titles = tr.getSectionTitles();
-        //we are looking for either a "main" section or "shell" section in jtr log
-        for (int i = 0; i < titles.length; i++) {
-            if (titles[i].equals("main") || titles[i].equals("shell")) {
-                Section s = tr.getSection(i);
-                for (String x : s.getOutputNames()) {
-                    return s.getOutput(name);
-                }
+        List<String> ttles = Arrays.asList(titles);
+        //we are looking primarily for either a "main" section or "shell" section in jtr log
+        //if neither "main" or "shell" sections are not found, we try searching for compile section
+        String [] sections = {"main","shell","compile"};
+        for (String section : sections){
+            if (ttles.contains(section)) {
+                return getOutputOfSection(name, ttles.indexOf(section));
             }
+        }
+        return "";
+    }
+
+    private String getOutputOfSection(String name, int sectionNum) throws TestResult.Fault {
+        Section s = tr.getSection(sectionNum);
+        for (String x : s.getOutputNames()) {
+            return s.getOutput(name);
         }
         return "";
     }


### PR DESCRIPTION
jtr.xml files generated while using -xml flag don't contain any info about why the compilation failed although the info is present in jtr files. This can be solved by looking for the compilation failure in case there is no main section -> the main has not been executed -> failure occurred during compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903738](https://bugs.openjdk.org/browse/CODETOOLS-7903738): jtr.xml logs produced with -xml argument do not contain compilation failure justification (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/198/head:pull/198` \
`$ git checkout pull/198`

Update a local copy of the PR: \
`$ git checkout pull/198` \
`$ git pull https://git.openjdk.org/jtreg.git pull/198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 198`

View PR using the GUI difftool: \
`$ git pr show -t 198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/198.diff">https://git.openjdk.org/jtreg/pull/198.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/198#issuecomment-2135237073)