### PR TITLE
7903780: NPE in new code for LIBRARY.properties

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -55,6 +55,8 @@ import com.sun.javatest.regtest.agent.ActionHelper;
 import com.sun.javatest.regtest.agent.Flags;
 import com.sun.javatest.regtest.agent.SearchPath;
 import com.sun.javatest.regtest.config.ExecMode;
+import com.sun.javatest.regtest.config.LibraryProperties;
+import com.sun.javatest.regtest.config.Locations;
 import com.sun.javatest.regtest.config.Modules;
 import com.sun.javatest.regtest.config.OS;
 import com.sun.javatest.regtest.config.ParseException;
@@ -694,6 +696,13 @@ public abstract class Action extends ActionHelper {
             }
         }
         return false;
+    }
+
+    protected boolean usesLibraryCompiledWithPreviewEnabled() {
+        return script.locations.getLibs().stream()
+                .filter(Locations.LibLocn::isLibrary)
+                .map(LibraryProperties::of) // cache library properties object in LibLocn ?
+                .anyMatch(LibraryProperties::isEnablePreview);
     }
 
     //----------misc statics----------------------------------------------------

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -59,7 +59,6 @@ import com.sun.javatest.regtest.agent.SearchPath;
 import com.sun.javatest.regtest.config.ExecMode;
 import com.sun.javatest.regtest.config.JDK;
 import com.sun.javatest.regtest.config.JDKOpts;
-import com.sun.javatest.regtest.config.LibraryProperties;
 import com.sun.javatest.regtest.config.Locations;
 import com.sun.javatest.regtest.config.Locations.LibLocn;
 import com.sun.javatest.regtest.config.Modules;
@@ -366,11 +365,13 @@ public class CompileAction extends Action {
 
         var needsEnablePreview = script.enablePreview() || usesLibraryCompiledWithPreviewEnabled();
 
-        if (runJavac && needsEnablePreview && !seenEnablePreview && libLocn.isTest()) {
+        if (runJavac && needsEnablePreview && !seenEnablePreview
+                && (libLocn == null || libLocn.isTest())) {
             javacArgs.add(insertPos, "--enable-preview");
             if (!seenSourceOrRelease) {
                 int v = script.getTestJDKVersion().major;
-                javacArgs.add(insertPos + 1, "--source=" + v);
+                javacArgs.add(insertPos + 1, "-source");
+                javacArgs.add(insertPos + 2, String.valueOf(v));
             }
         }
 
@@ -418,13 +419,6 @@ public class CompileAction extends Action {
     } // run()
 
     //----------internal methods------------------------------------------------
-
-    private boolean usesLibraryCompiledWithPreviewEnabled() {
-        return script.locations.getLibs().stream()
-                .filter(LibLocn::isLibrary)
-                .map(LibraryProperties::of) // cache library properties object in LibLocn ?
-                .anyMatch(LibraryProperties::isEnablePreview);
-    }
 
     private Status jasm(List<String> files) {
         return asmtools("jasm", files);

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -231,7 +231,8 @@ public class MainAction extends Action
                 throw new ParseException(PARSE_SECURE_OTHERVM);
         }
 
-        if (script.enablePreview() && !seenEnablePreview) {
+        boolean needsEnablePreview = script.enablePreview() || usesLibraryCompiledWithPreviewEnabled();
+        if (needsEnablePreview && !seenEnablePreview) {
             testJavaArgs.add("--enable-preview");
             if (!othervm) {
                 // ideally, this should not force othervm mode, but just allow


### PR DESCRIPTION
As well as the NPE, the following additional minor issues were fixed:

`--source` is a recent addition for `javac` options; older versions of `javac` still require `-source N`

`--enable-preview` is required at runtime if any library uses preview features.
For now, I just moved `usesLibraryCompiledWithPreviewEnabled` from `CompileAction` up into `Action`, so that it can be used from `MainAction`. We might want to consider merging the merging into `RegressionScript.enablePreview`, but that can be done when we clean up the use of `LIBRARY.properties`, caching the results in `LibLocn`.

We should also investigate the difference between `libLocn == null` and `libLocn.isTest()` 

After this, all self-tests pass, including the recently new tests for `LIBRARY.properties`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903780](https://bugs.openjdk.org/browse/CODETOOLS-7903780): NPE in new code for LIBRARY.properties (**Enhancement** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.org/jtreg.git pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/213.diff">https://git.openjdk.org/jtreg/pull/213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/213#issuecomment-2246067772)