### PR TITLE
7903765: wget failed in build.sh in jtreg

### DIFF
--- a/make/build-support/asmtools/build.sh
+++ b/make/build-support/asmtools/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ setup_asmtools_src() {
     check_arguments "${FUNCNAME}" 1 $#
 
     local dir="$1"
-
-    local ASMTOOLS_LOCAL_SRC_ARCHIVE="${dir}/../source.zip"
+    local src_archive_dir="$(builtin  cd ${dir}/..; pwd)"
+    local ASMTOOLS_LOCAL_SRC_ARCHIVE="${src_archive_dir}/source.zip"
     if [ "${ASMTOOLS_SRC_TAG}" = "tip" -o "${ASMTOOLS_SRC_TAG}" = "master" ]; then
         local BRANCH="master"
         get_archive_no_checksum "${CODE_TOOLS_URL_BASE}/asmtools/archive/${BRANCH}.zip" "${ASMTOOLS_LOCAL_SRC_ARCHIVE}" "${dir}"
@@ -58,6 +58,7 @@ build_asmtools() {
     check_arguments "${FUNCNAME}" 0 $#
 
     local ASMTOOLS_SRC_DIR_BASE="${BUILD_DIR}/src"
+    mkdir -p "${ASMTOOLS_SRC_DIR_BASE}"
     setup_asmtools_src "${ASMTOOLS_SRC_DIR_BASE}"
 
     local ASMTOOLS_DIST="${BUILD_DIR}/build"

--- a/make/build-support/build-common.sh
+++ b/make/build-support/build-common.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -311,8 +311,8 @@ if [ -z "${log_module:-}" ]; then
     error "log_module not set in caller (line/file): $(caller)"
     exit 1
 fi
-
-ROOT="$(abspath ${ROOT:-${mydir}/..})"
+DEFAULT_ROOT="$(builtin cd ${mydir}/..; pwd)"
+ROOT="$(abspath ${ROOT:-${DEFAULT_ROOT}})"
 BUILD_DIR="$(abspath "${BUILD_DIR:-${ROOT}/build}")"
 DEPS_DIR="${BUILD_DIR}/deps"
 

--- a/make/build-support/jtharness/build.sh
+++ b/make/build-support/jtharness/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ setup_jtharness_source() {
     local dir="$1"
 
     # Build jtharness
-    local JTHARNESS_LOCAL_SRC_ARCHIVE="${dir}/../source.zip"
+    local src_archive_dir="$(builtin  cd ${dir}/..; pwd)"
+    local JTHARNESS_LOCAL_SRC_ARCHIVE="${src_archive_dir}/source.zip"
     if [ "${JTHARNESS_SRC_TAG}" = "tip" -o "${JTHARNESS_SRC_TAG}" = "master" ]; then
         local BRANCH="master"
         get_archive_no_checksum "${CODE_TOOLS_URL_BASE}/jtharness/archive/${BRANCH}.zip" "${JTHARNESS_LOCAL_SRC_ARCHIVE}" "${dir}"
@@ -61,6 +62,7 @@ build_jtharness() {
     check_arguments "${FUNCNAME}" 0 $#
 
     local JTHARNESS_SRC_DIR_BASE="${BUILD_DIR}/src"
+    mkdir -p "${JTHARNESS_SRC_DIR_BASE}"
     setup_jtharness_source "${JTHARNESS_SRC_DIR_BASE}"
 
     local JTHARNESS_DIST="${BUILD_DIR}/build"


### PR DESCRIPTION
Can I get a review of this change which proposes to address the issue noted in https://bugs.openjdk.org/browse/CODETOOLS-7903765? This is an alternative approach that we decided to take when reviewing the original PR for this issue https://github.com/openjdk/jtreg/pull/211.

In this change, when passing destination directories for downloading source archives of asmtools and jtharness, we pass the absolute path instead of paths containing relative path elements (like `../`). This change prevents `wget` running into an issue when dealing with destination directories containing `../` path element.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903765](https://bugs.openjdk.org/browse/CODETOOLS-7903765): wget failed in build.sh in jtreg (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.org/jtreg.git pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/214.diff">https://git.openjdk.org/jtreg/pull/214.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/214#issuecomment-2251947497)