### PR TITLE
7901757: Race in counting total number of failures from TestNG

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.testng.IConfigurationListener;
@@ -104,8 +105,11 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
         testng.addListener(new XMLReporter());
         testng.setOutputDirectory(new File(".").getPath()); // current dir, i.e. scratch dir
         testng.run();
-        if (listener.configFailureCount > 0 || listener.failureCount > 0) {
-            throw new Exception("failures: " + listener.failureCount);
+        int configFailureCount = listener.configFailureCount.get();
+        int testFailureCount = listener.failureCount.get();
+        if (configFailureCount > 0 || testFailureCount > 0) {
+            throw new Exception("config failures: " + configFailureCount
+                    + ", test failures: " + testFailureCount);
         }
     }
 
@@ -113,13 +117,21 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
             implements ITestListener, IConfigurationListener {
         enum InfoKind { CONFIG, TEST }
 
+        private final AtomicInteger count = new AtomicInteger();
+        private final AtomicInteger successCount  = new AtomicInteger();
+        private final AtomicInteger failureCount = new AtomicInteger();
+        private final AtomicInteger skippedCount = new AtomicInteger();
+        private final AtomicInteger configSuccessCount = new AtomicInteger();
+        private final AtomicInteger configFailureCount = new AtomicInteger();
+        private final AtomicInteger configSkippedCount = new AtomicInteger();
+        private final AtomicInteger failedButWithinSuccessPercentageCount = new AtomicInteger();
         // keeps track of the test start time for each test
         private final Map<ITestResult, Long> startTimeNanos =
                 Collections.synchronizedMap(new IdentityHashMap<>());
 
         @Override
         public void onTestStart(ITestResult itr) {
-            count++;
+            count.incrementAndGet();
             // Although testng itself provides getStartMillis() and getEndMillis()
             // on ITestResult for duration tracking, the testng implementation uses
             // System.currentTimeMillis(). We instead prefer using System.nanoTime() API
@@ -129,13 +141,13 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void onTestSuccess(ITestResult itr) {
-            successCount++;
+            successCount.incrementAndGet();
             report(InfoKind.TEST, itr);
         }
 
         @Override
         public void onTestFailure(ITestResult itr) {
-            failureCount++;
+            failureCount.incrementAndGet();
             report(InfoKind.TEST, itr);
         }
 
@@ -146,13 +158,13 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
                 onTestFailure(itr);
                 return;
             }
-            skippedCount++;
+            skippedCount.incrementAndGet();
             report(InfoKind.TEST, itr);
         }
 
         @Override
         public void onTestFailedButWithinSuccessPercentage(ITestResult itr) {
-            failedButWithinSuccessPercentageCount++;
+            failedButWithinSuccessPercentageCount.incrementAndGet();
             report(InfoKind.TEST, itr);
         }
 
@@ -166,19 +178,19 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void onConfigurationSuccess(ITestResult itr) {
-            configSuccessCount++;
+            configSuccessCount.incrementAndGet();
             report(InfoKind.CONFIG, itr);
         }
 
         @Override
         public void onConfigurationFailure(ITestResult itr) {
-            configFailureCount++;
+            configFailureCount.incrementAndGet();
             report(InfoKind.CONFIG, itr);
         }
 
         @Override
         public void onConfigurationSkip(ITestResult itr) {
-            configSkippedCount++;
+            configSkippedCount.incrementAndGet();
             report(InfoKind.CONFIG, itr);
         }
 
@@ -255,15 +267,6 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
                     return "??";
             }
         }
-
-        int count;
-        int successCount;
-        int failureCount;
-        int skippedCount;
-        int configSuccessCount;
-        int configFailureCount;
-        int configSkippedCount;
-        int failedButWithinSuccessPercentageCount;
     }
 
     private static class FilterMethods implements IMethodInterceptor {

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -118,7 +118,7 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
         enum InfoKind { CONFIG, TEST }
 
         private final AtomicInteger count = new AtomicInteger();
-        private final AtomicInteger successCount  = new AtomicInteger();
+        private final AtomicInteger successCount = new AtomicInteger();
         private final AtomicInteger failureCount = new AtomicInteger();
         private final AtomicInteger skippedCount = new AtomicInteger();
         private final AtomicInteger configSuccessCount = new AtomicInteger();

--- a/test/testngFailureCount/FailingTest.java
+++ b/test/testngFailureCount/FailingTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.fail;
+
+/*
+ * @test
+ * @run testng/othervm -Ddataproviderthreadcount=4 FailingTest
+ */
+public class FailingTest {
+
+    @DataProvider(parallel = true)
+    public static Iterator<Object[]> integers() {
+        final List<Object[]> args = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            args.add(new Object[]{i});
+        }
+        return args.iterator();
+    }
+
+    @Test(dataProvider = "integers")
+    public void test(Integer arg) throws Exception {
+        TimeUnit.MILLISECONDS.sleep(100);
+        fail("failing intentionally for " + arg);
+    }
+}

--- a/test/testngFailureCount/TestngFailureCount.gmk
+++ b/test/testngFailureCount/TestngFailureCount.gmk
@@ -1,0 +1,38 @@
+#  Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#  This code is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 2 only, as
+#  published by the Free Software Foundation.
+#
+#  This code is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  version 2 for more details (a copy is included in the LICENSE file that
+#  accompanied this code).
+#
+#  You should have received a copy of the GNU General Public License version
+#  2 along with this work; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+#  or visit www.oracle.com if you need additional information or have any
+#  questions.
+
+# verify that the failure count is reported correctly when
+# testng executes multiple tests concurrently
+$(BUILDTESTDIR)/TestngFailureCount.ok: \
+	$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) && $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		$(TESTDIR)/testngFailureCount \
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+	    true "non-zero exit code from JavaTest intentionally ignored"
+	$(GREP) -s ' test failures: 10' $(@:%.ok=%/work/FailingTest.jtr)  > /dev/null
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/TestngFailureCount.ok


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/CODETOOLS-7901757?

As noted there, the current implementation in jtreg's testng test listener doesn't take into account that the callback methods on that listener instance can be invoked concurrently for different threads. As a result, the count tracking logic in the listener ends up in a race condition which results in reporting incorrect numbers.

The commit in this PR fixes that issue and introduces a self test which reproduces the race issue and verifies the fix. The new test and existing tests continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7901757](https://bugs.openjdk.org/browse/CODETOOLS-7901757): Race in counting total number of failures from TestNG (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/216/head:pull/216` \
`$ git checkout pull/216`

Update a local copy of the PR: \
`$ git checkout pull/216` \
`$ git pull https://git.openjdk.org/jtreg.git pull/216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 216`

View PR using the GUI difftool: \
`$ git pr show -t 216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/216.diff">https://git.openjdk.org/jtreg/pull/216.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/216#issuecomment-2252396201)