### PR TITLE
7903753: Report duration of testng test methods

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -185,12 +185,13 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
             } else {
                 suffix = "\n";
             }
-
+            long durationMillis = itr.getEndMillis() - itr.getStartMillis();
             System.out.print(k.toString().toLowerCase()
                     + " " + itr.getMethod().getConstructorOrMethod().getDeclaringClass().getName()
                     + "." + itr.getMethod().getMethodName()
                     + formatParams(itr)
                         + ": " + statusToString(itr.getStatus())
+                        + " [" + durationMillis + "ms]"
                         + suffix);
         }
 

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -29,7 +29,11 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.testng.IConfigurationListener;
@@ -109,10 +113,18 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
             implements ITestListener, IConfigurationListener {
         enum InfoKind { CONFIG, TEST }
 
+        // keeps track of the test start time for each test
+        private final Map<ITestResult, Long> startTimeNanos =
+                Collections.synchronizedMap(new IdentityHashMap<>());
+
         @Override
         public void onTestStart(ITestResult itr) {
             count++;
-//            report(itr);
+            // Although testng itself provides getStartMillis() and getEndMillis()
+            // on ITestResult for duration tracking, the testng implementation uses
+            // System.currentTimeMillis(). We instead prefer using System.nanoTime() API
+            // for duration tracking.
+            startTimeNanos.put(itr, System.nanoTime());
         }
 
         @Override
@@ -185,7 +197,11 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
             } else {
                 suffix = "\n";
             }
-            long durationMillis = itr.getEndMillis() - itr.getStartMillis();
+            Long startNanos = startTimeNanos.remove(itr);
+            Duration duration = startNanos == null
+                    ? Duration.ZERO
+                    : Duration.ofNanos(System.nanoTime() - startNanos);
+            long durationMillis = duration.toMillis();
             System.out.print(k.toString().toLowerCase()
                     + " " + itr.getMethod().getConstructorOrMethod().getDeclaringClass().getName()
                     + "." + itr.getMethod().getMethodName()

--- a/test/testngQueryTest/TestNGQueryTest.gmk
+++ b/test/testngQueryTest/TestNGQueryTest.gmk
@@ -39,7 +39,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-va \
 		$(TESTDIR)/testngQueryTest/ \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) "^test") ) ; \
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m11(): success test Test1.m12(): success test Test1.m13(): success test Test2.m21(): success test Test2.m22(): success test Test2.m23(): success" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -63,7 +63,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-va \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) "^test") ) ; \
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m12(): success" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -90,7 +90,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test2.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) "^test") ) ; \
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m12(): success test Test2.m21(): success test Test2.m22(): success test Test2.m23(): success" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -116,7 +116,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m13.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) "^test") ) ; \
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m12(): success" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -142,7 +142,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) "^test") ) ; \
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m13(): success" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -168,7 +168,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m13.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) "^test") ) ; \
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m11(): success test Test1.m12(): success test Test1.m13(): success" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -194,7 +194,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) "^test") ) ; \
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m13(): success" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi

--- a/test/testngTestDuration/Test.java
+++ b/test/testngTestDuration/Test.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.SkipException;
+
+/*
+ * @test
+ * @run testng Test
+ */
+public class Test {
+
+    @org.testng.annotations.Test
+    public void alwaysPass() {
+        System.out.println("running alwaysPass");
+    }
+
+    @org.testng.annotations.Test
+    public void alwaysFail() throws Exception {
+        System.out.println("running alwaysFail");
+        // intentionally sleep for while to allow the test duration to report
+        // a value that has more than one digit
+        Thread.sleep(30);
+        throw new RuntimeException("intentional failure from alwaysFail");
+    }
+
+    @org.testng.annotations.Test
+    public void alwaysSkip() {
+        System.out.println("running alwaysFail");
+        throw new SkipException("intentionally skipped from alwaysSkip");
+    }
+
+    @org.testng.annotations.Test(enabled = false)
+    public void disabledTest() {
+        throw new RuntimeException("should not have been invoked");
+    }
+}

--- a/test/testngTestDuration/Test.java
+++ b/test/testngTestDuration/Test.java
@@ -44,8 +44,9 @@ public class Test {
     }
 
     @org.testng.annotations.Test
-    public void alwaysSkip() {
+    public void alwaysSkip() throws Exception {
         System.out.println("running alwaysFail");
+        Thread.sleep(2);
         throw new SkipException("intentionally skipped from alwaysSkip");
     }
 

--- a/test/testngTestDuration/TestngTestDuration.gmk
+++ b/test/testngTestDuration/TestngTestDuration.gmk
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# verify that the testng test method execution report includes the duration of the test
+$(BUILDTESTDIR)/TestngTestDuration.ok: \
+	$(JTREG_IMAGEDIR)/lib/javatest.jar \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JDKHOME)/bin/java -jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		-w $(@:%.ok=%)/work/ -r $(@:%.ok=%)/report/ \
+		$(TESTDIR)/testngTestDuration/Test.java > $(@:%.ok=%/jt.log) 2>&1 ; ls $(@:%.ok=%)/work ; rc=$$? ; \
+		if [ "$$rc" != 0 ]; then echo "unexpected exit code from test execution: " $$rc ; exit 1 ; fi ; \
+		$(GREP) 'test Test.alwaysFail(): failure \[[0-9]\+ms\]' $(@:%.ok=%)/work/Test.jtr > /dev/null ; found=$$?; \
+		if [ "$$found" != 0 ]; then echo "Test.jtr is missing alwaysFail() report" ; exit 1 ; fi ; \
+		$(GREP) 'test Test.alwaysPass(): success \[[0-9]\+ms\]' $(@:%.ok=%)/work/Test.jtr > /dev/null ; found=$$?; \
+		if [ "$$found" != 0 ]; then echo "Test.jtr is missing alwaysPass() report" ; exit 1 ; fi ; \
+		$(GREP) 'test Test.alwaysSkip(): skip \[[0-9]\+ms\]' $(@:%.ok=%)/work/Test.jtr > /dev/null ; found=$$?; \
+		if [ "$$found" != 0 ]; then echo "Test.jtr is missing alwaysSkip() report" ; exit 1 ; fi
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/TestngTestDuration.ok


### PR DESCRIPTION
Can I please get a review of this change which proposes to print the duration for each of the testng test methods? This addresses https://bugs.openjdk.org/browse/CODETOOLS-7903753.

Similar to https://github.com/openjdk/jtreg/pull/206, which does this for junit tests, the commit in this PR includes the duration for each test method as follows:

```
test LargeEntriesTest.testForceZIP64End(java.util.ImmutableCollections$MapN@1398b884, 8): success [141ms]
test LargeEntriesTest.testForceZIP64End(java.util.ImmutableCollections$MapN@1caef225, 0): success [5ms]
test LargeEntriesTest.testForceZIP64End(java.util.ImmutableCollections$MapN@2a2df4a5, 8): success [4ms]
test LargeEntriesTest.testForceZIP64End(java.util.ImmutableCollections$MapN@85ce7c1, 0): success [3ms]
test LargeEntriesTest.testJar({create=true}, 8): success [5121ms]
test LargeEntriesTest.testJar(java.util.ImmutableCollections$MapN@34771e2b, 0): success [3029ms]
test LargeEntriesTest.testJar(java.util.ImmutableCollections$MapN@27fb5d9f, 8): success [4333ms]
test LargeEntriesTest.testZip({create=true}, 8): success [3944ms]
test LargeEntriesTest.testZip(java.util.ImmutableCollections$MapN@62272fdb, 0): success [2638ms]
test LargeEntriesTest.testZip(java.util.ImmutableCollections$MapN@6f1bd253, 8): success [4138ms]
```

A new self test has been introduced to verify this change and an existing self test had to be updated to allow for the presence of the duration in the text output. All self tests including the new one continue to pass with these changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903753](https://bugs.openjdk.org/browse/CODETOOLS-7903753): Report duration of testng test methods (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/207/head:pull/207` \
`$ git checkout pull/207`

Update a local copy of the PR: \
`$ git checkout pull/207` \
`$ git pull https://git.openjdk.org/jtreg.git pull/207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 207`

View PR using the GUI difftool: \
`$ git pr show -t 207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/207.diff">https://git.openjdk.org/jtreg/pull/207.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/207#issuecomment-2165442387)