### PR TITLE
7903808: IOOBE in compile action when processing class files only

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -367,6 +367,9 @@ public class CompileAction extends Action {
 
         if (runJavac && needsEnablePreview && !seenEnablePreview
                 && (libLocn == null || libLocn.isTest())) {
+            if (insertPos == -1) { // happens for example in "-proc:only CLASS" cases
+                insertPos = 0;     // prepend in order to not mess with variadic arguments
+            }
             javacArgs.add(insertPos, "--enable-preview");
             if (!seenSourceOrRelease) {
                 int v = script.getTestJDKVersion().major;

--- a/test/libPropertiesEnablePreview/TestProcessor.java
+++ b/test/libPropertiesEnablePreview/TestProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 7903808
+ * @library lib-with-preview
+ * @build TestProcessor WithPreview
+ * @compile -cp . -processor TestProcessor -proc:only TestProcessor.java
+ * @compile/process -cp . -processor TestProcessor -proc:only Test
+ */
+
+import java.util.*;
+import javax.annotation.processing.*;
+import javax.lang.model.*;
+import javax.lang.model.element.*;
+import javax.lang.model.util.*;
+
+public class TestProcessor extends AbstractProcessor {
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of();
+    }
+
+    public boolean process(Set<? extends TypeElement> types, RoundEnvironment env) {
+        return true;
+    }
+}
+
+class Test {
+    static {
+        WithPreview.class.toString();
+    }
+}


### PR DESCRIPTION
Please review this fix preventing an `IndexOutOfBoundsException` in the compile action when processing class files only.

As an library used by a test might need `--enable-preview` it is possible that the `insertPos` variable is still assigned with the value `-1`: the `for (String currArg : args) { ... }` loop may exit normally without setting a valid insertion position.

This change checks for `-1` values and use `0` instead in order to prepend `--enable-preview` and `--source N` before any variadic arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903808](https://bugs.openjdk.org/browse/CODETOOLS-7903808): IOOBE in compile action when processing class files only (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - Committer) ⚠️ Review applies to [ae72eb28](https://git.openjdk.org/jtreg/pull/224/files/ae72eb28c5b7a70d2071835f824755492c7383a2)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/jtreg.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/224.diff">https://git.openjdk.org/jtreg/pull/224.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/224#issuecomment-2322212067)