### PR TITLE
7903742: Some jtreg self-tests fail

### DIFF
--- a/test/rerun/RerunTest.gmk
+++ b/test/rerun/RerunTest.gmk
@@ -69,6 +69,7 @@ $(BUILDTESTDIR)/RerunTest.othervm.ok: \
 		    -e 's|^DISPLAY=.* \\|DISPLAY=%DISPLAY% \\|' \
 		    -e 's|$(JDK8HOME)|%JDKHOME%|g' \
 		    -e "s|`cd $(JDK8HOME); pwd -P`|%JDKHOME%|g" \
+		    -e 's|JTREG_HOME=.* \\|JTREG_HOME=%JTREG_HOME% \\|' \
 		    -e '/JTREG_JAVA=/d' \
 		    -e '/LC_CTYPE=/d' \
 		    -e 's|$(BUILDTESTDIR)|%BUILDTEST%|g' \

--- a/test/rerun/std/AppletTest.agentvm.out
+++ b/test/rerun/std/AppletTest.agentvm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/AppletTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -28,11 +30,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/AppletTest.java
-
 ### Section applet
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -50,6 +52,7 @@ TZ=GMT+0.00 \
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/AppletTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
@@ -57,4 +60,3 @@ TZ=GMT+0.00 \
         -Dtest.class.path=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d \
         -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/AppletTest.d:%WS%/test/rerun/std \
         -mx128m com.sun.javatest.regtest.agent.AppletWrapper %BUILDTEST%/RerunTest.agentvm/work/std/AppletTest.d/applet.0.jta
-

--- a/test/rerun/std/AppletTest.othervm.out
+++ b/test/rerun/std/AppletTest.othervm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/AppletTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -27,11 +29,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/AppletTest.java
-
 ### Section applet
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -49,10 +51,10 @@ TZ=GMT+0.00 \
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/AppletTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/AppletTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
         -Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d \
         -Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/std/AppletTest.d \
         -mx128m com.sun.javatest.regtest.agent.AppletWrapper %BUILDTEST%/RerunTest.othervm/work/std/AppletTest.d/applet.0.jta
-

--- a/test/rerun/std/BuildTest.agentvm.out
+++ b/test/rerun/std/BuildTest.agentvm.out
@@ -1,11 +1,11 @@
 ### Section clean
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 rm -f %BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d/BuildTest.class
-
 ### Section compile
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -21,6 +21,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/BuildTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/BuildTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -32,4 +33,3 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/BuildTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/BuildTest.java
-

--- a/test/rerun/std/BuildTest.othervm.out
+++ b/test/rerun/std/BuildTest.othervm.out
@@ -1,11 +1,11 @@
 ### Section clean
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 rm -f %BUILDTEST%/RerunTest.othervm/work/classes/std/BuildTest.d/BuildTest.class
-
 ### Section compile
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -21,6 +21,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/BuildTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/BuildTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -31,4 +32,3 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/BuildTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/BuildTest.java
-

--- a/test/rerun/std/CleanTest.agentvm.out
+++ b/test/rerun/std/CleanTest.agentvm.out
@@ -1,10 +1,8 @@
 ### Section clean
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 rm -f %BUILDTEST%/RerunTest.agentvm/work/classes/std/CleanTest.d/CleanTest.class
-
 ### Section clean
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 for f in %BUILDTEST%/RerunTest.agentvm/work/classes/std/CleanTest.d/p/*; do
   if [ -f $f ]; then rm $f ; fi
 done
-

--- a/test/rerun/std/CleanTest.othervm.out
+++ b/test/rerun/std/CleanTest.othervm.out
@@ -1,10 +1,8 @@
 ### Section clean
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 rm -f %BUILDTEST%/RerunTest.othervm/work/classes/std/CleanTest.d/CleanTest.class
-
 ### Section clean
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 for f in %BUILDTEST%/RerunTest.othervm/work/classes/std/CleanTest.d/p/*; do
   if [ -f $f ]; then rm $f ; fi
 done
-

--- a/test/rerun/std/CompileTest.agentvm.out
+++ b/test/rerun/std/CompileTest.agentvm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/CompileTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/CompileTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -27,4 +29,3 @@ TZ=GMT+0.00 \
         -d %BUILDTEST%/RerunTest.agentvm/work/classes/std/CompileTest.d \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/CompileTest.d:%JDKHOME%/lib/tools.jar %WS%/test/rerun/std/CompileTest.java
-

--- a/test/rerun/std/CompileTest.othervm.out
+++ b/test/rerun/std/CompileTest.othervm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/CompileTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/CompileTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -26,4 +28,3 @@ TZ=GMT+0.00 \
         -d %BUILDTEST%/RerunTest.othervm/work/classes/std/CompileTest.d \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/CompileTest.d:%JDKHOME%/lib/tools.jar %WS%/test/rerun/std/CompileTest.java
-

--- a/test/rerun/std/IgnoreTest.agentvm.out
+++ b/test/rerun/std/IgnoreTest.agentvm.out
@@ -1,4 +1,3 @@
 ### Section ignore
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 # @ignore:  (suppressed)
-

--- a/test/rerun/std/IgnoreTest.othervm.out
+++ b/test/rerun/std/IgnoreTest.othervm.out
@@ -1,4 +1,3 @@
 ### Section ignore
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 # @ignore:  (suppressed)
-

--- a/test/rerun/std/JUnitTest.agentvm.out
+++ b/test/rerun/std/JUnitTest.agentvm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/JUnitTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -28,11 +30,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/JUnitTest.java
-
 ### Section junit
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -47,6 +49,7 @@ TZ=GMT+0.00 \
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/JUnitTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
@@ -55,4 +58,3 @@ TZ=GMT+0.00 \
         -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std \
         -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/std/JUnitTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         com.sun.javatest.regtest.agent.JUnitRunner std/JUnitTest.java JUnitTest
-

--- a/test/rerun/std/JUnitTest.othervm.out
+++ b/test/rerun/std/JUnitTest.othervm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/JUnitTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -27,11 +29,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d:%BUILD%/images/jtreg/lib/junit.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/JUnitTest.java
-
 ### Section junit
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -47,6 +49,7 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d:%WS%/test/r
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/JUnitTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/JUnitTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
@@ -55,4 +58,3 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/JUnitTest.d:%WS%/test/r
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
         com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/std/JUnitTest.d/junit.0.jta std/JUnitTest.java JUnitTest
-

--- a/test/rerun/std/MainTest.agentvm.out
+++ b/test/rerun/std/MainTest.agentvm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/MainTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -28,11 +30,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/MainTest.java
-
 ### Section main
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -47,6 +49,7 @@ TZ=GMT+0.00 \
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/MainTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
@@ -55,4 +58,3 @@ TZ=GMT+0.00 \
         -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std \
         -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/std/MainTest.d:%WS%/test/rerun/std:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         MainTest
-

--- a/test/rerun/std/MainTest.othervm.out
+++ b/test/rerun/std/MainTest.othervm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/MainTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -27,11 +29,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/MainTest.java
-
 ### Section main
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -47,6 +49,7 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d:%WS%/test/re
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/MainTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/MainTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
@@ -55,4 +58,3 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/MainTest.d:%WS%/test/re
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
         com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/std/MainTest.d/main.0.jta
-

--- a/test/rerun/std/ShellTest.agentvm.out
+++ b/test/rerun/std/ShellTest.agentvm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -24,4 +25,3 @@ PS=: \
 NULL=/dev/null \
     sh \
         %WS%/test/rerun/std/ShellTest.sh
-

--- a/test/rerun/std/ShellTest.othervm.out
+++ b/test/rerun/std/ShellTest.othervm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -24,4 +25,3 @@ PS=: \
 NULL=/dev/null \
     sh \
         %WS%/test/rerun/std/ShellTest.sh
-

--- a/test/rerun/std/TestNGTest.agentvm.out
+++ b/test/rerun/std/TestNGTest.agentvm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/TestNGTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -28,11 +30,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/TestNGTest.java
-
 ### Section testng
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -47,6 +49,7 @@ TZ=GMT+0.00 \
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/TestNGTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
@@ -55,4 +58,3 @@ TZ=GMT+0.00 \
         -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std \
         -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/std/TestNGTest.d:%WS%/test/rerun/std:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         com.sun.javatest.regtest.agent.TestNGRunner std/TestNGTest.java false TestNGTest
-

--- a/test/rerun/std/TestNGTest.othervm.out
+++ b/test/rerun/std/TestNGTest.othervm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=std/TestNGTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/std \
         -J-Dtest.src.path=%WS%/test/rerun/std \
@@ -27,11 +29,11 @@ TZ=GMT+0.00 \
         -sourcepath %WS%/test/rerun/std \
         -classpath %WS%/test/rerun/std:%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true %WS%/test/rerun/std/TestNGTest.java
-
 ### Section testng
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -47,6 +49,7 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d:%WS%/test/
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=std/TestNGTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/std/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/std \
         -Dtest.src.path=%WS%/test/rerun/std \
@@ -55,4 +58,3 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/std/TestNGTest.d:%WS%/test/
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
         com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/std/TestNGTest.d/testng.0.jta std/TestNGTest.java false TestNGTest
-

--- a/test/rerun/testng/TestNGTest.agentvm.out
+++ b/test/rerun/testng/TestNGTest.agentvm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,6 +18,7 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=testng/TestNGTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/testng \
         -J-Dtest.src.path=%WS%/test/rerun/testng \
@@ -29,11 +31,11 @@ TZ=GMT+0.00 \
         -classpath %WS%/test/rerun/testng:%BUILDTEST%/RerunTest.agentvm/work/classes/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar \
         -XDignore.symbol.file=true \
         -implicit:none %WS%/test/rerun/testng/TestNGTest.java
-
 ### Section testng
 cd %BUILDTEST%/RerunTest.agentvm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -48,6 +50,7 @@ TZ=GMT+0.00 \
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=testng/TestNGTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/testng \
         -Dtest.src.path=%WS%/test/rerun/testng \
@@ -56,4 +59,3 @@ TZ=GMT+0.00 \
         -Dtest.class.path.prefix=%BUILDTEST%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng \
         -classpath %BUILDTEST%/RerunTest.agentvm/work/classes/testng:%WS%/test/rerun/testng:%BUILD%/images/jtreg/lib/testng.jar:%JDKHOME%/lib/tools.jar:%BUILD%/images/jtreg/lib/javatest.jar:%BUILD%/images/jtreg/lib/jtreg.jar \
         com.sun.javatest.regtest.agent.TestNGRunner testng/TestNGTest.java false TestNGTest
-

--- a/test/rerun/testng/TestNGTest.othervm.out
+++ b/test/rerun/testng/TestNGTest.othervm.out
@@ -2,6 +2,7 @@
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -17,17 +18,18 @@ TZ=GMT+0.00 \
         -J-Dtest.timeout.factor=1.0 \
         -J-Dtest.root=%WS%/test/rerun \
         -J-Dtest.name=testng/TestNGTest.java \
+        -J-Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -J-Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -J-Dtest.src=%WS%/test/rerun/testng \
         -J-Dtest.src.path=%WS%/test/rerun/testng \
         -J-Dtest.classes=%BUILDTEST%/RerunTest.othervm/work/classes/testng \
         -J-Dtest.class.path=%BUILDTEST%/RerunTest.othervm/work/classes/testng \
         @%BUILDTEST%/RerunTest.othervm/work/testng/TestNGTest.d/compile.0.jta
-
 ### Section testng
 cd %BUILDTEST%/RerunTest.othervm/work/scratch && \
 DISPLAY=%DISPLAY% \
 HOME=%HOME% \
+JTREG_HOME=%JTREG_HOME% \
 LANG=en_US.UTF-8 \
 MY_ENV_VAR=x \
 PATH=/bin:/usr/bin:/usr/sbin \
@@ -43,6 +45,7 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/testng:%WS%/test/rerun/test
         -Dtest.timeout.factor=1.0 \
         -Dtest.root=%WS%/test/rerun \
         -Dtest.name=testng/TestNGTest.java \
+        -Dtest.verbose=Verbose[p=SUMMARY,f=SUMMARY,e=SUMMARY,t=false,m=false] \
         -Dtest.file=%WS%/test/rerun/testng/TestNGTest.java \
         -Dtest.src=%WS%/test/rerun/testng \
         -Dtest.src.path=%WS%/test/rerun/testng \
@@ -51,4 +54,3 @@ CLASSPATH=%BUILDTEST%/RerunTest.othervm/work/classes/testng:%WS%/test/rerun/test
         -Dmy.vm.option=x \
         -Dmy.java.option=x \
         com.sun.javatest.regtest.agent.MainWrapper %BUILDTEST%/RerunTest.othervm/work/testng/TestNGTest.d/testng.1.jta testng/TestNGTest.java false TestNGTest
-


### PR DESCRIPTION
Please review some updates to the `jtreg` "self-tests, that needed to be updated as a result of other recent updates.

The changes are all for the "rerun" tests which check the output of the "rerun" sections written into each `.jtr` file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903742](https://bugs.openjdk.org/browse/CODETOOLS-7903742): Some jtreg self-tests fail (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/200/head:pull/200` \
`$ git checkout pull/200`

Update a local copy of the PR: \
`$ git checkout pull/200` \
`$ git pull https://git.openjdk.org/jtreg.git pull/200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 200`

View PR using the GUI difftool: \
`$ git pr show -t 200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/200.diff">https://git.openjdk.org/jtreg/pull/200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/200#issuecomment-2148436251)