### PR TITLE
7903760: Revert "7903622: Remove support for `jtdiff`"

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -34,6 +34,7 @@ all: build test
 
 #----------------------------------------------------------------------
 
+include jtdiff.gmk
 include jtreg.gmk
 include $(TOPDIR)/test/*.gmk
 include $(TOPDIR)/test/*/*.gmk

--- a/make/jtdiff.gmk
+++ b/make/jtdiff.gmk
@@ -1,0 +1,78 @@
+#
+# Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#----------------------------------------------------------------------
+#
+# compile com.sun.javatest.diff
+
+JAVAFILES.com.sun.javatest.diff := \
+	$(shell $(FIND) $(JAVADIR)/com/sun/javatest/diff -name \*.java )
+
+$(BUILDDIR)/classes.com.sun.javatest.diff.ok: \
+		$(JAVAFILES.com.sun.javatest.diff) \
+		$(BUILDDIR)/classes.com.sun.javatest.regtest.ok
+	CLASSPATH="$(CLASSDIR)$(PS)$(JAVATEST_JAR)$(PS)$(ANT_JAR)" \
+	    $(REGTEST_TOOL_JAVAC) $(REGTEST_TOOL_JAVAC_OPTIONS) \
+		-d $(CLASSDIR) \
+		-encoding ASCII \
+		$(JAVAFILES.com.sun.javatest.diff)
+	echo "classes built at `date`" > $@
+
+TARGETS.com.sun.javatest.diff += $(BUILDDIR)/classes.com.sun.javatest.diff.ok
+
+#----------------------------------------------------------------------
+#
+# resources required for com.sun.javatest.diff
+
+RESOURCES.com.sun.javatest.diff = \
+	$(CLASSDIR)/com/sun/javatest/diff/i18n.properties
+
+TARGETS.com.sun.javatest.diff += $(RESOURCES.com.sun.javatest.diff)
+
+#----------------------------------------------------------------------
+#
+# include jtdiff in jtreg.jar
+
+PKGS.JAR.jtreg += com.sun.javatest.diff
+TARGETS.JAR.jtreg += $(TARGETS.com.sun.javatest.diff)
+
+#----------------------------------------------------------------------
+#
+# executable scripts
+
+$(JTREG_IMAGEDIR)/bin/jtdiff: $(SRCSHAREBINDIR)/jtdiff.sh
+	$(MKDIR) -p $(@D)
+	$(RM) $@
+	$(CP) $<  $@
+	$(CHMOD) a+x,a-w $@
+
+TARGETS.ZIP.jtreg += \
+	$(JTREG_IMAGEDIR)/bin/jtdiff
+
+#----------------------------------------------------------------------
+
+TESTS += $(TESTS.jtdiff)
+
+

--- a/make/jtreg.gmk
+++ b/make/jtreg.gmk
@@ -51,7 +51,7 @@ $(BUILDDIR)/classes.com.sun.javatest.regtest.agent.ok: \
 		$(JAVAFILES.com.sun.javatest.regtest-agentvm)
 	echo "classes built at `date`" > $@
 
-### The following files are for the jtreg tool
+### The following files are for the jtreg and jtdiff tools
 
 JAVAFILES.com.sun.javatest.regtest-tools := \
 	$(shell $(FIND) $(JAVADIR)/com/sun/javatest/regtest -name agent -prune -o -name \*.java -print )

--- a/src/share/bin/jtdiff.sh
+++ b/src/share/bin/jtdiff.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+#
+# Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# Usage:
+#    jtdiff ...args....
+#
+# jtdiff requires a version of Java equivalent to JDK 1.5.0 or higher.
+
+# $JT_HOME can be used to specify the jtdiff installation directory
+#   (e.g. /usr/local/java/jct-tools/3.2.2)
+#
+# $JT_JAVA is used to specify the version of java to use when running JavaTest
+#   (e.g. /usr/local/java/jdk1.5.0/solaris-sparc/bin/java)
+#
+# jtdiff also provides an Ant task for direct invocation from Ant.
+
+# Determine jtdiff/JavaTest installation directory
+if [ -n "$JT_HOME" ]; then
+    if [ ! -r $JT_HOME/lib/jtreg.jar ];then
+        echo "Invalid JT_HOME=$JT_HOME. Cannot find or read $JT_HOME/lib/jtreg.jar"
+       exit 1;
+    fi
+else
+    # Deduce where script is installed
+    # - should work on most derivatives of Bourne shell, like ash, bash, ksh,
+    #   sh, zsh, etc, including on Windows, MKS (ksh) and Cygwin (ash or bash)
+    if type -p type 1>/dev/null 2>&1 && test -z "`type -p type`" ; then
+        myname=`type -p "$0"`
+    elif type type 1>/dev/null 2>&1 ; then
+        myname=`type "$0" | sed -e 's/^.* is a tracked alias for //' -e 's/^.* is //'`
+    elif whence whence 1>/dev/null 2>&1 ; then
+        myname=`whence "$0"`
+    fi
+    mydir=`dirname "$myname"`
+    p=`cd "$mydir" ; pwd`
+    while [ -n "$p" -a "$p" != "/" ]; do
+        if [ -r "$p"/lib/jtreg.jar ]; then JT_HOME="$p" ; break; fi
+        p=`dirname "$p"`
+    done
+    if [ -z "$JT_HOME" ]; then
+        echo "Cannot determine JT_HOME; please set it explicitly"; exit 1
+    fi
+fi
+
+# Normalize JT_HOME if using Cygwin
+case "`uname -s`" in
+    CYGWIN* ) cygwin=1 ; JT_HOME=`cygpath -a -m "$JT_HOME"` ;;
+esac
+
+
+# Separate out -J* options for the JVM
+# Unset IFS and use newline as arg separator to preserve spaces in args
+DUALCASE=1  # for MKS: make case statement case-sensitive (6709498)
+saveIFS="$IFS"
+nl='
+'
+for i in "$@" ; do
+    IFS=
+    if [ -n "$cygwin" ]; then i=`echo $i | sed -e 's|/cygdrive/\([A-Za-z]\)/|\1:/|'` ; fi
+    case $i in
+    -J* )       javaOpts=$javaOpts$nl`echo $i | sed -e 's/^-J//'` ;;
+    *   )       jtdiffOpts=$jtdiffOpts$nl$i ;;
+    esac
+    IFS="$saveIFS"
+done
+unset DUALCASE
+
+# Determine java for jtdiff, from JT_JAVA, JAVA_HOME, java
+if [ -n "$JT_JAVA" ]; then
+    if [ -d "$JT_JAVA" ]; then
+        JT_JAVA="$JT_JAVA/bin/java"
+    fi
+elif [ -n "$JAVA_HOME" ]; then
+    JT_JAVA="$JAVA_HOME/bin/java"
+else
+    JT_JAVA=java
+fi
+
+# Verify java version (1.)5 or newer used to run jtdiff
+version=`"$JT_JAVA" -classpath "${JT_HOME}/lib/jtreg.jar" com.sun.javatest.regtest.agent.GetSystemProperty java.version 2>&1 |
+        grep 'java.version=' | sed -e 's/^.*=//' -e 's/^1\.//' -e 's/\([1-9][0-9]*\).*/\1/'`
+
+if [ -z "$version" ]; then
+    echo "Cannot determine version of java to run jtdiff"
+    exit 1;
+elif [ "$version" -lt 5 ]; then
+    echo "java version 5 or later is required to run jtdiff"
+    exit 1;
+fi
+
+# And finally ...
+
+IFS=$nl
+
+"${JT_JAVA:-${JAVA_HOME:+$JAVA_HOME/bin/}java}" \
+    $javaOpts \
+    -Dprogram=`basename "$0"` \
+    -cp "${JT_HOME}/lib/jtreg.jar" \
+    com.sun.javatest.diff.Main \
+    $jtdiffOpts

--- a/src/share/classes/com/sun/javatest/diff/Diff.java
+++ b/src/share/classes/com/sun/javatest/diff/Diff.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import com.sun.javatest.Status;
+import com.sun.javatest.TestResult;
+import com.sun.javatest.TestSuite;
+import com.sun.javatest.WorkDirectory;
+import com.sun.javatest.util.I18NResourceBundle;
+
+public abstract class Diff {
+
+    public abstract boolean report(File outFile) throws Fault, InterruptedException;
+
+    protected boolean diff(List<File> files, File outFile)
+            throws Fault, InterruptedException {
+        this.outFile = outFile;
+        List<DiffReader> list = new ArrayList<>();
+        for (File f: files)
+            list.add(open(f));
+
+        PrintWriter prevOut = out;
+        if (outFile != null) {
+            try {
+                out = new PrintWriter(new BufferedWriter(new FileWriter(outFile))); // FIXME don't want to use PrintWriter
+            } catch (IOException e) {
+                throw new Fault(i18n, "diff.cantOpenFile", outFile, e);
+            }
+        }
+
+        try {
+            initComparator();
+
+            initReporter();
+            reporter.setTitle(title);
+            reporter.setComparator(comparator);
+            reporter.setReaders(list);
+
+            List<int[]> testCounts = new ArrayList<>();
+            MultiMap<String, TestResult> table = new MultiMap<>();
+            for (DiffReader r: list) {
+                int index = table.addColumn(r.getFile().getPath());
+                int[] counts = new int[Status.NUM_STATES];
+                for (TestResult tr: r) {
+                    table.addRow(index, tr.getTestName(), tr);
+                    counts[tr.getStatus().getType()]++;
+                }
+                testCounts.add(counts);
+            }
+            reporter.setTestCounts(testCounts);
+
+            try {
+                reporter.write(table);
+            } catch (IOException e) {
+                throw new Fault(i18n, "diff.ioError", e);
+            }
+
+            return (reporter.diffs == 0);
+        } finally {
+            if (out != prevOut) {
+//                try {
+                    out.close();
+//                } catch (IOException e) {
+//                    throw new Fault(i18n, "main.ioError", e);
+//                }
+                out = prevOut;
+            }
+        }
+    }
+
+    protected void initFormat() {
+        if (format == null && outFile != null) {
+            String name = outFile.getName();
+            int dot = name.lastIndexOf(".");
+            if (dot != -1)
+                format = name.substring(dot + 1).toLowerCase();
+        }
+    }
+
+    protected void initReporter() throws Fault {
+        if (reporter == null) {
+            try {
+                initFormat();
+                if (format != null && format.equals("html"))
+                    reporter = new HTMLReporter(out);
+                else
+                    reporter = new SimpleReporter(out);
+            } catch (IOException e) {
+                throw new Fault(i18n, "diff.cantOpenReport", e);
+            }
+        }
+    }
+
+    protected void initComparator() {
+        if (comparator == null)
+            comparator = new StatusComparator(includeReason);
+    }
+
+    protected DiffReader open(File f) throws Fault {
+        if (!f.exists())
+            throw new Fault(i18n, "main.cantFindFile", f);
+
+        try {
+            if (WorkDirectoryReader.accepts(f))
+                return new WorkDirectoryReader(f);
+
+            if (ReportReader.accepts(f))
+                return new ReportReader(f);
+
+            throw new Fault(i18n, "main.unrecognizedFile", f);
+
+        } catch (TestSuite.Fault
+                 | WorkDirectory.Fault
+                 | IOException e) {
+            throw new Fault(i18n, "main.cantOpenFile", f, e);
+        }
+
+    }
+
+    protected File outFile;
+    protected PrintWriter out;
+    protected Comparator<TestResult> comparator;
+    protected Reporter reporter;
+    protected boolean includeReason;
+    protected String format;
+    protected String title;
+    private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Diff.class);
+}

--- a/src/share/classes/com/sun/javatest/diff/DiffReader.java
+++ b/src/share/classes/com/sun/javatest/diff/DiffReader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.File;
+
+import com.sun.javatest.TestResult;
+
+/**
+ * Interface for reading a series of test-status results.
+ */
+public interface DiffReader extends Iterable<TestResult> {
+    File getWorkDirectory();
+    String getFileType();
+    File getFile();
+}
+

--- a/src/share/classes/com/sun/javatest/diff/Fault.java
+++ b/src/share/classes/com/sun/javatest/diff/Fault.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import com.sun.javatest.util.I18NResourceBundle;
+
+/**
+ * Exception to report a problem while executing in Main.
+ */
+public class Fault extends Exception {
+
+    static final long serialVersionUID = 1607979458544175906L;
+
+    Fault(I18NResourceBundle i18n, String s, Object... args) {
+        super(i18n.getString(s, args));
+    }
+}

--- a/src/share/classes/com/sun/javatest/diff/HTMLReporter.java
+++ b/src/share/classes/com/sun/javatest/diff/HTMLReporter.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Date;
+import java.util.Map;
+
+import com.sun.javatest.Status;
+import com.sun.javatest.TestResult;
+import com.sun.javatest.util.I18NResourceBundle;
+
+import static com.sun.javatest.util.HTMLWriter.*;
+
+/*
+ * TODO: import CSS
+ * TODO: links to .jtr files
+ */
+
+/**
+ * Report differences to an HTML file.
+ */
+public class HTMLReporter extends Reporter {
+
+    /** Creates a new instance of HTMLReporter */
+    public HTMLReporter(Writer out) throws IOException {
+        this.out = new HTMLWriter(out, DOCTYPE);
+        this.out.setI18NResourceBundle(i18n);
+    }
+
+    public void write(MultiMap<String, TestResult> table) throws IOException {
+        this.table = table;
+        size = table.getColumns();
+
+        startReport(title);
+
+        out.startTag(H1);
+        if (title == null)
+            out.writeI18N("html.head.notitle");
+        else
+            out.writeI18N("html.head.title", title);
+        out.endTag(H1);
+
+        writeIndexTable();
+        writeMainTable();
+        writeSummary();
+
+        endReport();
+    }
+
+    protected void startReport(String title) throws IOException {
+        out.startTag(HTML);
+        writeHead(title);
+        out.startTag(BODY);
+    }
+
+    protected void endReport() throws IOException {
+        out.startTag(HR);
+        out.writeI18N("html.generatedAt", new Date());
+        out.endTag(BODY);
+
+        out.endTag(HTML);
+        out.flush();
+    }
+
+    protected void writeHead(String title) throws IOException {
+        out.startTag(HEAD);
+        out.startTag(TITLE);
+        if (title == null)
+            out.writeI18N("html.head.notitle");
+        else
+            out.writeI18N("html.head.title", title);
+        out.endTag(TITLE);
+        out.startTag(STYLE);
+        out.writeAttr(TYPE, "text/css");
+        out.write("\n");
+        out.write("table   { background-color:white }");
+        out.write("tr.head { background-color:#dddddd }");
+        out.write("tr.odd  { background-color:#eeeeee }");
+        out.write("tr.even { background-color:white } ");
+        out.write("td { padding: 0 .5em }");
+        out.write("td.pass { background-color:#ddffdd } ");
+        out.write("td.fail { background-color:#ffdddd } ");
+        out.write("td.error { background-color:#ddddff } ");
+        out.write("td.notRun { background-color:#dddddd } ");
+        out.write("th { padding: 0 .5em }");
+        out.write("hr      { margin-top:30px; }");
+        out.write("\n");
+        out.endTag(STYLE);
+        out.endTag(HEAD);
+
+    }
+
+    private void writeIndexTable() throws IOException {
+        out.startTag(H2);
+        out.writeI18N("html.head.sets");
+        out.endTag(H2);
+
+        out.startTag(TABLE);
+        out.writeAttr(FRAME, BOX);
+        out.writeAttr(RULES, GROUPS);
+        out.startTag(THEAD);
+        out.startTag(TR);
+        out.writeAttr(CLASS, HEAD);
+        out.startTag(TH);
+        out.writeI18N("html.th.set");
+        out.endTag(TH);
+        out.startTag(TH);
+        out.writeI18N("html.th.location");
+        out.endTag(TH);
+        writeIndexTableInfoHeadings();
+//        out.startTag(TH);
+//        out.writeI18N("html.th.type");
+//        out.endTag(TH);
+        for (int c = 0; c < Status.NUM_STATES; c++) {
+            out.startTag(TH);
+            switch (c) {
+                case Status.PASSED:
+                    out.writeI18N("html.th.pass");
+                    break;
+                case Status.FAILED:
+                    out.writeI18N("html.th.fail");
+                    break;
+                case Status.ERROR:
+                    out.writeI18N("html.th.error");
+                    break;
+                default:
+                    out.writeI18N("html.th.notRun");
+                    break;
+            }
+            out.endTag(TH);
+        }
+        out.startTag(TH);
+        out.writeI18N("html.th.total");
+        out.endTag(TH);
+        out.endTag(TR);
+        out.endTag(THEAD);
+
+        out.startTag(TBODY);
+        for (int i = 0; i < size; i++) {
+            out.startTag(TR);
+            out.writeAttr(CLASS, (i % 2 == 0 ? EVEN : ODD));
+            out.startTag(TD);
+            out.write(String.valueOf(i + 1));
+            out.endTag(TD);
+            out.startTag(TD);
+            out.write(table.getColumnName(i));
+            out.endTag(TD);
+            writeIndexTableInfoValues(table.getColumnName(i));
+//            out.startTag(TD);
+//            out.write("??");
+//            out.endTag(TD);
+            int total = 0;
+            int[] counts = testCounts.get(i);
+            for (int c = 0; c < Status.NUM_STATES; c++) {
+                out.startTag(TD);
+                if (counts[c] > 0)
+                    out.write(String.valueOf(counts[c]));
+                else
+                    out.writeEntity("&nbsp;");
+                total += counts[c];
+                out.endTag(TD);
+            }
+            out.startTag(TD);
+            out.write(String.valueOf(total));
+            out.endTag(TD);
+            out.endTag(TR);
+        }
+        out.endTag(TBODY);
+        out.endTag(TABLE);
+    }
+
+    protected void writeIndexTableInfoHeadings() throws IOException {
+    }
+
+    protected void writeIndexTableInfoValues(String name) throws IOException {
+    }
+
+    private void writeMainTable() throws IOException {
+        diffs = 0;
+        for (Map.Entry<String, MultiMap.Entry<TestResult>> e: table.entrySet()) {
+            String testName = e.getKey();
+            MultiMap.Entry<TestResult> result = e.getValue();
+            if (result.allEqual(comparator))
+                continue;
+            if (diffs == 0) {
+                out.startTag(H2);
+                out.writeI18N("html.head.differences");
+                out.endTag(H2);
+                out.startTag(TABLE);
+                out.writeAttr(FRAME, BOX);
+                out.writeAttr(RULES, GROUPS);
+                out.startTag(THEAD);
+                out.startTag(TR);
+                out.writeAttr(CLASS, HEAD);
+                out.startTag(TH);
+                out.writeI18N("html.th.test");
+                out.endTag(TH);
+                for (int i = 0; i < result.getSize(); i++) {
+                    out.startTag(TH);
+                    if (compact)
+                        out.write(String.valueOf(i + 1));
+                    else
+                        out.writeI18N("html.th.setN", i + 1);
+                    out.endTag(TH);
+                }
+                out.endTag(TR);
+                out.endTag(THEAD);
+                out.startTag(TBODY);
+            }
+            out.startTag(TR);
+            out.writeAttr(CLASS, (diffs % 2 == 0 ? EVEN : ODD));
+            out.startTag(TD);
+            out.write(testName);
+            out.endTag(TD);
+            for (int i = 0; i < result.getSize(); i++) {
+                TestResult tr = result.get(i);
+                File trFile = (tr == null ? null : tr.getFile());
+                if (trFile == null) {
+                    File wd = readers.get(i).getWorkDirectory();
+                    if (wd != null)
+                        trFile = new File(wd, tr.getWorkRelativePath());
+                }
+                out.startTag(TD);
+                Status s = (tr == null ? null : tr.getStatus());
+                out.writeAttr(CLASS, getClassAttr(s));
+                String text = getText(s);
+                if (trFile != null && trFile.exists()) {
+                    out.startTag(A);
+                    out.writeAttr(HREF, trFile.toURI().toString());
+                    if (text.startsWith("&"))
+                        out.writeEntity(text);
+                    else
+                        out.write(text);
+                    out.endTag(A);
+                } else {
+                    if (text.startsWith("&"))
+                        out.writeEntity(text);
+                    else
+                        out.write(text);
+                }
+                out.endTag(TD);
+            }
+            out.endTag(TR);
+            diffs++;
+        }
+        if (diffs > 0) {
+            out.endTag(TBODY);
+            out.endTag(TABLE);
+        }
+    }
+
+    private void writeSummary() throws IOException {
+        out.startTag(P);
+        if (diffs == 0)
+            out.writeI18N("html.diffs.none");
+        else
+            out.writeI18N("html.diffs.count", diffs);
+        out.endTag(P);
+    }
+
+    protected String getClassAttr(Status s) {
+        switch (s == null ? Status.NOT_RUN : s.getType()) {
+            case Status.PASSED:
+                return PASS;
+            case Status.FAILED:
+                return FAIL;
+            case Status.ERROR:
+                return ERROR;
+            default:
+                return NOT_RUN;
+        }
+    }
+
+    protected String getText(Status s) {
+        if (statusStrings == null) {
+            statusStrings = new String[Status.NUM_STATES];
+            if (compact) {
+                statusStrings[Status.PASSED] = i18n.getString("html.pass.compact");
+                statusStrings[Status.FAILED] = i18n.getString("html.fail.compact");
+                statusStrings[Status.ERROR] = i18n.getString("html.error.compact");
+                statusStrings[Status.NOT_RUN] = i18n.getString("html.notRun.compact");
+            } else {
+                statusStrings[Status.PASSED] = i18n.getString("html.pass");
+                statusStrings[Status.FAILED] = i18n.getString("html.fail");
+                statusStrings[Status.ERROR] = i18n.getString("html.error");
+                statusStrings[Status.NOT_RUN] = i18n.getString("html.notRun");
+            }
+        }
+        return statusStrings[s == null ? Status.NOT_RUN : s.getType()];
+    }
+
+    private String[] statusStrings;
+
+    protected final HTMLWriter out;
+    private MultiMap<String, TestResult> table;
+    private int size;
+
+    private static final String DOCTYPE = "<!DOCTYPE HTML>";
+
+    // HTML tags
+    private static final String THEAD = "thead";
+    private static final String TBODY = "tbody";
+
+    // HTML attribute names
+    private static final String CLASS = "class";
+    private static final String FRAME = "frame";
+    private static final String RULES = "rules";
+
+    // HTML attribute values
+    private static final String BOX = "box";
+    private static final String GROUPS = "groups";
+
+    // HTML class values
+    private static final String HEAD = "head";
+    private static final String ODD  = "odd";
+    private static final String EVEN = "even";
+    private static final String PASS = "pass";
+    private static final String FAIL = "fail";
+    private static final String ERROR = "error";
+    private static final String NOT_RUN = "notRun";
+
+    private boolean compact = Boolean.TRUE.equals(Boolean.getBoolean("jtdiff.html.compact"));
+    private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(HTMLReporter.class);
+}

--- a/src/share/classes/com/sun/javatest/diff/HTMLWriter.java
+++ b/src/share/classes/com/sun/javatest/diff/HTMLWriter.java
@@ -1,0 +1,559 @@
+/*
+ * Copyright (c) 1996, 2008, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URL;
+
+import com.sun.javatest.util.I18NResourceBundle;
+
+/**
+ * A class to facilitate writing HTML via a stream.
+ */
+public class HTMLWriter
+{
+    /**
+     * Create an HTMLWriter object, using a default doctype for HTML 3.2.
+     * @param out a Writer to which to write the generated HTML
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public HTMLWriter(Writer out) throws IOException {
+        this(out, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2//EN\">");
+    }
+
+    /**
+     * Create an HTMLWriter object, using a specifed doctype header.
+     * @param out a Writer to which to write the generated HTML
+     * @param docType a string containing a doctype header for the HTML to be generetaed
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public HTMLWriter(Writer out, String docType) throws IOException {
+        if (out instanceof BufferedWriter)
+            this.out = (BufferedWriter) out;
+        else
+            this.out = new BufferedWriter(out);
+        this.out.write(docType);
+        this.out.newLine();
+    }
+
+    /**
+     * Create an HTMLWriter object, using a specified bundle for l0calizing messages.
+     * @param out a Writer to which to write the generated HTML
+     * @param i18n a resource bundle to use to localize messages
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public HTMLWriter(Writer out, I18NResourceBundle i18n) throws IOException {
+        this(out);
+        this.i18n = i18n;
+    }
+
+
+    /**
+     * Create an HTMLWriter object, using a specifed doctype header and
+     * using a specified bundle for l0calizing messages.
+     * @param out a Writer to which to write the generated HTML
+     * @param docType a string containing a doctype header for the HTML to be generetaed
+     * @param i18n a resource bundle to use to localize messages
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public HTMLWriter(Writer out, String docType, I18NResourceBundle i18n) throws IOException {
+        this(out, docType);
+        this.i18n = i18n;
+    }
+
+    /**
+     * Set the reource bundle to be used for localizing messages.
+     * @param i18n the resource bundle to be used for localizing messages
+     */
+    public void setI18NResourceBundle(I18NResourceBundle i18n) {
+        this.i18n = i18n;
+    }
+
+    /**
+     * Flush the stream, and the underlying output stream.
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    /**
+     * Close the stream, and the underlying output stream.
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void close() throws IOException {
+        out.close();
+    }
+
+    /**
+     * Write a newline to the underlying output stream.
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void newLine() throws IOException {
+        out.newLine();
+    }
+
+    /**
+     * Start an HTML tag.  If a prior tag has been started, it will
+     * be closed first. Once a tag has been opened, attributes for the
+     * tag may be written out, followed by body content before finally
+     * ending the tag.
+     * @param tag the tag to be started
+     * @throws IOException if there is a problem writing to the underlying stream
+     * @see #writeAttr
+     * @see #write
+     * @see #endTag
+     */
+    public void startTag(String tag) throws IOException {
+        if (state == IN_TAG) {
+            out.write(">");
+            state = IN_BODY;
+        }
+        newLine();
+        out.write("<");
+        out.write(tag);
+        state = IN_TAG;
+    }
+
+    /**
+     * Finish an HTML tag. It is expected that a call to endTag will match
+     * a corresponding earlier call to startTag, but there is no formal check
+     * for this.
+     * @param tag the tag to be closed.
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void endTag(String tag) throws IOException {
+        if (state == IN_TAG) {
+            out.write(">");
+            state = IN_BODY;
+            out.newLine();
+        }
+        out.write("</");
+        out.write(tag);
+        out.write(">");
+        //out.newLine();   // PATCHED, jjg
+        state = IN_BODY;
+    }
+
+    /**
+     * Finish an empty element tag, such as a META, BASE or LINK tag.
+     * This is expected to correspond with a startTag.
+     * @param tag the tag which is being closed.  this is only useful for
+     *        validation, it is not written out
+     * @throws IllegalStateException if this call does not follow startTag
+     *         (stream is not currently inside a tag)
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void endEmptyTag(String tag) throws IOException {
+        if (state != IN_TAG)
+            throw new IllegalStateException();
+
+        out.write(">");
+        state = IN_BODY;
+        out.newLine();
+    }
+
+    /**
+     * Write an attribute for a tag. A tag must previously have been started.
+     * All tag attributes must be written before any body text is written.
+     * The value will be quoted if necessary when writing it to the underlying
+     * stream. No check is made that the attribute is valid for the current tag.
+     * @param name the name of the attribute to be written
+     * @param value the value of the attribute to be written
+     * @throws IllegalStateException if the stream is not in a state to
+     * write attributes -- e.g. if this call does not follow startTag or other
+     * calls of writteAttr
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void writeAttr(String name, String value) throws IOException {
+        if (state != IN_TAG)
+            throw new IllegalStateException();
+
+        out.write(" ");
+        out.write(name);
+        out.write("=");
+        boolean alpha = true;
+        for (int i = 0; i < value.length() && alpha; i++)
+            alpha = Character.isLetter(value.charAt(i));
+        if (!alpha)
+            out.write("\"");
+        out.write(value);
+        if (!alpha)
+            out.write("\"");
+    }
+
+    /**
+     * Write an attribute for a tag. A tag must previously have been started.
+     * All tag attributes must be written before any body text is written.
+     * The value will be quoted if necessary when writing it to the underlying
+     * stream. No check is made that the attribute is valid for the current tag.
+     * @param name the name of the attribute to be written
+     * @param value the value of the attribute to be written
+     * @throws IllegalStateException if the stream is not in a state to
+     * write attributes -- e.g. if this call does not follow startTag or other
+     * calls of writteAttr
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void writeAttr(String name, int value) throws IOException {
+        writeAttr(name, Integer.toString(value));
+    }
+
+    /**
+     * Write a line of text, followed by a newline.
+     * The text will be escaped as necessary.
+     * @param text the text to be written.
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeLine(String text) throws IOException {
+        write(text);
+        out.newLine();
+    }
+
+    /**
+     * Write body text, escaping it as necessary.
+     * If this call follows a call of startTag, the open tag will be
+     * closed -- meaning that no more attributes can be written until another
+     * tag is started.  If the text value is null, the current tag will still
+     * be closed, but no other text will be written.
+     * @param text the text to be written, may be null or zero length.
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void write(String text) throws IOException {
+        if (state == IN_TAG) {
+            out.write(">");
+            state = IN_BODY;
+        }
+
+        if (text == null)
+            return;
+
+        // check to see if there are any special characters
+        boolean specialChars = false;
+        for (int i = 0; i < text.length() && !specialChars; i++) {
+            switch (text.charAt(i)) {
+            case '<': case '>': case '&':
+                specialChars = true;
+            }
+        }
+
+        // if there are special characters write the string character at a time;
+        // otherwise, write it out as is
+        if (specialChars) {
+            for (int i = 0; i < text.length(); i++) {
+                char c = text.charAt(i);
+                switch (c) {
+                case '<': out.write("&lt;"); break;
+                case '>': out.write("&gt;"); break;
+                case '&': out.write("&amp;"); break;
+                default: out.write(c);
+                }
+            }
+        }
+        else
+            out.write(text);
+    }
+
+    /**
+     * Write a basic HTML entity, such as &nbsp; or &#123; .
+     * @param entity the entity to write
+     * @throws IOException if there is a problem writing to the underlying stream
+     */
+    public void writeEntity(String entity) throws IOException {
+        if (state == IN_TAG) {
+            out.write(">");
+            state = IN_BODY;
+        }
+        out.write(entity);
+    }
+
+    /**
+     * Write an image tag, using a specified path for the image source attribute.
+     * @param imagePath the path for the image source
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeImage(String imagePath) throws IOException {
+        startTag(IMAGE);
+        writeAttr(SRC, imagePath);
+    }
+
+    /**
+     * Write an image tag, using a specified path for the image source attribute.
+     * @param imageURL the url for the image source
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeImage(URL imageURL) throws IOException {
+        writeImage(imageURL.toString());
+    }
+
+    /**
+     * Write a hypertext link.
+     * @param anchor the target for the link
+     * @param body the body text for the link
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeLink(String anchor, String body) throws IOException {
+        startTag(A);
+        writeAttr(HREF, anchor);
+        write(body);
+        endTag(A);
+    }
+
+    /**
+     * Write a hypertext link.
+     * @param file the target for the link
+     * @param body the body text for the link
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeLink(File file, String body) throws IOException {
+        startTag(A);
+        StringBuilder sb = new StringBuilder();
+        String path = file.getPath().replace(File.separatorChar, '/');
+        if (file.isAbsolute() && !path.startsWith("/"))
+            sb.append('/');
+        sb.append(path);
+        writeAttr(HREF, sb.toString());
+        write(body);
+        endTag(A);
+    }
+
+    /**
+     * Write a hypertext link.
+     * @param file the target and body for the link
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeLink(File file) throws IOException {
+        writeLink(file, file.getPath());
+    }
+
+    /**
+     * Write a hypertext link.
+     * @param url the target for the link
+     * @param body the body text for the link
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeLink(URL url, String body) throws IOException {
+        startTag(A);
+        writeAttr(HREF, url.toString());
+        write(body);
+        endTag(A);
+    }
+
+    /**
+     * Write the destination marker for a hypertext link.
+     * @param anchor the destination marker for hypertext links
+     * @param body the body text for the marker
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeLinkDestination(String anchor, String body) throws IOException {
+        startTag(A);
+        writeAttr(NAME, anchor);
+        write(body);
+        endTag(A);
+    }
+
+    /**
+     * Write a parameter tag.
+     * @param name the name of the parameter
+     * @param value the value of the parameter
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeParam(String name, String value) throws IOException {
+        startTag(PARAM);
+        writeAttr(NAME, name);
+        writeAttr(VALUE, value);
+    }
+
+    /**
+     * Write a style attribute.
+     * @param value the value for the style atrtribute
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeStyleAttr(String value) throws IOException {
+        writeAttr(STYLE, value);
+    }
+
+    /**
+     * Write a localized message, using a specified resource bundle.
+     * @param i18n the resource bundle used to localize the message
+     * @param key the key for the message to be localized
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void write(I18NResourceBundle i18n, String key) throws IOException {
+        write(i18n.getString(key));
+    }
+
+    /**
+     * Write a localized message, using a specified resource bundle.
+     * @param i18n the resource bundle used to localize the message
+     * @param key the key for the message to be localized
+     * @param arg an argument to be formatted into the localized message
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void write(I18NResourceBundle i18n, String key, Object arg) throws IOException {
+        write(i18n.getString(key, arg));
+    }
+
+    /**
+     * Write a localized message, using a specified resource bundle.
+     * @param i18n the resource bundle used to localize the message
+     * @param key the key for the message to be localized
+     * @param args arguments to be formatted into the localized message
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void write(I18NResourceBundle i18n, String key, Object[] args) throws IOException {
+        write(i18n.getString(key, args));
+    }
+
+    /**
+     * Write a localized message, using the default resource bundle.
+     * @param key the key for the message to be localized
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeI18N(String key) throws IOException {
+        write(i18n.getString(key));
+    }
+
+    /**
+     * Write a localized message, using the default resource bundle.
+     * @param key the key for the message to be localized
+     * @param arg an argument to be formatted into the localized message
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeI18N(String key, Object arg) throws IOException {
+        write(i18n.getString(key, arg));
+    }
+
+    /**
+     * Write a localized message, using the default resource bundle.
+     * @param key the key for the message to be localized
+     * @param args arguments to be formatted into the localized message
+     * @throws IOException if there is a problem closing the underlying stream
+     */
+    public void writeI18N(String key, Object[] args) throws IOException {
+        write(i18n.getString(key, args));
+    }
+
+    /** The HTML "a" tag. */
+    public static final String A = "a";
+    /** The HTML "align" attribute. */
+    public static final String ALIGN = "align";
+    /** The HTML "b" tag. */
+    public static final String B = "b";
+    /** The HTML "body" tag. */
+    public static final String BODY = "body";
+    /** The HTML "border" attribute. */
+    public static final String BORDER = "border";
+    /** The HTML "br" tag. */
+    public static final String BR = "br";
+    /** The HTML "classid" attribute. */
+    public static final String CLASSID  = "classid";
+    /** The HTML "code" tag. */
+    public static final String CODE  = "code";
+    /** The HTML "color" attribte. */
+    public static final String COLOR  = "color";
+    /** The HTML "col" attribute value. */
+    public static final String COL = "col";
+    /** The HTML "font" tag. */
+    public static final String FONT = "font";
+    /** The HTML "h1" tag. */
+    public static final String H1 = "h1";
+    /** The HTML "h2" tag. */
+    public static final String H2 = "h2";
+    /** The HTML "h3" tag. */
+    public static final String H3 = "h3";
+    /** The HTML "h4" tag. */
+    public static final String H4 = "h4";
+    /** The HTML "head" tag. */
+    public static final String HEAD = "head";
+    /** The HTML "href" attribute. */
+    public static final String HREF = "href";
+    /** The HTML "html" tag. */
+    public static final String HTML = "html";
+    /** The HTML "hr" tag. */
+    public static final String HR = "hr";
+    /** The HTML "i" tag. */
+    public static final String I = "i";
+    /** The HTML "image" tag. */
+    public static final String IMAGE = "image";
+    /** The HTML "left" attribute value. */
+    public static final String LEFT = "left";
+    /** The HTML "li" tag. */
+    public static final String LI = "li";
+    /** The HTML "link" tag. */
+    public static final String LINK = "link";
+    /** The HTML "name" attribute. */
+    public static final String NAME = "name";
+    /** The HTML "object" tag. */
+    public static final String OBJECT = "object";
+    /** The HTML "p" tag. */
+    public static final String PARAM = "param";
+    /** The HTML "param" tag. */
+    public static final String P = "p";
+    /** The HTML "rel" attribute value. */
+    public static final String REL = "rel";
+    /** The HTML "right" attribute value. */
+    public static final String RIGHT = "right";
+    /** The HTML "row" attribute value. */
+    public static final String ROW = "row";
+    /** The HTML "small" tag. */
+    public static final String SMALL = "small";
+    /** The HTML "src" attribute. */
+    public static final String SRC = "src";
+    /** The HTML "scope" attribute. */
+    public static final String SCOPE = "scope";
+    /** The HTML "style" attribute. */
+    public static final String STYLE = "style";
+    /** The HTML "table" tag. */
+    public static final String TABLE = "table";
+    /** The HTML "td" tag. */
+    public static final String TD = "td";
+    /** The HTML "title"attribute. */
+    public static final String TITLE = "title";
+    /** The HTML "th" tag. */
+    public static final String TH = "th";
+    /** The HTML "top" attribute value. */
+    public static final String TOP = "top";
+    /** The HTML "tr" tag. */
+    public static final String TR = "tr";
+    /** The HTML "type" attribute. */
+    public static final String TYPE = "type";
+    /** The HTML "ul" tag. */
+    public static final String UL = "ul";
+    /** The HTML "valign" attribute. */
+    public static final String VALIGN = "valign";
+    /** The HTML "value" attribute. */
+    public static final String VALUE = "value";
+
+
+    private BufferedWriter out;
+    private int state;
+    private I18NResourceBundle i18n;
+    private static final int IN_TAG = 1;
+    private static final int IN_BODY = 2;
+}

--- a/src/share/classes/com/sun/javatest/diff/Help.java
+++ b/src/share/classes/com/sun/javatest/diff/Help.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.DateFormat;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import com.sun.javatest.regtest.tool.Option;
+import com.sun.javatest.util.HelpTree;
+import com.sun.javatest.util.I18NResourceBundle;
+import com.sun.javatest.util.WrapWriter;
+
+/**
+ * Handles help options for main program
+ */
+public class Help {
+
+    /** Creates a new instance of Help */
+    public Help(List<Option> options) {
+        this.options = options;
+    }
+
+    void setVersionFlag(boolean yes) {
+        versionFlag = yes;
+    }
+
+    void setCommandLineHelpQuery(String query) {
+        if (commandLineHelpQuery == null)
+            commandLineHelpQuery = new ArrayList<>();
+        if (query != null)
+            commandLineHelpQuery.addAll(List.of(query.trim().split("\\s+")));
+    }
+
+    void show(PrintStream out) {
+        PrintWriter w = new PrintWriter(out);
+        show(w);
+        w.flush();
+    }
+
+    void show(PrintWriter out) {
+
+        if (versionFlag)
+            showVersion(out);
+
+        if (commandLineHelpQuery != null)
+            showCommandLineHelp(out);
+    }
+
+    /**
+     * Show version information for JavaTest.
+     * @param out the stream to which to write the information
+     */
+    void showVersion(PrintWriter out) {
+        Properties manifest = getManifestForClass(getClass());
+        if (manifest == null)
+            manifest = new Properties();
+
+        String unknown = i18n.getString("help.version.unknown");
+
+        // build properties, from manifest
+        String prefix = "jtreg"; // base name of containing .jar file
+        String product = "jtdiff"; // manifest.getProperty(productPrefix + "-Name", unknown);
+        String version = manifest.getProperty(prefix + "-Version", unknown);
+        String milestone = manifest.getProperty(prefix + "-Milestone", unknown);
+        String build = manifest.getProperty(prefix + "-Build", unknown);
+        String buildJavaVersion = manifest.getProperty(prefix + "-BuildJavaVersion", unknown);
+        String buildDate = manifest.getProperty(prefix + "-BuildDate", unknown);
+
+        String thisJavaHome = System.getProperty("java.home");
+        String thisJavaVersion = System.getProperty("java.version");
+
+        File classPathFile = getClassPathFileForClass(Main.class);
+        String classPath = (classPathFile == null ? unknown : classPathFile.getPath());
+
+        DateFormat df = DateFormat.getDateInstance(DateFormat.LONG);
+
+        Object[] versionArgs = {
+            product,
+            version,
+            milestone,
+            build,
+            classPath,
+            thisJavaVersion,
+            thisJavaHome,
+            buildJavaVersion,
+            buildDate
+        };
+
+        /*
+         * Example format string:
+         *
+         * {0}, version {1} {2} {3}
+         * Installed in {4}
+         * Running on platform version {5} from {6}.
+         * Built with {7} on {8}.
+         *
+         * Example output:
+         *
+         * jtdiff, version 3.2.2 dev b00
+         * Installed in /tl/ws/jct-tools-322dev/dist/jtreg/lib/jtreg.jar
+         * Running on platform version 1.5.0_06 from /opt/java/5.0/jre.
+         * Built with 1.5.0_06 on 09/11/2006 07:52 PM.
+         */
+
+        out.println(i18n.getString("help.version.txt", versionArgs));
+        out.println(i18n.getString("help.copyright.txt"));
+    }
+
+    private File getDocDir() {
+        File classPathFile = getClassPathFileForClass(Main.class);
+        if (classPathFile == null)
+            return null;
+        File lib = classPathFile.getParentFile();
+        File home = lib.getParentFile();
+        File doc = new File(new File(home, "doc"), "jtreg");
+        if (doc.exists())
+            return doc;
+        return null;
+    }
+
+    private URL getClassPathEntryForClass(Class<?> c) {
+        try {
+            URL url = c.getResource("/" + c.getName().replace('.', '/') + ".class");
+            if (url.getProtocol().equals("jar")) {
+                String path = url.getPath();
+                int sep = path.lastIndexOf("!");
+                return new URL(path.substring(0, sep));
+            }
+        } catch (MalformedURLException ignore) {
+        }
+        return null;
+    }
+
+    private File getClassPathFileForClass(Class<?> c) {
+        URL url = getClassPathEntryForClass(c);
+        if (url.getProtocol().equals("file"))
+            return new File(url.getPath());
+        return null;
+    }
+
+    private Properties getManifestForClass(Class<?> c) {
+        URL classPathEntry = getClassPathEntryForClass(c);
+        if (classPathEntry == null)
+            return null;
+
+        try {
+            Enumeration<URL> e = getClass().getClassLoader().getResources("META-INF/MANIFEST.MF");
+            while (e.hasMoreElements()) {
+                URL url = e.nextElement();
+                if (url.getProtocol().equals("jar")) {
+                    String path = url.getPath();
+                    int sep = path.lastIndexOf("!");
+                    URL u = new URL(path.substring(0, sep));
+                    if (u.equals(classPathEntry)) {
+                        Properties p = new Properties();
+                        InputStream in = url.openStream();
+                        p.load(in);
+                        in.close();
+                        return p;
+                    }
+                }
+            }
+        } catch (IOException ignore) {
+        }
+        return null;
+    }
+
+
+    /**
+     * Print out info about the options accepted by the command line decoder.
+     * @param out A stream to which to write the information.
+     */
+    void showCommandLineHelp(PrintWriter out) {
+        HelpTree commandHelpTree = new HelpTree();
+
+        Integer nodeIndent = Integer.getInteger("javatest.help.nodeIndent");
+        if (nodeIndent != null)
+            commandHelpTree.setNodeIndent(nodeIndent);
+
+        Integer descIndent = Integer.getInteger("javatest.help.descIndent");
+        if (descIndent != null)
+            commandHelpTree.setDescriptionIndent(descIndent);
+
+        // first, group the options by their group, and sort within group
+        // by their first name
+        Set<String> groups = new LinkedHashSet<>();
+        for (Option o: options)
+            groups.add(o.group);
+        Map<String, SortedMap<String, Option>> map =
+            new LinkedHashMap<>();
+        for (String g: groups)
+            map.put(g, new TreeMap<>(new CaseInsensitiveStringComparator()));
+        for (Option o: options) {
+            if (o.names.length > 0)
+                map.get(o.group).put(o.names[0], o);
+        }
+
+        // now build the help tree nodes and add then into the primary help node
+        for (String g: groups) {
+            SortedMap<String, Option> optionsForGroup = map.get(g);
+//                continue;
+            List<HelpTree.Node> nodesForGroup = new ArrayList<>();
+            for (Option o: optionsForGroup.values())
+                nodesForGroup.add(createOptionHelpNode(o));
+            HelpTree.Node groupNode = new HelpTree.Node(i18n, "help." + g.toLowerCase(),
+                    nodesForGroup.toArray(new HelpTree.Node[0]));
+            commandHelpTree.addNode(groupNode);
+        }
+
+        String progName = getProgramName();
+
+        try {
+            WrapWriter ww = new WrapWriter(out);
+
+            if (commandLineHelpQuery == null || commandLineHelpQuery.isEmpty()) {
+                // no keywords given
+                ww.write(i18n.getString("help.cmd.proto", progName));
+                ww.write("\n\n");
+                ww.write(i18n.getString("help.cmd.introHead"));
+                ww.write('\n');
+                commandHelpTree.writeSummary(ww);
+            } else if (commandLineHelpQuery.contains("all")) {
+                // -help all
+                ww.write(i18n.getString("help.cmd.proto", progName));
+                ww.write("\n\n");
+                ww.write(i18n.getString("help.cmd.fullHead"));
+                ww.write('\n');
+                commandHelpTree.write(ww);
+            } else {
+                String[] query = commandLineHelpQuery.toArray(new String[0]);
+                HelpTree.Selection s = commandHelpTree.find(query);
+                if (s != null)
+                    commandHelpTree.write(ww, s);
+                else {
+                    ww.write(i18n.getString("help.cmd.noEntriesFound"));
+                    ww.write("\n\n");
+                    ww.write(i18n.getString("help.cmd.summaryHead"));
+                    ww.write('\n');
+                    commandHelpTree.writeSummary(ww);
+                }
+            }
+
+            ww.write('\n');
+            ww.write(i18n.getString("help.cmd.tail"));
+            ww.write("\n\n");
+            ww.write(i18n.getString("help.cmd.ant"));
+            ww.write("\n\n");
+            ww.write(i18n.getString("help.copyright.txt"));
+            ww.write("\n\n");
+
+            ww.flush();
+        } catch (IOException e) {
+            // should not happen, from PrintWriter
+        }
+
+    }
+
+    private HelpTree.Node createOptionHelpNode(Option o) {
+        String prefix = "help." + o.group.toLowerCase() + "."
+                + o.names[0].replaceAll("^-+", "").replaceAll("[^A-Za-z0-9.]+", "_");
+        String arg = (o.argType == Option.ArgType.NONE ? null : i18n.getString(prefix + ".arg"));
+        StringBuilder sb = new StringBuilder();
+        for (String n: o.names) {
+            if (sb.length() > 0)
+                sb.append("  |  ");
+            sb.append(n);
+            switch (o.argType) {
+                case NONE:
+                    break;
+
+                case OLD:       // old is deprecated, so just show preferred format
+                case STD:
+                case FILE:
+                    sb.append(":").append(arg);
+                    break;
+
+                case GNU:
+                case SEP:
+                case REST:
+                    sb.append(" ").append(arg);
+                    break;
+
+                case WILDCARD:
+                    sb.append(arg);
+                    break;
+
+                case OPT:
+                    sb.append("  |  -").append(n).append(":").append(arg);
+                    break;
+
+                default:
+                    throw new AssertionError();
+            }
+        }
+
+        String name = sb.toString();
+        String desc = i18n.getString(prefix + ".desc");
+        String[] values = o.getChoices();
+        if (values == null || values.length == 0)
+            return new HelpTree.Node(name, desc);
+        else {
+            HelpTree.Node[] children = new HelpTree.Node[values.length];
+            for (int i = 0; i < children.length; i++)
+                children[i] = new HelpTree.Node(values[i], i18n.getString(prefix + "." + values[i] + ".desc"));
+            return new HelpTree.Node(name, desc, children);
+        }
+    }
+
+    private static String getProgramName() {
+        String p = System.getProperty("program");
+        if (p != null)
+            return p;
+
+        return "java " + Main.class.getName();
+    }
+
+    private static class CaseInsensitiveStringComparator implements Comparator<String> {
+        public int compare(String s1, String s2) {
+            if (s1 == null && s2 == null)
+                return 0;
+
+            if (s1 == null || s2 == null)
+                return (s1 == null ? -1 : +1);
+
+            return s1.compareToIgnoreCase(s2);
+        }
+
+    }
+
+    private final List<Option> options;
+    private boolean versionFlag;
+    private List<String> commandLineHelpQuery;
+
+    private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Main.class);
+}

--- a/src/share/classes/com/sun/javatest/diff/Main.java
+++ b/src/share/classes/com/sun/javatest/diff/Main.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * TODO: XMLReporter
+ * TODO: filter options
+ * TODO: comparator option
+ * TODO: css option
+ **/
+
+package com.sun.javatest.diff;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sun.javatest.regtest.BadArgs;
+import com.sun.javatest.regtest.tool.Option;
+import com.sun.javatest.regtest.tool.OptionDecoder;
+import com.sun.javatest.util.I18NResourceBundle;
+
+import static com.sun.javatest.regtest.tool.Option.ArgType.*;
+
+
+/**
+ * Main entry point for jtdiff.
+ */
+public class Main {
+    //---------- command line option decoding ----------------------------------
+
+    private static final String COMPARE = "compare";
+    private static final String OUTPUT = "output";
+    private static final String DOC = "doc";
+    private static final String FILES = "files";
+
+    List<Option> options = List.of(
+        new Option(NONE, COMPARE, "r", "-r", "-reason") {
+            @Override
+            public void process(String opt, String arg) {
+                includeReason = true;
+            }
+        },
+        new Option(NONE, COMPARE, "s", "-s", "-super") {
+            @Override
+            public void process(String opt, String arg) {
+                superMode = true;
+            }
+        },
+        new Option(OLD, OUTPUT, "o", "-o", "-outFile") {
+            @Override
+            public void process(String opt, String arg) {
+                outFile = new File(arg);
+            }
+        },
+        new Option(STD, OUTPUT, "format", "-format") {
+            @Override
+            public void process(String opt, String arg) {
+                format = arg;
+            }
+        },
+        new Option(OLD, OUTPUT, "title", "-title") {
+            @Override
+            public void process(String opt, String arg) {
+                title = arg;
+            }
+        },
+        new Option(REST, DOC, "help", "-h", "-help", "--help", "-usage") {
+            @Override
+            public void process(String opt, String arg) {
+                if (help == null)
+                    help = new Help(options);
+                help.setCommandLineHelpQuery(arg);
+            }
+        },
+        new Option(NONE, DOC, "help", "-version") {
+            @Override
+            public void process(String opt, String arg) {
+                if (help == null)
+                    help = new Help(options);
+                help.setVersionFlag(true);
+            }
+        },
+        new Option(FILE, FILES, null) {
+            @Override
+            public void process(String opt, String arg) {
+                File f = new File(arg);
+                fileArgs.add(f);
+            }
+        }
+    );
+
+    //---------- Command line invocation support -------------------------------
+
+    /**
+     * Standard entry point. Only returns if GUI mode is initiated; otherwise, it calls System.exit
+     * with an appropriate exit code.
+     * @param args An array of args, such as might be supplied on the command line.
+     */
+    public static void main(String[] args) {
+        PrintWriter out = new PrintWriter(System.out, true);
+        PrintWriter err = new PrintWriter(System.err, true);
+        Main m = new Main(out, err);
+        try {
+            boolean ok;
+            try {
+                ok = m.run(args);
+                if (!ok && (m.outFile != null)) {
+                    // no need for an additional message if outFile == null
+                    err.println(i18n.getString("main.diffsFound"));
+                }
+            } finally {
+                out.flush();
+            }
+
+            if (!ok) {
+                // take care not to exit if GUI might be around,
+                // and take care to ensure JavaTestSecurityManager will
+                // permit the exit
+                exit(1);
+            }
+        } catch (Fault e) {
+            err.println(i18n.getString("main.error", e.getMessage()));
+            exit(2);
+        } catch (BadArgs e) {
+            err.println(i18n.getString("main.badArgs", e.getMessage()));
+            new Help(m.options).showCommandLineHelp(out);
+            exit(2);
+        } catch (InterruptedException e) {
+            err.println(i18n.getString("main.interrupted"));
+            exit(2);
+        } catch (Exception e) {
+            err.println(i18n.getString("main.unexpectedException"));
+            e.printStackTrace(System.err);
+            exit(3);
+        }
+    } // main()
+
+    public Main() {
+        this(new PrintWriter(System.out, true), new PrintWriter(System.err, true));
+    }
+
+    public Main(PrintWriter out, PrintWriter err) {
+        this.out = out;
+        this.err = err;
+    }
+
+    /**
+     * Decode command line args and perform the requested operations.
+     * @param args An array of args, such as might be supplied on the command line.
+     * @throws BadArgs if problems are found with any of the supplied args
+     * @throws Fault if exception problems are found while trying to compare the results
+     * @throws InterruptedException if the tool is interrupted while comparing the results
+     */
+    public final boolean run(String[] args) throws BadArgs, Fault, InterruptedException {
+        new OptionDecoder(options).decodeArgs(args);
+
+        if (superMode) {
+            if (fileArgs.size() != 1 || !fileArgs.get(0).isDirectory())
+                throw new Fault(i18n, "main.bad.super.dir");
+            if (format != null)
+                throw new Fault(i18n, "main.bad.super.format");
+            if (outFile == null)
+                throw new Fault(i18n, "main.no.output.dir");
+        }
+
+        return run();
+    }
+
+    private boolean run() throws Fault, InterruptedException {
+        if (fileArgs.isEmpty() && !superMode && help == null) {
+            help = new Help(options);
+            help.setCommandLineHelpQuery(null);
+        }
+
+        if (help != null) {
+            help.show(out);
+            return true;
+        }
+
+        Diff d;
+        if (superMode)
+            d = new SuperDiff(fileArgs.get(0));
+        else
+            d = new StandardDiff(fileArgs);
+
+        d.out = out;
+        d.includeReason = includeReason;
+        d.format = format;
+        d.title = title;
+
+        return d.report(outFile);
+    }
+
+    private static void exit(int exitCode) {
+        System.exit(exitCode);
+    }
+
+    private final PrintWriter out;
+    private final PrintWriter err;
+
+    private boolean includeReason;
+    private String format;
+    private String title;
+    private File outFile;
+    private final List<File> fileArgs = new ArrayList<>();
+    private boolean superMode;
+    private Help help;
+
+    private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Main.class);
+}

--- a/src/share/classes/com/sun/javatest/diff/MultiMap.java
+++ b/src/share/classes/com/sun/javatest/diff/MultiMap.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * A Map from a key to a possibly sparse array of values.
+ */
+public class MultiMap<K, V> implements Map<K, MultiMap.Entry<V>> {
+    public static class Entry<V> {
+
+        private Entry(MultiMap<?, ?> t) {
+            table = t;
+        }
+
+        V get(int index) {
+            return (index < list.size() ? list.get(index) : null);
+        }
+
+        int getSize() {
+            return table.getColumns();
+        }
+
+        void put(int index, V value) {
+            if (index >= table.getColumns())
+                throw new IndexOutOfBoundsException();
+
+            if (list == null)
+                list = new ArrayList<>(index);
+
+            if (index < list.size())
+                list.set(index, value);
+            else {
+                while (index > list.size())
+                    list.add(null);
+                list.add(value);
+            }
+        }
+
+        boolean allEqual(Comparator<V> c) {
+            if (list.size() == 0)
+                return true;
+            int size = table.getColumns();
+            V v0 = list.get(0);
+            for (int i = 1; i < size; i++) {
+                V v = get(i);
+                if (c.compare(v, v0) != 0)
+                    return false;
+            }
+            return true;
+        }
+
+        private List<V> list;
+        private MultiMap<?, ?> table;
+    }
+
+    /** Creates a new instance of MultiMap */
+    public MultiMap() {
+        names = new ArrayList<>();
+        map = new TreeMap<>();
+    }
+
+    int getColumns() {
+        return names.size();
+    }
+
+    String getColumnName(int index) {
+        return names.get(index);
+    }
+
+    int addColumn(String name) {
+        names.add(name);
+        return names.size() - 1;
+    }
+
+    void addColumn(String name, Map<K, V> map) {
+        addColumn(name, map.entrySet());
+    }
+
+    void addColumn(String name, Iterable<Map.Entry<K, V>> iter) {
+        int index = addColumn(name);
+        for (Map.Entry<K, V> e: iter)
+            addRow(index, e.getKey(), e.getValue());
+    }
+
+    void addRow(int index, K k, V v) {
+        Entry<V> de = get(k);
+        if (de == null)
+            put(k, de = new Entry<>(this));
+        de.put(index, v);
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public Entry<V> get(Object path) {
+        return map.get(path);
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    public Entry<V> put(K key, Entry<V> value) {
+        return map.put(key, value);
+    }
+
+    public Entry<V> remove(Object key) {
+        return map.remove(key);
+    }
+
+    public void putAll(Map<? extends K, ? extends Entry<V>> t) {
+        map.putAll(t);
+    }
+
+    public void clear() {
+        map.clear();
+    }
+
+    public Set<Map.Entry<K, Entry<V>>> entrySet() {
+        return map.entrySet();
+    }
+
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    public Collection<Entry<V>> values() {
+        return map.values();
+    }
+
+    private List<String> names;
+    private TreeMap<K, Entry<V>> map;
+}

--- a/src/share/classes/com/sun/javatest/diff/ReportReader.java
+++ b/src/share/classes/com/sun/javatest/diff/ReportReader.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import com.sun.javatest.Status;
+import com.sun.javatest.TestDescription;
+import com.sun.javatest.TestResult;
+import com.sun.javatest.util.I18NResourceBundle;
+
+/**
+ * Read a set of test results from summary.txt, possibly located in a
+ * report directory.
+ */
+public class ReportReader implements DiffReader {
+    private static final String SUMMARY_TXT = "summary.txt";
+
+    public static boolean accepts(File f) {
+        if (!f.exists())
+            return false;
+
+        if (f.isFile() && f.getName().equals(SUMMARY_TXT))
+            return true;
+
+        if (f.isDirectory() && new File(f, SUMMARY_TXT).exists())
+            return true;
+
+        if (f.isDirectory() && new File(new File(f, "text"), SUMMARY_TXT).exists())
+            return true;
+
+        return false;
+    }
+
+    /** Creates a new instance of SummaryReader */
+    public ReportReader(File file) {
+        this.file = file;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public String getFileType() {
+        if (file != null && file.isDirectory())
+            return i18n.getString("report.reportDir");
+        else
+            return i18n.getString("report.reportFile");
+    }
+
+    public File getWorkDirectory() {
+        return null;
+    }
+
+    public Iterator<TestResult> iterator() {
+        return readSummary().iterator();
+    }
+
+    private List<TestResult> readSummary() {
+        List<TestResult> list = new ArrayList<>();
+        File root = getRoot();
+        File f;
+        if (file.isFile() && file.getName().equals(SUMMARY_TXT))
+            f = file;
+        else if (file.isDirectory() && new File(file, SUMMARY_TXT).exists())
+            f = new File(file, SUMMARY_TXT);
+        else if (file.isDirectory() && new File(new File(file, "text"), SUMMARY_TXT).exists())
+            f = new File(new File(file, "text"), SUMMARY_TXT);
+        else
+            throw new IllegalStateException();
+
+        try {
+            BufferedReader in = new BufferedReader(new FileReader(f));
+            String line;
+            while ((line = in.readLine()) != null) {
+                int sp = line.indexOf(' ');
+                String t = line.substring(0, sp);
+                Status s = Status.parse(line.substring(sp).trim());
+                TestDescription td = new TestDescription(root, new File(t), Collections.emptyMap());
+                TestResult tr = new TestResult(td, s);
+                list.add(tr);
+            }
+        } catch (IOException e) {
+        }
+        return list;
+    }
+
+    private File getRoot() {
+        return UNKNOWN;
+    }
+
+    private static File UNKNOWN = new File("unknown");
+
+    private File file;
+
+    private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(WorkDirectoryReader.class);
+}

--- a/src/share/classes/com/sun/javatest/diff/Reporter.java
+++ b/src/share/classes/com/sun/javatest/diff/Reporter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import com.sun.javatest.TestResult;
+
+
+/**
+ * Interface for generating reports.
+ */
+public abstract class Reporter {
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Comparator<TestResult> getComparator() {
+        return comparator;
+    }
+
+    public void setComparator(Comparator<TestResult> c) {
+        this.comparator = c;
+    }
+
+    public void setReaders(List<DiffReader> readers) {
+        this.readers = readers;
+    }
+
+    public void setTestCounts(List<int[]> testCounts) {
+        this.testCounts = testCounts;
+    }
+
+    public int getDiffCount() {
+        return diffs;
+    }
+
+    abstract void write(MultiMap<String, TestResult> table) throws IOException;
+
+    protected List<DiffReader> readers;
+    protected List<int[]> testCounts = new ArrayList<>();
+    protected Comparator<TestResult> comparator;
+    protected String title;
+    protected int diffs;
+}

--- a/src/share/classes/com/sun/javatest/diff/SimpleReporter.java
+++ b/src/share/classes/com/sun/javatest/diff/SimpleReporter.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// TODO: colorize output?
+
+package com.sun.javatest.diff;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+import com.sun.javatest.Status;
+import com.sun.javatest.TestResult;
+import com.sun.javatest.util.I18NResourceBundle;
+
+/**
+ * Write simple reports to a text file.
+ */
+public class SimpleReporter extends Reporter {
+
+    /**
+     * Creates a new instance of SimpleReporter
+     */
+    public SimpleReporter(PrintWriter out) {
+        if (out == null)
+            throw new NullPointerException();
+
+        this.out = out;
+
+        statusStrings = new String[4];
+        statusStrings[Status.PASSED] = i18n.getString("simple.pass");
+        statusStrings[Status.FAILED] = i18n.getString("simple.fail");
+        statusStrings[Status.ERROR] = i18n.getString("simple.error");
+        statusStrings[Status.NOT_RUN] = i18n.getString("simple.notRun");
+        for (String ss: statusStrings)
+            maxStatusStringLength = Math.max(maxStatusStringLength, ss.length());
+    }
+
+    public void write(MultiMap<String, TestResult> table) throws IOException {
+        this.table = table;
+        size = table.getColumns();
+
+        if (title != null) {
+            println(title);
+            println();
+        }
+
+        writeHead();
+        writeBody();
+        writeSummary();
+    }
+
+    private void writeHead() throws IOException {
+        for (int i = 0; i < size; i++) {
+            int[] c = testCounts.get(i);
+            int passed = c[Status.PASSED];
+            int failed = c[Status.FAILED];
+            int error = c[Status.ERROR];
+            int notRun = c[Status.NOT_RUN];
+            writeI18N("simple.set", i, table.getColumnName(i));
+            print("  ");
+            writeI18N("simple.counts",
+                    passed,
+                    (passed > 0) && (failed + error + notRun > 0) ? 1 : 0,
+                    failed,
+                    (failed > 0) && (error + notRun > 0) ? 1 : 0,
+                    error,
+                    (error > 0) && (notRun > 0) ? 1 : 0,
+                    notRun);
+            println();
+        }
+    }
+
+    private void writeBody() throws IOException {
+        diffs = 0;
+        for (Map.Entry<String, MultiMap.Entry<TestResult>> e: table.entrySet()) {
+            String testName = e.getKey();
+            MultiMap.Entry<TestResult> result = e.getValue();
+            if (result.allEqual(comparator))
+                continue;
+            if (diffs == 0) {
+                println();
+                for (int i = 0; i < result.getSize(); i++) {
+                    print(String.valueOf(i), maxStatusStringLength + 2);
+                }
+                writeI18N("simple.test");
+                println();
+            }
+            for (int i = 0; i < result.getSize(); i++) {
+                TestResult tr = result.get(i);
+                Status s = (tr == null ? null : tr.getStatus());
+                print(getStatusString(s), maxStatusStringLength + 2);
+            }
+            println(testName);
+            diffs++;
+        }
+    }
+
+    private void writeSummary() throws IOException {
+        println();
+        if (diffs == 0)
+            writeI18N("simple.diffs.none");
+        else
+            writeI18N("simple.diffs.count", diffs);
+        println();
+    }
+
+    private void writeI18N(String key, Object... args) throws IOException {
+        print(i18n.getString(key, args));
+    }
+
+    private void print(Object o) throws IOException {
+        out.print(o.toString());
+    }
+
+    private void print(String s, int width) throws IOException {
+        out.print(s);
+        for (int i = s.length(); i < width; i++)
+            out.print(' ');
+    }
+
+    private void println() throws IOException {
+        out.println();
+    }
+
+    private void println(Object o) throws IOException {
+        out.println(o.toString());
+    }
+
+    private String getStatusString(Status s) {
+        return statusStrings[s == null ? Status.NOT_RUN : s.getType()];
+    }
+
+    private MultiMap<String, TestResult> table;
+    private int size;
+    private PrintWriter out;
+
+    private String[] statusStrings;
+    private int maxStatusStringLength;
+
+    private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(SimpleReporter.class);
+}

--- a/src/share/classes/com/sun/javatest/diff/StandardDiff.java
+++ b/src/share/classes/com/sun/javatest/diff/StandardDiff.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.File;
+import java.util.List;
+
+public class StandardDiff extends Diff {
+    StandardDiff(List<File> files) {
+        this.files = files;
+    }
+
+    @Override
+    public boolean report(File outFile) throws Fault, InterruptedException {
+        return diff(files, outFile);
+    }
+
+    List<File> files;
+}

--- a/src/share/classes/com/sun/javatest/diff/StatusComparator.java
+++ b/src/share/classes/com/sun/javatest/diff/StatusComparator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.util.Comparator;
+
+import com.sun.javatest.Status;
+import com.sun.javatest.TestResult;
+
+/**
+ * A comparator for the status contained in a test result.
+ */
+public class StatusComparator implements Comparator<TestResult> {
+
+    /** Creates a new instance of StatusComparator */
+    public StatusComparator() {
+    }
+
+    /** Creates a new instance of StatusComparator */
+    public StatusComparator(boolean includeReason) {
+        this.includeReason = includeReason;
+    }
+
+    public int compare(TestResult o1, TestResult o2) {
+        int t1 = getType(o1);
+        int t2 = getType(o2);
+
+        if (t1 < t2)
+            return -1;
+
+        if (t1 > t2)
+            return +1;
+
+        if (!includeReason)
+            return 0;
+
+        String r1 = getReason(o1);
+        String r2 = getReason(o2);
+        return r1.compareTo(r2);
+    }
+
+    private static int getType(TestResult tr) {
+        if (tr == null)
+            return Status.NOT_RUN;
+        Status s = tr.getStatus();
+        return (s == null ? Status.NOT_RUN : s.getType());
+    }
+
+    private static String getReason(TestResult tr) {
+        if (tr == null)
+            return "";
+        Status s = tr.getStatus();
+        return (s == null ? "" : s.getReason());
+    }
+
+    private boolean includeReason;
+}

--- a/src/share/classes/com/sun/javatest/diff/SuperDiff.java
+++ b/src/share/classes/com/sun/javatest/diff/SuperDiff.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import com.sun.javatest.util.I18NResourceBundle;
+
+import static com.sun.javatest.util.HTMLWriter.*;
+
+class SuperDiff extends Diff {
+    SuperDiff(File dir) {
+        table = new SuperTable(dir, resultPath);
+    }
+
+    @Override
+    public boolean report(File outDir) throws Fault, InterruptedException {
+        baseTitle = title;
+        boolean ok = true;
+        for (YearDay yearDay: table.getRecentKeys(historySize))
+            ok &= diffPlatforms(yearDay, outDir);
+        for (String platform : table.platforms) {
+            ok &= diffHistory(platform, outDir);
+        }
+        writeIndex(outDir, baseTitle);
+        return ok;
+    }
+
+    protected boolean diff(List<File> files, File outFile, String title) throws Fault, InterruptedException {
+        this.title = title;
+        reporter = null;
+        return diff(files, outFile);
+    }
+
+    @Override
+    protected void initReporter() throws Fault {
+        try {
+             reporter = new SuperReporter(out);
+        } catch (IOException e) {
+            throw new Fault(i18n, "main.cantOpenReport", e);
+        }
+    }
+
+    private boolean diffPlatforms(YearDay yearDay, File outDir) throws Fault, InterruptedException {
+        Map<String, File> pMap = table.get(yearDay);
+        List<File> pDirs = new ArrayList<>();
+        for (String platform : table.platforms) {
+            File dir = pMap.get(platform);
+            if (dir != null) {
+                pDirs.add(dir);
+            }
+        }
+        File file = new File(outDir, yearDay.year + "_" + yearDay.dayOfYear + ".html");
+        platformIndex.put(yearDay.toDateString(monthDayFormat), file);
+        String prefix = baseTitle == null ? "" : baseTitle + ": ";
+        return diff(pDirs, file, prefix + yearDay.toDateString(mediumDateFormat)); // I18N a better title?
+    }
+
+    private boolean diffHistory(String platform, File outDir) throws Fault, InterruptedException {
+        List<File> pDirs = new ArrayList<>();
+        for (YearDay yearDay: table.getRecentKeys(historySize, platform)) {
+            pDirs.add(table.get(yearDay).get(platform));
+        }
+        File file = new File(outDir, platform + ".html");
+        historyIndex.put(platform, file);
+        String prefix = baseTitle == null ? "" : baseTitle + ": ";
+        return diff(pDirs, file, prefix + platform); // I18N a better title?
+    }
+
+    private void writeIndex(File outDir, String title) throws Fault {
+        PrintWriter out;
+        try {
+            out = new PrintWriter(new BufferedWriter(new FileWriter(new File(outDir, "index.html"))));
+        } catch (IOException e) {
+            throw new Fault(i18n, "main.cantOpenReport", e);
+        }
+
+        try {
+            SuperReporter r = new SuperReporter(out);
+            r.writeMainIndex(title);
+        } catch (IOException e) {
+            throw new Fault(i18n, "main.ioError", e);
+        } finally {
+            out.close();
+        }
+    }
+
+    protected String resultPath = System.getProperty("jtdiff.super.testResults", "JTreport/text/summary.txt");
+    protected int historySize = Integer.getInteger("jtdiff.super.history", 21);
+
+    private SuperTable table;
+    private String baseTitle;
+    private Map<String, File> historyIndex = new LinkedHashMap<>();
+    private Map<String, File> platformIndex = new LinkedHashMap<>();
+
+    private static DateFormat monthDayFormat = new SimpleDateFormat("MMM d");
+    private static DateFormat mediumDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM);
+    private static I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Main.class);
+
+    static class Info {
+        Info(String platform, Date date) {
+            this.platform = platform;
+            this.date = date;
+        }
+
+        final String platform;
+        final Date date;
+    }
+
+    class SuperReporter extends HTMLReporter {
+        SuperReporter(Writer out) throws IOException {
+            super(out);
+        }
+
+        protected void writeIndexTableInfoHeadings() throws IOException {
+            out.startTag(TH);
+            out.writeI18N("super.th.platform");
+            out.endTag(TH);
+            out.startTag(TH);
+            out.writeI18N("super.th.date");
+            out.endTag(TH);
+        }
+
+        protected void writeIndexTableInfoValues(String path) throws IOException {
+            Info info = table.getInfo(path);
+            out.startTag(TD);
+            if (info != null)
+                out.write(info.platform);
+            out.endTag(TD);
+            out.startTag(TD);
+            if (info != null)
+                out.write(monthDayFormat.format(info.date));
+            out.endTag(TD);
+        }
+
+        void writeMainIndex(String title) throws IOException {
+            startReport(title);
+
+            if (baseTitle != null) {
+                out.startTag(H1);
+                out.write(baseTitle);
+                out.endTag(H1);
+            }
+
+            writeMainIndexList(i18n.getString("super.platforms"), platformIndex);
+            writeMainIndexList(i18n.getString("super.history"), historyIndex);
+
+            endReport();
+        }
+
+        void writeMainIndexList(String head, Map<String, File> map) throws IOException {
+            out.startTag(H2);
+            out.write(head);
+            out.endTag(H2);
+            out.startTag(P);
+            String comma = "";
+            for (Map.Entry<String, File> e: map.entrySet()) {
+                out.write(comma);
+                out.startTag(A);
+                out.writeAttr(HREF, e.getValue().getName());
+                String nbsp = "";
+                for (String s: e.getKey().split(" ")) {
+                    out.writeEntity(nbsp);
+                    out.write(s);
+                    nbsp = "&nbsp;";
+                }
+                out.endTag(A);
+                comma = ", ";
+            }
+        }
+    }
+
+    @SuppressWarnings("serial")
+    static class SuperTable extends TreeMap<YearDay, Map<String, File>> {
+
+        SuperTable(File inDir, String resultPath) {
+            super();
+            for (File pDir : inDir.listFiles()) {
+                if (!pDir.isDirectory()) {
+                    continue;
+                }
+                for (File yDir : pDir.listFiles()) {
+                    if (!yDir.isDirectory()) {
+                        continue;
+                    }
+                    for (File dDir : yDir.listFiles()) {
+                        if (!dDir.isDirectory()) {
+                            continue;
+                        }
+                        File resultDir = new File(dDir, resultPath);
+                        if (resultDir.exists()) {
+                            add(pDir.getName(), yDir.getName(), dDir.getName(), resultDir);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void add(String platform, String year, String day, File dir) {
+            platforms.add(platform);
+            YearDay yd = new YearDay(year, day);
+            Map<String, File> pMap = get(yd);
+            if (pMap == null) {
+                pMap = new HashMap<>();
+                put(yd, pMap);
+            }
+            pMap.put(platform, dir);
+
+            Date date;
+            try {
+                Calendar c = Calendar.getInstance();
+                c.clear();
+                c.set(Calendar.YEAR, Integer.parseInt(year));
+                c.set(Calendar.DAY_OF_YEAR, Integer.parseInt(day));
+                date = c.getTime();
+            } catch (NumberFormatException e) {
+                date = null;
+            }
+            infoTable.put(dir.getPath(), new Info(platform, date));
+        }
+
+        List<YearDay> getRecentKeys(int n) {
+            return getRecentKeys(n, null);
+        }
+
+        List<YearDay> getRecentKeys(int n, String platform) {
+            LinkedList<YearDay> results = new LinkedList<>();
+            List<YearDay> keys = new ArrayList<>(keySet());
+            for (ListIterator<YearDay> iter = keys.listIterator(keys.size());
+                    iter.hasPrevious() && results.size() < n; ) {
+                YearDay key = iter.previous();
+                if (platform == null || get(key).get(platform) != null)
+                    results.addFirst(key);
+            }
+            return results;
+        }
+
+        Info getInfo(String path) {
+            return infoTable.get(path);
+        }
+
+        final Set<String> platforms = new TreeSet<>();
+        final Map<String, Info> infoTable = new HashMap<>();
+    }
+
+    static class YearDay implements Comparable<YearDay> {
+        YearDay(String year, String dayOfYear) {
+            year.getClass();
+            dayOfYear.getClass();
+            this.year = year;
+            this.dayOfYear = dayOfYear;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof YearDay))
+                return false;
+            YearDay ydo = (YearDay) o;
+            return year.equals(ydo.year) && dayOfYear.equals(ydo.dayOfYear);
+        }
+
+        @Override
+        public int hashCode() {
+            return year.hashCode() * 37 + dayOfYear.hashCode();
+        }
+
+        //@Override
+        public int compareTo(YearDay o) {
+            int c = compare(year, o.year);
+            return (c == 0 ? compare(dayOfYear, o.dayOfYear) : c);
+        }
+
+        public String toString() {
+            return year + ":" + dayOfYear;
+        }
+
+        public Date asDate() {
+            try {
+                Calendar c = Calendar.getInstance();
+                c.clear();
+                c.set(Calendar.YEAR, Integer.parseInt(year));
+                c.set(Calendar.DAY_OF_YEAR, Integer.parseInt(dayOfYear));
+                return c.getTime();
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        public String toDateString(DateFormat f) {
+            Date d = asDate();
+            return (d == null ? toString() : f.format(d));
+        }
+
+        private int compare(String left, String right) {
+            return left.compareTo(right);
+        }
+
+        final String year;
+        final String dayOfYear;
+    }
+
+}

--- a/src/share/classes/com/sun/javatest/diff/WorkDirectoryReader.java
+++ b/src/share/classes/com/sun/javatest/diff/WorkDirectoryReader.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javatest.diff;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Properties;
+
+import com.sun.javatest.TestResult;
+import com.sun.javatest.TestResultTable;
+import com.sun.javatest.TestSuite;
+import com.sun.javatest.WorkDirectory;
+import com.sun.javatest.regtest.config.RegressionTestSuite;
+import com.sun.javatest.util.I18NResourceBundle;
+
+/**
+ * Read test results from a work directory.
+ */
+public class WorkDirectoryReader implements DiffReader {
+    public static boolean accepts(File f) {
+        return WorkDirectory.isWorkDirectory(f);
+    }
+
+    /** Creates a new instance of WorkDirectoryReader */
+    public WorkDirectoryReader(File file)
+            throws FileNotFoundException, WorkDirectory.Fault, TestSuite.Fault {
+        this.file = file;
+
+        // Because regtest testsuites don't contain testsuite.jtt
+        // files, we can't use the standard WorkDirectory.open call.
+        File tsp = getTestSuitePath(file);
+        if (tsp != null && new File(tsp, "TEST.ROOT").exists()) {
+            TestSuite ts = new RegressionTestSuite(tsp, WorkDirectoryReader.this::error);
+            wd = WorkDirectory.open(file, ts);
+        } else
+            wd = WorkDirectory.open(file);
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public String getFileType() {
+        return i18n.getString("wd.name");
+    }
+
+    public File getWorkDirectory() {
+        return wd.getRoot();
+    }
+
+    public Iterator<TestResult> iterator() {
+        TestResultTable trt = wd.getTestResultTable();
+        trt.waitUntilReady();
+        return trt.getIterator();
+    }
+
+    private static File getTestSuitePath(File workDir) {
+        File f = new File(new File(workDir, "jtData"), "testsuite");
+        if (!f.exists())
+            return null;
+
+        InputStream in = null;
+        try {
+            in = new BufferedInputStream(new FileInputStream(f));
+            Properties p = new Properties();
+            p.load(in);
+            in.close();
+            String ts = p.getProperty("root");
+            return (ts == null ? null : new File(ts));
+        } catch (IOException e) {
+            try {
+                if (in != null)
+                    in.close();
+            } catch (IOException ignore) {
+            }
+            return null;
+        }
+    }
+
+    private void error(String msg) {
+        System.err.println("Error: " + msg);
+    }
+
+    private final File file;
+    private final WorkDirectory wd;
+
+    private static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(WorkDirectoryReader.class);
+}

--- a/src/share/classes/com/sun/javatest/diff/i18n.properties
+++ b/src/share/classes/com/sun/javatest/diff/i18n.properties
@@ -1,0 +1,150 @@
+#
+# Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+diff.cantOpenFile=Cannot open file {0}: {1}
+diff.cantOpenReport=Cannot open report: {0}
+diff.ioError=Error: {0}
+
+help.cmd.ant=jtdiff can also be run with Ant.
+help.cmd.fullHead=
+help.cmd.introHead=For brief details about a topic, use "-help <term> ...". \
+    The argument <term> is a command option or other word related to the topic. \
+    Use "-help all" to show all of the help entries.\n\nInformation is \
+    available for the following topics.\n
+help.cmd.noEntriesFound=No entries were found that matched your query.
+help.cmd.proto=Usage:\n\t{0} options... [directory|file]...
+help.cmd.summaryHead=Information is available for the following topics:
+help.cmd.tail=
+help.copyright.txt=Copyright (c) 2008, 2013 Oracle and/or its affiliates. \
+    All rights reserved.\nUse is subject to license terms.
+
+help.compare.name=Compare Options
+help.compare.desc=
+help.compare.r.desc=Include the reason string in the comparison, as well as \
+    the type (i.e. Passed, Failed, etc.)
+help.compare.s.desc=Perform a "super-diff" looking for result sets within \
+    a directory hierarchy. The hierarchy must be arranged as \
+    follows: PATH/PLATFORM/YEAR/DAY_OF_YEAR/TEST_RESULTS, where PATH is \
+    given by the single directory argument, PLATFORM is the name of the \
+    platform on which the tests were run, YEAR and DAY_OF_YEAR are numbers \
+    identifying when the tests were run, and TESTSUITE_RESULTS is a fixed string \
+    identifying when to find the result set in the hierarchy. The default \
+    is "JTreport/text/summary.txt", but it can be set to a different value by \
+    setting the system property "jtdiff.super.testResults". It may identify any \
+    source of results acceptable to a standard invocation of jtdiff. \
+    Set system property jtdiff.html.compact=true for a more output format, with \
+    symbols replacing the words "pass" (check mark), "fail" (cross), "error" \
+    (cross in a circle), and "not run" (horizontal bar).
+
+help.doc.name=Help Options
+help.doc.desc=Options for additional help and information
+help.doc.h.arg=[words...]
+help.doc.h.desc=Command line help. Give words to see help info containing those \
+    or use "-help all" to see all available help.
+help.doc.version.desc=Give information about the version of jtdiff in use.
+
+help.files.name=Input Files
+help.files.desc=Input files can be any of work directories, report directories, \
+    or the summary.txt files in a report directory.
+
+help.output.name=Output Options
+help.output.desc=Options to customize the output
+help.output.format.arg=html|text
+help.output.format.desc=Output format. If not specified, it is inferred from the \
+    extension of the output file.
+help.output.o.arg=<file>
+help.output.o.desc=File to which to write the results
+help.output.title.arg=<string>
+help.output.title.desc=Title to use for the results
+
+help.version.txt={0}, version {1} {2} {3}\nInstalled in {4}\nRunning on platform version {5} from {6}.\nBuilt with {7} on {8}.
+help.version.unknown=(unknown)
+
+html.diffs.count={0} differences
+html.diffs.none=No differences
+html.generatedAt=Generated at {0}
+html.error=error
+html.fail=fail
+html.notRun=not run
+html.pass=pass
+html.error.compact=&otimes;
+html.fail.compact=&times;
+html.notRun.compact=&mdash;
+html.pass.compact=&radic;
+
+html.head.differences=Differences
+html.head.notitle=jtdiff results
+html.head.sets=Test Result Sets
+html.head.title=jtdiff results: {0}
+
+html.th.location=Location
+html.th.set=Set
+html.th.setN=Set {0}
+html.th.test=Test
+html.th.error=Errors
+html.th.fail=Failed
+html.th.notRun=Not Run
+html.th.pass=Passed
+html.th.total=Total
+html.th.type=Type
+
+main.badArgs=Error: {0}
+main.bad.super.dir=Bad directory argument for "super" mode
+main.bad.super.format=Cannot specify format in "super" mode
+main.cantFindFile=Cannot find file: {0}
+main.cantOpenFile=Cannot open file {0}: {1}
+main.cantOpenReport=Cannot open report: {0}
+main.diffsFound=Differences found.
+main.error=Error: {0}
+main.interrupted=Error: Interrupted!
+main.ioError=Error: {0}
+main.no.output.dir=No output directory given; use -o dir
+main.unexpectedException=Error: Unexpected exception occured!
+main.unrecognizedFile=File not recognized: {0}
+
+report.reportDir=Report Drectory
+report.reportFile=Report File
+
+simple.diffs.count={0} differences
+simple.diffs.none=No differences
+simple.set={0}: {1}
+simple.test=Test
+simple.error=error
+simple.fail=fail
+simple.notRun=---
+simple.pass=pass
+
+simple.counts=\
+    {0,choice,0#|0<pass: {0,number}}{1,choice,0#|1#; }\
+    {2,choice,0#|0<fail: {2,number}}{3,choice,0#|1#; }\
+    {4,choice,0#|0<error: {4,number}}{5,choice,0#|1#; }\
+    {6,choice,0#|0<not run: {6,number}}
+
+wd.name=Work Directory
+
+super.history=Comparison of recent results by platform
+super.platforms=Comparison across platforms by date
+super.th.date=Date
+super.th.platform=Platform

--- a/test/6783039/T6783039.gmk
+++ b/test/6783039/T6783039.gmk
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#----------------------------------------------------------------------
+
+$(BUILDTESTDIR)/T6783039.ok: \
+	$(JTREG_IMAGEDIR)/lib/javatest.jar \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar
+	$(RM) $(BUILDTESTDIR)/6783039/
+	for p in p1 p2 ; do for y in 2007 2008 ; do for d in 1 2 3 ; do \
+	    mkdir -p $(BUILDTESTDIR)/6783039/$$p/$$y/$$d/JTreport/text/ ; touch $(BUILDTESTDIR)/6783039/$$p/$$y/$$d/JTreport/text/summary.txt ; \
+	done ; done ; done
+	$(JDKJAVA) -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar com.sun.javatest.diff.Main \
+		$(BUILDTESTDIR)/6783039/*/*/*/JTreport/text/summary.txt > $(BUILDTESTDIR)/6783039/stdout
+	$(JDKJAVA) -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar com.sun.javatest.diff.Main \
+		-o $(BUILDTESTDIR)/6783039/out.txt $(BUILDTESTDIR)/6783039/*/*/*/JTreport/text/summary.txt
+	diff $(BUILDTESTDIR)/6783039/stdout $(BUILDTESTDIR)/6783039/out.txt
+	mkdir $(BUILDTESTDIR)/6783039/super
+	$(JDKJAVA) -cp $(JTREG_IMAGEDIR)/lib/jtreg.jar com.sun.javatest.diff.Main \
+		-o $(BUILDTESTDIR)/6783039/super -super $(BUILDTESTDIR)/6783039/
+	if [ `find $(BUILDTESTDIR)/6783039/super -name \*.html | wc -l` != 9 ]; then \
+		echo "super output not as expected" ; exit 1 ; \
+	fi
+	echo $@ passed at `date` > $@
+
+TESTS.jtdiff += $(BUILDTESTDIR)/T6783039.ok

--- a/test/i18n/i18n.com.sun.javatest.diff.gmk
+++ b/test/i18n/i18n.com.sun.javatest.diff.gmk
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#----------------------------------------------------------------------
+
+$(BUILDTESTDIR)/i18n.com.sun.javatest.diff.ok: \
+		$(JAVAFILES.com.sun.javatest.diff) \
+		$(JAVADIR)/com/sun/javatest/diff/i18n.properties \
+		$(BUILDDIR)/classes.com.sun.javatest.diff.ok \
+		$(TESTDIR)/i18n/checkI18NProps.sh
+	$(MKDIR) -p $(@:%.ok=%)
+	CLASSPATH="$(CLASSDIR)$(PS)$(JAVADIR)$(PS)$(JAVATEST_JAR)" \
+		$(JDKJAVA) -Djavatest.i18n.log=com.sun.javatest.diff \
+			com.sun.javatest.diff.Main -help all \
+			> $(@:%.ok=%/i18n-log.txt) 2>&1
+	$(SH) $(TESTDIR)/i18n/checkI18NProps.sh $(@:%.ok=%) $(JAVADIR)/com/sun/javatest/diff $(@:%.ok=%/i18n-log.txt)
+	echo $@ passed at `date` > $@
+
+TESTS.jtdiff += $(BUILDTESTDIR)/i18n.com.sun.javatest.diff.ok


### PR DESCRIPTION
This reverts commit a8698b72b3695778c946752fe22c1f6fadfbe936.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903760](https://bugs.openjdk.org/browse/CODETOOLS-7903760): Revert "7903622: Remove support for `jtdiff`" (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.org/jtreg.git pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/209.diff">https://git.openjdk.org/jtreg/pull/209.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/209#issuecomment-2188545593)