### PR TITLE
7902346: Need better message when test times out in agentvm mode

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -87,6 +87,12 @@ public class Agent {
         }
     }
 
+    // represents a timeout that occurred while executing
+    // a test action within an agentvm
+    static final class ActionTimeout extends Exception {
+        private static final long serialVersionUID = 7956108605006221253L;
+    }
+
     // legacy support for logging to stderr
     // showAgent is superseded by always-on log to file
     static final boolean showAgent = Flags.get("showAgent");
@@ -309,7 +315,7 @@ public class Agent {
             int timeout,
             final TimeoutHandler timeoutHandler,
             TestResult.Section trs)
-                throws Fault {
+                throws ActionTimeout, Fault {
         trace("doCompileAction " + testName + " " + cmdArgs);
 
         return doAction("doCompileAction",
@@ -342,7 +348,7 @@ public class Agent {
             int timeout,
             final TimeoutHandler timeoutHandler,
             TestResult.Section trs)
-                throws Fault {
+                throws ActionTimeout, Fault {
         trace("doMainAction: " + testName
                     + " " + testClassPath
                     + " " + modulePath
@@ -382,7 +388,7 @@ public class Agent {
             int timeout,
             final TimeoutHandler timeoutHandler,
             TestResult.Section trs)
-                throws Fault {
+                throws ActionTimeout, Fault {
         final PrintWriter messageWriter = trs.getMessageWriter();
         // Handle the timeout here (instead of in the agent) to make it possible
         // to see the unchanged state of the Agent JVM when the timeout happens.
@@ -417,8 +423,7 @@ public class Agent {
             keepAlive.setEnabled(true);
             if (alarm.didFire()) {
                 waitForTimeoutHandler(actionName, timeoutHandler, timeoutHandlerDone);
-                throw new Fault(new Exception("Agent " + id + " timed out with a timeout of "
-                        + timeout + " seconds"));
+                throw new ActionTimeout();
             }
         }
     }

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -721,6 +721,10 @@ public class CompileAction extends Action {
                     timeout,
                     timeoutHandler,
                     section);
+        } catch (Agent.ActionTimeout te) {
+            final String msg = "\"" + getName() + "\" action timed out with a timeout of "
+                    + timeout + " seconds on agent " + agent.id;
+            status = error(msg);
         } catch (Agent.Fault e) {
             if (e.getCause() instanceof IOException)
                 status = error(String.format(AGENTVM_IO_EXCEPTION, e.getCause()));

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -715,6 +715,10 @@ public class MainAction extends Action
                     timeout,
                     timeoutHandler,
                     section);
+        } catch (Agent.ActionTimeout e) {
+            final String msg = "\"" + getName() + "\" action timed out with a timeout of "
+                    + timeout + " seconds on agent " + agent.id;
+            status = error(msg);
         } catch (Agent.Fault e) {
             if (e.getCause() instanceof IOException)
                 status = error(String.format(AGENTVM_IO_EXCEPTION, e.getCause()));

--- a/test/agentvmtimeout/AgentVMTimeout.gmk
+++ b/test/agentvmtimeout/AgentVMTimeout.gmk
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# verify that a test that times out in agentvm mode will have the expected
+# timeout message in its jtr file
+
+# verify timeout message for main action
+$(BUILDTESTDIR)/AgentVMMainActionTimeout.ok: \
+	$(JTREG_IMAGEDIR)/lib/javatest.jar \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		-w $(@:%.ok=%)/work/ -r $(@:%.ok=%)/report/ \
+		-agentvm \
+		$(TESTDIR)/agentvmtimeout/OneSecondTimeoutTest.java#main > $(@:%.ok=%/jt.log) 2>&1 ; ls $(@:%.ok=%)/work ; \
+		$(GREP) '"main" action timed out with a timeout of' $(@:%.ok=%)/work/OneSecondTimeoutTest_main.jtr > /dev/null ; found=$$?; \
+        if [ "$$found" != 0 ]; then echo "OneSecondTimeoutTest_main.jtr is missing \"main\" action timeout message" ; exit 1 ; fi
+	echo $@ passed at `date` > $@
+
+# verify timeout message for driver action
+$(BUILDTESTDIR)/AgentVMDriverActionTimeout.ok: \
+	$(JTREG_IMAGEDIR)/lib/javatest.jar \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		-w $(@:%.ok=%)/work/ -r $(@:%.ok=%)/report/ \
+		-agentvm \
+		$(TESTDIR)/agentvmtimeout/OneSecondTimeoutTest.java#driver > $(@:%.ok=%/jt.log) 2>&1 ; ls $(@:%.ok=%)/work ; \
+		$(GREP) '"driver" action timed out with a timeout of' $(@:%.ok=%)/work/OneSecondTimeoutTest_driver.jtr > /dev/null ; found=$$?; \
+        if [ "$$found" != 0 ]; then echo "OneSecondTimeoutTest_driver.jtr is missing \"driver\" action timeout message" ; exit 1 ; fi;
+	echo $@ passed at `date` > $@
+
+$(BUILDTESTDIR)/AgentVMActionTimeout.ok: \
+				$(BUILDTESTDIR)/AgentVMMainActionTimeout.ok \
+				$(BUILDTESTDIR)/AgentVMDriverActionTimeout.ok
+
+TESTS.jtreg += $(BUILDTESTDIR)/AgentVMActionTimeout.ok

--- a/test/agentvmtimeout/OneSecondTimeoutTest.java
+++ b/test/agentvmtimeout/OneSecondTimeoutTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=main
+ * @run main/timeout=1 OneSecondTimeoutTest
+ */
+
+/*
+ * @test id=driver
+ * @run driver/timeout=1 OneSecondTimeoutTest
+ */
+public class OneSecondTimeoutTest {
+
+    public static void main(final String[] args) throws Exception {
+        final Object obj = new Object();
+        synchronized (obj) {
+            obj.wait(); // wait forever so that the test times out
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to improve the error message when a test action times out on an agent VM? This addresses https://bugs.openjdk.org/browse/CODETOOLS-7902346.

Before this change, whenever a test action timed out in an agentvm, then it would be reported as:

> result: Error. Agent error: java.lang.Exception: Agent 3 timed out with a timeout of 1200 seconds; check console log for any additional details 

With the changes in this PR, the error reporting will be a more accurate and won't give an impression that this was some error within the jtreg agent implementation. For `@run main ...`, the error will now say:

> result: Error. "main" action timed out with a timeout of 1200 seconds on agent 3

Another example, this time for a driver action:

> result: Error. "driver" action timed out with a timeout of 1200 seconds on agent 3

A couple of new self tests have been added to verify this change. Self tests including this new one continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7902346](https://bugs.openjdk.org/browse/CODETOOLS-7902346): Need better message when test times out in agentvm mode (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jtreg.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/205.diff">https://git.openjdk.org/jtreg/pull/205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/205#issuecomment-2157526410)