### PR TITLE
7903765: wget failed in build.sh in jtreg

### DIFF
--- a/make/build-support/build-common.sh
+++ b/make/build-support/build-common.sh
@@ -106,7 +106,7 @@ download_using_wget() {
     check_arguments "${FUNCNAME}" 2 $#
 
     local url="$1"
-    local destfile="$2"
+    local destfile=`realpath "$2"`
 
     set +e
     "${WGET}" ${WGET_OPTIONS} "${url}" -O "${destfile}"


### PR DESCRIPTION
I tried to build jtreg, but it failed as following:

```
$ bash make/build.sh --jdk /usr/lib/jvm/java-22-ope
njdk
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/java-22-openjdk
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/ysuenaga/github-forked/jtreg/make/../build/deps/apache-ant-1.10.8-bin.zip
[build.sh][ERROR] wget exited with exit code 1
```

I tried it on Fedora 40, wget is from wget2-wget-2.1.0-9.fc40.x86_64 . Related path seems not to be accepted in this version at least.