### PR TITLE
7903793: Latent typo in ReportOnlyTest.gmk

### DIFF
--- a/test/basic/ReportOnlyTest.gmk
+++ b/test/basic/ReportOnlyTest.gmk
@@ -42,7 +42,7 @@ $(BUILDTESTDIR)/ReportOnlyTest.ok: $(BUILDTESTDIR)/Basic.othervm.ok \
 	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-reportOnly  -automatic -v \
 		-workDir:$(BUILDTESTDIR)/Basic.othervm/work \
-		-reportDir:$(@:%.ok=%) \
+		-reportDir:$(@:%.ok=%)/report \
 		$(TESTDIR)/share/basic \
 			> $(@:%.ok=%.jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"

--- a/test/basic/ReportOnlyTest.gmk
+++ b/test/basic/ReportOnlyTest.gmk
@@ -42,7 +42,7 @@ $(BUILDTESTDIR)/ReportOnlyTest.ok: $(BUILDTESTDIR)/Basic.othervm.ok \
 	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-reportOnly  -automatic -v \
 		-workDir:$(BUILDTESTDIR)/Basic.othervm/work \
-		-reportDir:$(BUILDTESTDIR)/$(@:%.ok=%) \
+		-reportDir:$(@:%.ok=%) \
 		$(TESTDIR)/share/basic \
 			> $(@:%.ok=%.jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"


### PR DESCRIPTION
Please review a test-only fix for a mistake in `ReportOnlyTest.gmk`.

The report directory previously had a double prefix of the value of `$(BUILDTESTDIR)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903793](https://bugs.openjdk.org/browse/CODETOOLS-7903793): Latent typo in ReportOnlyTest.gmk (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - Committer) ⚠️ Review applies to [8bca34ac](https://git.openjdk.org/jtreg/pull/222/files/8bca34ac7ce8180c7506184d2d47bf5493f65130)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.org/jtreg.git pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/222.diff">https://git.openjdk.org/jtreg/pull/222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/222#issuecomment-2297625912)