### PR TITLE
7903781: Report the process id of the agent or other VM that was used for a jtreg action

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -578,7 +578,7 @@ public class Agent {
 
     /**
      * Returns the process id of the {@code AgentServer} with which this {@code Agent}
-     * communicates. Returns {@code -1} if the process id of the {@code AgentServer}
+     * communicates or {@code -1} if the process id of the {@code AgentServer}
      * couldn't be determined.
      *
      * @return the AgentServer's process id

--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -98,23 +98,6 @@ public class Agent {
     static final boolean showAgent = Flags.get("showAgent");
     static final boolean traceAgent = Flags.get("traceAgent");
 
-    // the following code here allows us to run jtreg on older
-    // JDKs where the pid() method is unavailable on the
-    // Process class. we use PID only for debug purposes and
-    // the inability to get the PID of a launched AgentServer
-    // is OK.
-    private static final long UNKNOWN_PID = -1;
-    private static final Method PID_METHOD;
-    static {
-        Method pidMethod = null;
-        try {
-            pidMethod = Process.class.getDeclaredMethod("pid"); // only available in Java 9+
-        } catch (Exception e) {
-            pidMethod = null;
-        }
-        PID_METHOD = pidMethod;
-    }
-
     /**
      * Start a JDK with given JVM options.
      */
@@ -180,7 +163,7 @@ public class Agent {
             env.clear();
             env.putAll(envVars);
             agentServerProcess = process = pb.start();
-            final long pid = getPid(process);
+            agentServerPid = ProcessUtils.getProcessId(process);
             copyAgentProcessStream("stdout", process.getInputStream());
             copyAgentProcessStream("stderr", process.getErrorStream());
 
@@ -190,7 +173,7 @@ public class Agent {
                 ss.setSoTimeout(ACCEPT_TIMEOUT);
                 log("Waiting up to " + ACCEPT_TIMEOUT + " milli seconds for a" +
                         " socket connection on port " + port +
-                        (pid != UNKNOWN_PID ? " from process " + pid : ""));
+                        (agentServerPid != -1 ? " from process " + agentServerPid : ""));
                 Socket s = ss.accept();
                 log("Received connection on port " + port + " from " + s);
                 s.setSoTimeout((int)(KeepAlive.READ_TIMEOUT * timeoutFactor));
@@ -594,6 +577,17 @@ public class Agent {
     }
 
     /**
+     * Returns the process id of the {@code AgentServer} with which this {@code Agent}
+     * communicates. Returns {@code -1} if the process id of the {@code AgentServer}
+     * couldn't be determined.
+     *
+     * @return the AgentServer's process id
+     */
+    long getAgentServerPid() {
+        return agentServerPid;
+    }
+
+    /**
      * Logs a message to the log file managed by the logger.
      *
      * @param message the message
@@ -620,17 +614,6 @@ public class Agent {
         out.println("[" + AgentServer.logDateFormat.format(new Date()) + "] Agent[" + getId() + "]: " + message);
     }
 
-    private static long getPid(final Process process) {
-        if (PID_METHOD == null) {
-            return UNKNOWN_PID;
-        }
-        try {
-            return (long) PID_METHOD.invoke(process);
-        } catch (Exception e) {
-            return UNKNOWN_PID;
-        }
-    }
-
     final JDK jdk;
     final List<String> vmOpts;
     final File execDir;
@@ -641,6 +624,7 @@ public class Agent {
     final int id;
     final Logger logger;
     Instant idleStartTime;
+    private final long agentServerPid;
 
     static int count;
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/AppletAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -296,6 +296,7 @@ public class AppletAction extends Action
 
             // RUN THE APPLET WRAPPER CLASS
             ProcessCommand cmd = new ProcessCommand();
+            cmd.setMessageWriter(section.getMessageWriter());
             cmd.setExecDir(script.absTestScratchDir().toFile());
 
             // Set the exit codes and their associated strings.  Note that we

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -644,6 +644,7 @@ public class CompileAction extends Action {
                 return new Status(aStatus.getType(), aStatus.getReason());
             }
         };
+        cmd.setMessageWriter(section.getMessageWriter());
 
         TimeoutHandler timeoutHandler =
             script.getTimeoutHandlerProvider().createHandler(this.getClass(), script, section);
@@ -703,6 +704,8 @@ public class CompileAction extends Action {
                     : script.getTestVMOptions();
             agent = script.getAgent(jdk, agentClasspath, vmOpts, null, null);
             section.getMessageWriter().println("Agent id: " + agent.getId());
+            final long pid = agent.getAgentServerPid();
+            section.getMessageWriter().println("Process id: " + ((pid == -1) ? "unknown" : pid));
             new ModuleConfig("Boot Layer (javac runtime environment)")
                     .setFromOpts(agent.vmOpts)
                     .write(configWriter);

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -518,6 +518,7 @@ public class MainAction extends Action
 
             // RUN THE MAIN WRAPPER CLASS
             ProcessCommand cmd = new ProcessCommand();
+            cmd.setMessageWriter(section.getMessageWriter());
             cmd.setExecDir(script.absTestScratchDir().toFile());
 
             // Set the exit codes and their associated strings.  Note that we
@@ -632,6 +633,8 @@ public class MainAction extends Action
                     factory,
                     script.getTestThreadFactoryPath());
             section.getMessageWriter().println("Agent id: " + agent.getId());
+            final long pid = agent.getAgentServerPid();
+            section.getMessageWriter().println("Process id: " + ((pid == -1) ? "unknown" : pid));
             new ModuleConfig("Boot Layer").setFromOpts(agent.vmOpts).write(configWriter);
         } catch (Agent.Fault e) {
             return error(AGENTVM_CANT_GET_VM + ": " + e.getCause());

--- a/src/share/classes/com/sun/javatest/regtest/exec/ProcessCommand.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ProcessCommand.java
@@ -216,6 +216,11 @@ public class ProcessCommand
         return timeoutHandler;
     }
 
+    ProcessCommand setMessageWriter(PrintWriter messageWriter) {
+        this.log = messageWriter;
+        return this;
+    }
+
     /**
      * Execute the command.
      * @return The result of the method is obtained by calling
@@ -239,6 +244,10 @@ public class ProcessCommand
                 pb.environment().putAll(env);
             }
             final Process process = pb.start();
+            if (log != null) {
+                final long pid = ProcessUtils.getProcessId(process);
+                log.println("Process id: " + ((pid == -1) ? "unknown" : pid));
+            }
             InputStream processIn = process.getInputStream();
             InputStream processErr = process.getErrorStream();
 
@@ -423,5 +432,6 @@ public class ProcessCommand
     private PrintWriter err;
     private long timeout;
     private TimeoutHandler timeoutHandler;
+    private PrintWriter log;
 }
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -296,6 +296,7 @@ public class ShellAction extends Action
 
                 // RUN THE SHELL SCRIPT
                 ProcessCommand cmd = new ProcessCommand()
+                    .setMessageWriter(section.getMessageWriter())
                     .setExecDir(script.absTestScratchDir().toFile())
                     .setCommand(command)
                     .setEnvironment(env)

--- a/src/share/classes/com/sun/javatest/regtest/util/ProcessUtils.java
+++ b/src/share/classes/com/sun/javatest/regtest/util/ProcessUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,20 +27,35 @@ package com.sun.javatest.regtest.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 /**
  * Utilities for handling Processes.
  */
 public class ProcessUtils {
 
-    private static Method destroyForciblyMethod;
+    private static final Method destroyForciblyMethod;
+    private static final Method PID_METHOD;
+
+    private static final long UNKNOWN_PID = -1;
 
     static {
+        Method destroyMethod;
         try {
-            destroyForciblyMethod = Process.class.getDeclaredMethod("destroyForcibly");
+            destroyMethod = Process.class.getDeclaredMethod("destroyForcibly");
         } catch (NoSuchMethodException e) {
             // expected on pre-1.8 JDKs
+            destroyMethod = null;
         }
+        destroyForciblyMethod = destroyMethod;
+
+        Method pidMethod = null;
+        try {
+            pidMethod = Process.class.getDeclaredMethod("pid"); // only available in Java 9+
+        } catch (NoSuchMethodException e) {
+            pidMethod = null;
+        }
+        PID_METHOD = pidMethod;
     }
 
     /**
@@ -65,5 +80,26 @@ public class ProcessUtils {
         // fallback
         process.destroy();
         return process;
+    }
+
+    /**
+     * Returns the process id of the {@code process}. If the process id cannot be determined
+     * or if there was some exception when determining the process id, then this method returns
+     * {@code -1}.
+     *
+     * @param process the process
+     * @throws NullPointerException if {@code process} is null
+     * @return the process id or -1
+     */
+    public static long getProcessId(Process process) {
+        Objects.requireNonNull(process);
+        if (PID_METHOD == null) {
+            return UNKNOWN_PID;
+        }
+        try {
+            return (long) PID_METHOD.invoke(process);
+        } catch (Exception e) {
+            return UNKNOWN_PID;
+        }
     }
 }

--- a/src/share/classes/com/sun/javatest/regtest/util/ProcessUtils.java
+++ b/src/share/classes/com/sun/javatest/regtest/util/ProcessUtils.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  */
 public class ProcessUtils {
 
-    private static final Method destroyForciblyMethod;
+    private static final Method DESTROY_FORCIBLY_METHOD;
     private static final Method PID_METHOD;
 
     private static final long UNKNOWN_PID = -1;
@@ -47,7 +47,7 @@ public class ProcessUtils {
             // expected on pre-1.8 JDKs
             destroyMethod = null;
         }
-        destroyForciblyMethod = destroyMethod;
+        DESTROY_FORCIBLY_METHOD = destroyMethod;
 
         Method pidMethod = null;
         try {
@@ -68,9 +68,9 @@ public class ProcessUtils {
      * @return the Process object
      */
     public static Process destroyForcibly(Process process) {
-        if (destroyForciblyMethod != null) {
+        if (DESTROY_FORCIBLY_METHOD != null) {
             try {
-                return (Process) destroyForciblyMethod.invoke(process);
+                return (Process) DESTROY_FORCIBLY_METHOD.invoke(process);
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             } catch (InvocationTargetException e) {

--- a/test/processid/Test.java
+++ b/test/processid/Test.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ */
+public class Test {
+    public static void main(String[] args) {
+    }
+}
+

--- a/test/processid/TestVersionCheck.gmk
+++ b/test/processid/TestVersionCheck.gmk
@@ -1,0 +1,39 @@
+#  Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#  This code is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 2 only, as
+#  published by the Free Software Foundation.
+#
+#  This code is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  version 2 for more details (a copy is included in the LICENSE file that
+#  accompanied this code).
+#
+#  You should have received a copy of the GNU General Public License version
+#  2 along with this work; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+#  or visit www.oracle.com if you need additional information or have any
+#  questions.
+
+# verify that the jtr file of a test execution
+# reports "Process id: " in each section messages of the jtreg action
+$(BUILDTESTDIR)/ReportProcessId.ok: \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) && $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/processid \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from JavaTest intentionally ignored"
+	num_occur=`$(GREP) -s 'Process id: ' -R $(@:%.ok=%/work/Test.jtr) | wc -l | xargs`; \
+		if [ "$$num_occur" != 2 ]; then echo "Unexpected number of \"Process id: \" occurrences: $$num_occur" ; exit 1 ; fi
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/ReportProcessId.ok


### PR DESCRIPTION
Can I please get a review of this change which proposes to repor the process id of the process that was used to run a jtreg action? This change addresses https://bugs.openjdk.org/browse/CODETOOLS-7903781.

As noted in that linked enhancement request, this change will report the process id  the `section` messages of each action. This will now look like:

```
#section:compile
----------messages:(7/297)----------
command: compile test/streams/FileDescriptorTest.java
reason: .class file out of date or does not exist
started: Fri Jul 26 00:56:01 UTC 2024
Mode: othervm
Process id: 88469
finished: Fri Jul 26 00:56:01 UTC 2024
elapsed time (seconds): 0.254

....

#section:main
----------messages:(7/232)----------
command: main FileDescriptorTest
reason: User specified action: run main FileDescriptorTest 
started: Fri Jul 26 00:56:01 UTC 2024
Mode: othervm
Process id: 88470
finished: Fri Jul 26 00:56:01 UTC 2024
elapsed time (seconds): 0.042
```
Notice the new "Process id: ..." line in those sections.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903781](https://bugs.openjdk.org/browse/CODETOOLS-7903781): Report the process id of the agent or other VM that was used for a jtreg action (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/jtreg.git pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/215.diff">https://git.openjdk.org/jtreg/pull/215.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/215#issuecomment-2252035339)