### PR TITLE
7903741: some test properties are not documented

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -1150,7 +1150,8 @@ public class RegressionScript extends Script {
         p.put("test.classes", locations.absTestClsDir().toString());
         p.put("test.class.path", toString(locations.absTestClsPath()));
         if (getExecMode() == ExecMode.AGENTVM) {
-            // The following will be added to javac.class.path on the test VM
+            // The following will be added to java.class.path on the test VM
+            // and is not for general use
             SearchPath path = new SearchPath()
                     .append(locations.absTestClsDir())
                     .append(locations.absTestSrcDir())

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
- Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -1243,9 +1243,9 @@ in environment variables.
 <tr>
 <td><code>test.name</code>
 <td><i>Not Available</i>
-<td>The name of the test, formed from the defining file of the test
-and any corresponding id if the file contains many separate test
-descriptions.
+<td>The name of the test, as a relative URL formed from the defining file
+of the test and any corresponding id if the file contains multiple separate
+test descriptions.
 
 <tr>
 <td><code>test.src</code>

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -1228,7 +1228,8 @@ for information on how to extend the set of supported names for a particular tes
 <p>The system properties in the following table will be set
 while executing any class specified in an action tag;
 the environment variables will be set while executing a shell
-action tag.
+action tag. Recently added values may not be available
+in environment variables.
 
 <table>
 <caption>Test-specific system properties and environment variables</caption>
@@ -1238,6 +1239,13 @@ action tag.
 <td><code>test.file</code>
 <td><code>TESTFILE</code>
 <td>The defining file of the test
+
+<tr>
+<td><code>test.name</code>
+<td><i>Not Available</i>
+<td>The name of the test, formed from the defining file of the test
+and any corresponding id if the file contains many separate test
+descriptions.
 
 <tr>
 <td><code>test.src</code>
@@ -1314,6 +1322,17 @@ will be unset or empty, if the version of JDK used to run the tests does not
 support modules.
 
 <tr>
+<td><code>test.module.path</code>
+<td><i>Not Available</i>
+<td>The path for any library modules used by the test.
+
+<tr>
+<td><code>test.patch.path</code>
+<td><i>Not Available</i>
+<td>The path for tests that are written as a patch for
+a system module.
+
+<tr>
 <td><code>test.root</code>
 <td><code>TESTROOT</code>
 <td>The root directory of the test suite
@@ -1325,6 +1344,11 @@ support modules.
 <td>Set (to <code>true</code>code>) if the test is using "preview features"
 as indicated by <code>@enablePreview</code> in the test description
 or an <code>enablePreview</code> entry in a TEST.properties file.
+
+<tr>
+<td><code>test.verbose</code>
+<td><i>Not Available</i>
+<td>The cumulative value of any command-line "verbose" options.
 
 <tr>
 <td><code>test.query</code>

--- a/test/tag-spec/TestTagSpec.gmk
+++ b/test/tag-spec/TestTagSpec.gmk
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#----------------------------------------------------------------------
+#
+# checks that the env vars and system properties given to tests
+# are documented in tag-spec.html, and vice-versa
+
+$(BUILDTESTDIR)/TestTagSpec_env.ok: \
+		$(JTREG_TAGSPEC) \
+		$(JAVAFILES.com.sun.javatest.regtest-tools)
+	$(GREP) -oh '.put("TEST[^"]*' $(JAVAFILES.com.sun.javatest.regtest-tools) | \
+		$(SED) -e 's/.*"//' | $(SORT) -u > $(@:%.ok=%.src)
+	$(GREP) -o '<code>TEST[^<]*</code>' $(JTREG_TAGSPEC) | \
+		$(SED) -e 's/<[^>]*>//g' | $(SORT) -u > $(@:%.ok=%.spec)
+	$(DIFF) $(@:%.ok=%.src) $(@:%.ok=%.spec)
+	echo "test passed at `date`" > $@
+
+$(BUILDTESTDIR)/TestTagSpec_sysProps.ok: \
+		$(JTREG_TAGSPEC) \
+		$(JAVAFILES.com.sun.javatest.regtest-tools)
+	$(GREP) -oh '\(.put(\|put(map, \)"test.[^"]*' $(JAVAFILES.com.sun.javatest.regtest-tools) | \
+		$(GREP) -v "test.class.path.prefix" | \
+		$(SED) -e 's/.*"//' | $(SORT) -u > $(@:%.ok=%.src)
+	$(GREP) -o '<code>test[^<]*</code>' $(JTREG_TAGSPEC) | \
+		$(SED) -e 's/<[^>]*>//g' | $(SORT) -u > $(@:%.ok=%.spec)
+	$(DIFF) $(@:%.ok=%.src) $(@:%.ok=%.spec)
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/TestTagSpec_env.ok \
+	$(BUILDTESTDIR)/TestTagSpec_sysProps.ok


### PR DESCRIPTION
Please review a simple doc and test update for tag-spec.html, after it was recently noted that `test.module.path` was available but not documented.

The new test verifies 1:1 correspondence between names that are available, as env vars or system properties, and those that are documented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903741](https://bugs.openjdk.org/browse/CODETOOLS-7903741): some test properties are not documented (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [56c463c9](https://git.openjdk.org/jtreg/pull/203/files/56c463c998e93b21c7129b609858bd97a49c1e74)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jtreg.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/203.diff">https://git.openjdk.org/jtreg/pull/203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/203#issuecomment-2153454044)