### PR TITLE
7903763: [jtreg] grep: /proc/version: No such file or directory

### DIFF
--- a/src/share/bin/jtreg.sh
+++ b/src/share/bin/jtreg.sh
@@ -65,7 +65,7 @@
 
 case "`uname -s`" in
     CYGWIN* ) cygwin=1 ;;
-    Linux ) if grep -qi Microsoft /proc/version ; then wsl=1 ; fi ;;
+    Linux ) if test -f /proc/version && grep -qi Microsoft /proc/version ; then wsl=1 ; fi ;;
 esac
 
 # Determine jtreg installation directory

--- a/src/share/bin/jtreg.sh
+++ b/src/share/bin/jtreg.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,
In rpmbuild mock enviroment, there is not `/proc/version` file, `jtreg -version` command will print `grep: /proc/version: No such file or directory` message.
This PR add check the file `/proc/version` exists or not before execute command `grep /proc/version`
The change has been verified locally, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903763](https://bugs.openjdk.org/browse/CODETOOLS-7903763): [jtreg] grep: /proc/version: No such file or directory (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [fcfd90b7](https://git.openjdk.org/jtreg/pull/210/files/fcfd90b709f154ff39915cd8ced11df5a31816cb)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/210/head:pull/210` \
`$ git checkout pull/210`

Update a local copy of the PR: \
`$ git checkout pull/210` \
`$ git pull https://git.openjdk.org/jtreg.git pull/210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 210`

View PR using the GUI difftool: \
`$ git pr show -t 210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/210.diff">https://git.openjdk.org/jtreg/pull/210.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/210#issuecomment-2191643831)