### PR TITLE
7903746: jtreg tests run extremely slow on some environments due to hostname lookups

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionEnvironment.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionEnvironment.java
@@ -52,13 +52,13 @@ public class RegressionEnvironment extends TestEnvironment
      * {@return the hostname of the host in which this test harness is being run}
      */
     public final String getHostName() {
-        return LazyHostNameLookup.HOST_NAME;
+        return CachedCanonicalHostName.HOST_NAME;
     }
 
     public final RegressionParameters params;
 
 
-    private static final class LazyHostNameLookup {
+    private static final class CachedCanonicalHostName {
         private static final String HOST_NAME;
 
         static {

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionEnvironment.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package com.sun.javatest.regtest.config;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 
 import com.sun.javatest.TestEnvironment;
@@ -46,5 +48,27 @@ public class RegressionEnvironment extends TestEnvironment
         return new RegressionEnvironment(this);
     }
 
+    /**
+     * {@return the hostname of the host in which this test harness is being run}
+     */
+    public final String getHostName() {
+        return LazyHostNameLookup.HOST_NAME;
+    }
+
     public final RegressionParameters params;
+
+
+    private static final class LazyHostNameLookup {
+        private static final String HOST_NAME;
+
+        static {
+            String hostname;
+            try {
+                hostname = InetAddress.getLocalHost().getCanonicalHostName();
+            } catch (UnknownHostException e) {
+                hostname = "127.0.0.1";
+            }
+            HOST_NAME = hostname;
+        }
+    }
 }

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -128,14 +128,7 @@ public class RegressionScript extends Script {
         // defaults
 
         testResult = getTestResult();
-
-        String hostname;
-        try {
-            hostname = InetAddress.getLocalHost().getCanonicalHostName();
-        } catch (UnknownHostException e) {
-            hostname = "127.0.0.1";
-        }
-        testResult.putProperty("hostname", hostname);
+        testResult.putProperty("hostname", regEnv.getHostName());
         String[] props = { "user.name" };
         for (String p: props) {
             testResult.putProperty(p, System.getProperty(p));

--- a/test/jtrContentTest/Test.java
+++ b/test/jtrContentTest/Test.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ */
+public class Test {
+    public static void main(String... args) {
+        System.out.println("hello!");
+    }
+}

--- a/test/jtrContentTest/VerifyHostname.gmk
+++ b/test/jtrContentTest/VerifyHostname.gmk
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#----------------------------------------------------------------------
+
+# verifies that the .jtr file contains the "hostname" property in the
+# testresult
+$(BUILDTESTDIR)/VerifyHostname.ok: \
+	$(JTREG_IMAGEDIR)/lib/javatest.jar \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		-w $(@:%.ok=%)/work/ -r $(@:%.ok=%)/report/ \
+		$(TESTDIR)/jtrContentTest/Test.java > $(@:%.ok=%/jt.log) 2>&1; \
+        $(GREP) 'hostname=' $(@:%.ok=%)/work/Test.jtr > /dev/null ; found=$$?; \
+        if [ "$$found" != 0 ]; then echo "Missing hostname in testresult of Test.jtr" ; exit 1 ; fi
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/VerifyHostname.ok
+


### PR DESCRIPTION
Can I please get a review of this change which proposes to address https://bugs.openjdk.org/browse/CODETOOLS-7903746?

As noted in that issue, jtreg determines the hotsname and populates that detail in the `TestResult`. Right now, it does it for every single test that's part of that test run. The hostname determination is expensive and on some system can be slow due to hostname resolutions. It's not necessary to do this lookup for every test and can be done just once for that test run. The commit in this PR does just that by looking it up once for that run and then making it available in the `TestResult` of each of the tests.

I have run this change against our JDK mainline in the CI for tier1 through tier6. This hasn't shown any regressions and I have manually verified that the hostname is correctly made available, like before, in the .jtr files of these tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903746](https://bugs.openjdk.org/browse/CODETOOLS-7903746): jtreg tests run extremely slow on some environments due to hostname lookups (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [f1943fc7](https://git.openjdk.org/jtreg/pull/204/files/f1943fc75fcea4a583fada2ff339c2ed0eb8097f)
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.org/jtreg.git pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/204.diff">https://git.openjdk.org/jtreg/pull/204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/204#issuecomment-2156349951)