### PR TITLE
7903759: Amend changelog to include the removal of `jtdiff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,36 @@
 ## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-7.4+1...master)
 
-_nothing noteworthy, yet_
+* Restore `jtdiff` tool [CODETOOLS-7903760](https://bugs.openjdk.org/browse/CODETOOLS-7903760)
+
+* Add support for `LIBRARY.properties` file in the directory specified in the `@library` tag  [CODETOOLS-7903775](https://bugs.openjdk.org/browse/CODETOOLS-7903775)
+  > Set `enablePreview=true` in the `LIBRARY.properties` file in the root directory
+  > of the library (the directory specified in the `@library` tag.)
+  > Note that if a library uses preview features, any tests that use the library
+  > will be assumed to need preview features enabled as well.
+
+* The verbose option given at the command-line is now propagated to test agents, including the JUnit test runner.
+  [CODETOOLS-7903443](https://bugs.openjdk.org/browse/CODETOOLS-7903443)
+  [CODETOOLS-7903745](https://bugs.openjdk.org/browse/CODETOOLS-7903745)
+
+* Report test duration information in JUnit and TestNG-based tests
+  [CODETOOLS-7903752](https://bugs.openjdk.org/browse/CODETOOLS-7903752)
+  [CODETOOLS-7903753](https://bugs.openjdk.org/browse/CODETOOLS-7903753)
+
+* Improve message when test times out in Agent VM mode [CODETOOLS-7902346](https://bugs.openjdk.org/browse/CODETOOLS-7902346)
+
+* Log time spent waiting to acquire exclusive access lock [CODETOOLS-7903188](https://bugs.openjdk.org/browse/CODETOOLS-7903188)
+
+* Speed-up error reporting on hosts with slow hostname lookups [CODETOOLS-7903746](https://bugs.openjdk.org/browse/CODETOOLS-7903746)
 
 ## [7.4](https://git.openjdk.org/jtreg/compare/jtreg-7.3.1+1...jtreg-7.4+1)
+
+* Remove support for `jtdiff` [CODETOOLS-7903622](https://bugs.openjdk.org/browse/CODETOOLS-7903622)
 
 * jtreg now verifies ProblemList files [CODETOOLS-7903659](https://bugs.openjdk.org/browse/CODETOOLS-7903659)
 
 * jtreg no longer ignores VM exit code when test process reports status with "STATUS: " line [CODETOOLS-7903621](https://bugs.openjdk.org/browse/CODETOOLS-7903621)
 
-* Use SOURCE_BUILD_EPOCH to suppport reproducible builds
+* Use SOURCE_BUILD_EPOCH to support reproducible builds
   [CODETOOLS-7903539](https://bugs.openjdk.org/browse/CODETOOLS-7903539)
 
 * Updated jtreg to bundle JUnit 5.10.2 [CODETOOLS-7903578](https://bugs.openjdk.org/browse/CODETOOLS-7903578)


### PR DESCRIPTION
Please review this documentation-only PR updating the `CHANGELOG.md` file in preparation of the upcoming `jtreg` 7.5 release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903759](https://bugs.openjdk.org/browse/CODETOOLS-7903759): Amend changelog to include the removal of `jtdiff` (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - Committer)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/220/head:pull/220` \
`$ git checkout pull/220`

Update a local copy of the PR: \
`$ git checkout pull/220` \
`$ git pull https://git.openjdk.org/jtreg.git pull/220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 220`

View PR using the GUI difftool: \
`$ git pr show -t 220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/220.diff">https://git.openjdk.org/jtreg/pull/220.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/220#issuecomment-2291034959)