### PR TITLE
7903738 : jtr.xml logs produced with -xml argument do not contain compilation failure justification - alternative approach

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/XMLWriter.java
@@ -178,16 +178,17 @@ public class XMLWriter {
 
     private String getOutput(String name) throws TestResult.Fault {
         String[] titles = tr.getSectionTitles();
-        //we are looking for either a "main" section or "shell" section in jtr log
+        StringBuilder sb = new StringBuilder();
+        // try to find and return all outputs from the following sequence of title names
         for (int i = 0; i < titles.length; i++) {
-            if (titles[i].equals("main") || titles[i].equals("shell")) {
+            if (titles[i].equals("main") || titles[i].equals("shell") || titles[i].equals("compile")) {
                 Section s = tr.getSection(i);
                 for (String x : s.getOutputNames()) {
-                    return s.getOutput(name);
+                    sb.append(s.getOutput(name));
                 }
             }
         }
-        return "";
+        return sb.toString();
     }
 
     private void insertSystemOut() throws TestResult.Fault {


### PR DESCRIPTION
this is an alternative to https://github.com/openjdk/jtreg/pull/198
here we are collecting all the System.err outputs and putting them into a StringBuilder and returning them as one long string..
Order of the sections should be intact, so it should go chronologically according to the test execution.
This could be also improved by adding section separator Strings into the StringBuilder between individual sections.
Also we could drop the `if (titles[i].equals("main") || ...` part and output any System.err output found in jtr.xml as part of the test failure

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [CODETOOLS-7903738](https://bugs.openjdk.org/browse/CODETOOLS-7903738)

### Issue
 * [CODETOOLS-7903738](https://bugs.openjdk.org/browse/CODETOOLS-7903738): jtr.xml logs produced with -xml argument do not contain compilation failure justification (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/jtreg.git pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/199.diff">https://git.openjdk.org/jtreg/pull/199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/199#issuecomment-2135718005)