### PR TITLE
7903790: Use source instead of release option for library compilation

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
@@ -309,7 +309,7 @@ public class BuildAction extends Action
                 var properties = LibraryProperties.of(libLocn);
                 if (properties.isEnablePreview()) {
                     compArgs.add("--enable-preview");
-                    compArgs.add("--release=" + script.getTestJDKVersion().major);
+                    compArgs.add("--source=" + script.getTestJDKVersion().major);
                 }
             } catch (UncheckedIOException exception) {
                 throw new TestRunException("Reading library properties failed: " + libLocn, exception);

--- a/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
@@ -309,6 +309,8 @@ public class BuildAction extends Action
                 var properties = LibraryProperties.of(libLocn);
                 if (properties.isEnablePreview()) {
                     compArgs.add("--enable-preview");
+                    // use "--source" below, as "--release" fails with errors like the following:
+                    // "exporting a package from system module M is not allowed with --release"
                     compArgs.add("--source=" + script.getTestJDKVersion().major);
                 }
             } catch (UncheckedIOException exception) {

--- a/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
@@ -309,8 +309,9 @@ public class BuildAction extends Action
                 var properties = LibraryProperties.of(libLocn);
                 if (properties.isEnablePreview()) {
                     compArgs.add("--enable-preview");
-                    // use "--source" below, as "--release" fails with errors like the following:
-                    // "exporting a package from system module M is not allowed with --release"
+                    // "--enable-preview" requires either "--source" or "--release" to
+                    // confirm the expected source level. "--release" restricts
+                    // the visible API to the exported API, so use "--source" instead.
                     compArgs.add("--source=" + script.getTestJDKVersion().major);
                 }
             } catch (UncheckedIOException exception) {

--- a/test/libPropertiesEnablePreview/LibPropertiesEnablePreviewTest.gmk
+++ b/test/libPropertiesEnablePreview/LibPropertiesEnablePreviewTest.gmk
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+$(BUILDTESTDIR)/LibPropertiesEnablePreviewTest.ok: \
+				$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/lib/javatest.jar
+	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
+	$(MKDIR) -p $(@:%.ok=%)
+	$(JDKHOME)/bin/java \
+		-jar $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		-w:$(@:%.ok=%/work) \
+		-r:$(@:%.ok=%/report) \
+		$(TESTDIR)/libPropertiesEnablePreview \
+		> $(@:%.ok=%/log 2>&1) \
+		|| (cat $(@:%.ok=%/log) ; exit 1)
+	echo $@ passed at `date` > $@
+
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/LibPropertiesEnablePreviewTest.ok

--- a/test/libPropertiesEnablePreview/TestNoLibraries.java
+++ b/test/libPropertiesEnablePreview/TestNoLibraries.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run junit TestNoLibraries
+ */
+public class TestNoLibraries {
+    public static void main(String... args) {
+        System.out.println(new TestNoLibraries());
+    }
+}

--- a/test/libPropertiesEnablePreview/TestUsingAllLibraries.java
+++ b/test/libPropertiesEnablePreview/TestUsingAllLibraries.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library lib-no-properties lib-with-preview lib-without-preview
+ * @build *
+ * @run main TestUsingAllLibraries
+ */
+public class TestUsingAllLibraries {
+    public static void main(String... args) {
+        System.out.println(new TestUsingAllLibraries());
+        System.out.println(new NoProperties());
+        System.out.println(new WithPreview());
+        System.out.println(new WithoutPreview());
+    }
+}

--- a/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
+++ b/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library lib-with-preview
+ * @build *
+ * @run main TestUsingPreviewLibrary
+ */
+public class TestUsingPreviewLibrary {
+    public static void main(String... args) {
+        System.out.println(new TestUsingPreviewLibrary());
+        System.out.println(new WithPreview());
+    }
+}

--- a/test/libPropertiesEnablePreview/TestWithEnablePreview.java
+++ b/test/libPropertiesEnablePreview/TestWithEnablePreview.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @library lib-without-preview
+ * @build *
+ * @run main TestWithEnablePreview
+ */
+public class TestWithEnablePreview {
+    public static void main(String... args) {
+        System.out.println(new TestWithEnablePreview());
+        System.out.println(new WithoutPreview());
+    }
+}

--- a/test/libPropertiesEnablePreview/lib-no-properties/NoProperties.java
+++ b/test/libPropertiesEnablePreview/lib-no-properties/NoProperties.java
@@ -1,0 +1,1 @@
+class NoProperties {}

--- a/test/libPropertiesEnablePreview/lib-with-preview/LIBRARY.properties
+++ b/test/libPropertiesEnablePreview/lib-with-preview/LIBRARY.properties
@@ -1,0 +1,1 @@
+enablePreview = true

--- a/test/libPropertiesEnablePreview/lib-with-preview/WithPreview.java
+++ b/test/libPropertiesEnablePreview/lib-with-preview/WithPreview.java
@@ -1,0 +1,1 @@
+class WithPreview {}

--- a/test/libPropertiesEnablePreview/lib-without-preview/LIBRARY.properties
+++ b/test/libPropertiesEnablePreview/lib-without-preview/LIBRARY.properties
@@ -1,0 +1,1 @@
+enablePreview = false

--- a/test/libPropertiesEnablePreview/lib-without-preview/WithoutPreview.java
+++ b/test/libPropertiesEnablePreview/lib-without-preview/WithoutPreview.java
@@ -1,0 +1,1 @@
+class WithoutPreview {}


### PR DESCRIPTION
Please review this change to use `--source=N` instead of `--release=N` in order to prevent compiler errors reading `exporting a package from system module java.base is not allowed with --release` when compiling a library using preview features, enabled via the new `LIBRARY.properties` configuration file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903790](https://bugs.openjdk.org/browse/CODETOOLS-7903790): Use source instead of release option for library compilation (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [34eb7ce4](https://git.openjdk.org/jtreg/pull/221/files/34eb7ce40474eec383247d4af48ab09c2b234e3a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/jtreg.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/221.diff">https://git.openjdk.org/jtreg/pull/221.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/221#issuecomment-2296960902)