### PR TITLE
CODETOOLS-7903792: ReportOnlyTest may fail in "headless" environments

### DIFF
--- a/test/basic/Basic.java
+++ b/test/basic/Basic.java
@@ -78,7 +78,7 @@ public class Basic
         System.out.println("jdk:       " + jdkPath);
         System.out.println("envVars:   " + envVars);
         System.out.println("mode:      " + modeOpt);
-        System.out.println("headless:  " + isHeadless);
+        System.out.println("headless:  " + isHeadless);  // note: used by ReportOnlyTest.gmk
         System.out.println("java.awt.headless: " + headlessProperty);
 
         try {

--- a/test/basic/ReportOnlyTest.gmk
+++ b/test/basic/ReportOnlyTest.gmk
@@ -25,15 +25,16 @@
 
 #----------------------------------------------------------------------
 
-ifdef HEADLESS
-REPORT_EXPECT_PASS = 91
-REPORT_EXPECT_FAIL = 40
-else
-REPORT_EXPECT_PASS = 93
-REPORT_EXPECT_FAIL = 44
-endif
-
 # for full JavaTest gui, add "-gui" to jtreg call
+#
+# This test is a followup to Basic.othervm, and depends on the output from
+# test for its data. Basic.othervm adapts its behavior depending on whether
+# it is running in a headless environment, as determined by
+# java.awt.GraphicsEnvironment.isHeadless(). (See Basic.java, line 59)
+# This value is reported in the log that is written by Basic.java.
+# Because this test is a report of the tests executed in Basic.othervm,
+# we check that setting and adapt the behavior here accordingly.
+#
 $(BUILDTESTDIR)/ReportOnlyTest.ok: $(BUILDTESTDIR)/Basic.othervm.ok \
 		   $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		   $(JTREG_IMAGEDIR)/lib/jtreg.jar \
@@ -46,7 +47,14 @@ $(BUILDTESTDIR)/ReportOnlyTest.ok: $(BUILDTESTDIR)/Basic.othervm.ok \
 		$(TESTDIR)/share/basic \
 			> $(@:%.ok=%.jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: $(REPORT_EXPECT_PASS); failed: $(REPORT_EXPECT_FAIL); error: 88' $(@:%.ok=%.jt.log)  > /dev/null
+	if grep "headless: true" $(BUILDTESTDIR)/Basic.othervm/log > /dev/null ; then \
+	    REPORT_EXPECT_PASS=91 ; \
+	    REPORT_EXPECT_FAIL=40 ; \
+	else \
+	    REPORT_EXPECT_PASS=93 ; \
+	    REPORT_EXPECT_FAIL=44 ; \
+	fi ; \
+	$(GREP) -s "Test results: passed: $${REPORT_EXPECT_PASS}; failed: $${REPORT_EXPECT_FAIL}; error: 88" $(@:%.ok=%.jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/ReportOnlyTest.ok


### PR DESCRIPTION
Please review a test-only fix to the problems observed running `ReportOnlyTest.gmk`, as seen in some GitHub actions for other PRs. 

The general problem that is addressed is inconsistent determination of a "headless" environment, as determined by `Basic.java` and as given by an env variable when running the tests. 

More details are given in the test itself.