### PR TITLE
7903188: Log time spent waiting to acquire exclusive access lock

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -711,6 +711,7 @@ public abstract class Action extends ActionHelper {
         LOG_JT_COMMAND        = "JavaTest command: ",
         LOG_REASON            = "reason: ",
         LOG_ELAPSED_TIME      = "elapsed time (seconds): ",
+        LOG_EXCLUSIVE_ACCESS_TIME = "exclusiveAccess wait time (seconds): ",
         LOG_STARTED = "started: ",
         LOG_FINISHED = "finished: ",
         //LOG_JDK               = "JDK under test: ",

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -282,7 +283,13 @@ public class ShellAction extends Action
             PrintWriter sysOut = section.createOutput("System.out");
             PrintWriter sysErr = section.createOutput("System.err");
             Lock lock = script.getLockIfRequired();
-            if (lock != null) lock.lock();
+            if (lock != null) {
+                long startNanos = System.nanoTime();
+                lock.lock();
+                long durationMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
+                section.getMessageWriter().println(LOG_EXCLUSIVE_ACCESS_TIME
+                        + ((double) durationMillis/1000.0));
+            }
             try {
                 if (showCmd)
                     showCmd("shell", command, section);

--- a/test/exclusive/ExclusiveAccessTest.gmk
+++ b/test/exclusive/ExclusiveAccessTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -34,11 +34,12 @@ $(BUILDTESTDIR)/ExclusiveAccessTest.single.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		-conc:4 \
+		-conc:5 \
 		$(TESTDIR)/exclusive \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: 4' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: 5' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'exclusiveAccess wait time' -R $(@:%.ok=%/work/)  > /dev/null
 	$(DIFF) $(BUILDTESTDIR)/ExclusiveAccessTest.ref $(@:%.ok=%)/Test.log
 	echo "test passed at `date`" > $@
 

--- a/test/exclusive/dir/Test.java
+++ b/test/exclusive/dir/Test.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.Date;
+
+/*
+ * @test
+ * @run main Test
+ */
+public class Test {
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println("test run at " + new Date());
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to implement the enhancement requested in https://bugs.openjdk.org/browse/CODETOOLS-7903188?

jtreg supports the ability to sequentially execute tests, instead of concurrently, for tests belonging to a pre-configured `exclusiveAccess.dirs` directory. The `MainAction` and `ShellAction` before launching the test, first acquire a lock. The lock acquisition can be time consuming and depends on how long an already running test from that directory takes to complete. This lock acquisiton time isn't reported anywhere in the jtreg action's `section` in the report. Because of this, it sometimes makes it difficult to determine where the unaccounted time is spent.

The change in this PR prints out how long it took to acquire a exclusive access before launching the test. It's only printed if the test was configured with exclusiveAccess. The reported message will look like:

```
#section:main
----------messages:(7/230)----------
command: main Test
reason: User specified action: run main Test 
started: Wed Jun 19 14:45:21 IST 2024
exclusiveAccess wait time (seconds): 20.289
Mode: othervm
finished: Wed Jun 19 14:45:21 IST 2024
elapsed time (seconds): 0.123
```

An existing self test has been updated to verify this change. All existing tests continue to pass with this change.