### PR TITLE
7903813: Tag enablePreview with false should take precedence

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/BuildAction.java
@@ -312,7 +312,8 @@ public class BuildAction extends Action
                     // "--enable-preview" requires either "--source" or "--release" to
                     // confirm the expected source level. "--release" restricts
                     // the visible API to the exported API, so use "--source" instead.
-                    compArgs.add("--source=" + script.getTestJDKVersion().major);
+                    compArgs.add("-source"); // use "-source" "N" for Java 11 and lower
+                    compArgs.add(String.valueOf(script.getTestJDKVersion().major));
                 }
             } catch (UncheckedIOException exception) {
                 throw new TestRunException("Reading library properties failed: " + libLocn, exception);

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -366,7 +366,7 @@ public class CompileAction extends Action {
         if (runJavac
                 && !script.disablePreview()
                 && !seenEnablePreview
-                && script.enablePreview() || usesLibraryCompiledWithPreviewEnabled()
+                && (script.enablePreview() || usesLibraryCompiledWithPreviewEnabled())
                 && (libLocn == null || libLocn.isTest())) {
             javacArgs.add(insertPos, "--enable-preview");
             if (!seenSourceOrRelease) {

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -363,9 +363,10 @@ public class CompileAction extends Action {
             }
         }
 
-        var needsEnablePreview = script.enablePreview() || usesLibraryCompiledWithPreviewEnabled();
-
-        if (runJavac && needsEnablePreview && !seenEnablePreview
+        if (runJavac
+                && !script.disablePreview()
+                && !seenEnablePreview
+                && script.enablePreview() || usesLibraryCompiledWithPreviewEnabled()
                 && (libLocn == null || libLocn.isTest())) {
             javacArgs.add(insertPos, "--enable-preview");
             if (!seenSourceOrRelease) {

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -231,13 +231,15 @@ public class MainAction extends Action
                 throw new ParseException(PARSE_SECURE_OTHERVM);
         }
 
-        boolean needsEnablePreview = script.enablePreview() || usesLibraryCompiledWithPreviewEnabled();
-        if (needsEnablePreview && !seenEnablePreview) {
-            testJavaArgs.add("--enable-preview");
-            if (!othervm) {
-                // ideally, this should not force othervm mode, but just allow
-                // the use of an agent with preview enabled
-                othervmOverrideReasons.add("test requires --enable-preview");
+        if (!script.disablePreview()) { // test with explicit `@enablePreview false` take precedence
+            boolean needsEnablePreview = script.enablePreview() || usesLibraryCompiledWithPreviewEnabled();
+            if (needsEnablePreview && !seenEnablePreview) {
+                testJavaArgs.add("--enable-preview");
+                if (!othervm) {
+                    // ideally, this should not force othervm mode, but just allow
+                    // the use of an agent with preview enabled
+                    othervmOverrideReasons.add("test requires --enable-preview");
+                }
             }
         }
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -444,6 +444,11 @@ public class RegressionScript extends Script {
         return ep != null && ep.equals("true");
     }
 
+    boolean disablePreview() {
+        String ep = td.getParameter("enablePreview");
+        return ep != null && ep.equals("false");
+    }
+
     private List<String> processArgs(List<String> args, Expr.Context c, Map<String,String> testProps)
             throws TestSuite.Fault, Expr.Fault, ParseException {
         if (!testSuite.getAllowSmartActionArgs(td))
@@ -1159,6 +1164,9 @@ public class RegressionScript extends Script {
         }
         if (enablePreview()) {
             p.put("test.enable.preview", "true");
+        }
+        if (disablePreview()) {
+            p.put("test.enable.preview", "false");
         }
         p.put("test.root", getTestRootDir().getPath());
         return Collections.unmodifiableMap(p);

--- a/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/ShellAction.java
@@ -237,6 +237,9 @@ public class ShellAction extends Action
             if (script.enablePreview()) {
                 env.put("TESTENABLEPREVIEW", "true");
             }
+            if (script.disablePreview()) {
+                env.put("TESTENABLEPREVIEW", "false");
+            }
             String testQuery = script.getTestQuery();
             if (testQuery != null) {
                 env.put("TESTQUERY", testQuery);

--- a/test/libPropertiesEnablePreview/TestUsingAllLibraries.java
+++ b/test/libPropertiesEnablePreview/TestUsingAllLibraries.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @library lib-no-properties lib-with-preview lib-without-preview
- * @build *
+ * @build TestUsingAllLibraries NoProperties WithPreview WithoutPreview
  * @run main TestUsingAllLibraries
  */
 public class TestUsingAllLibraries {

--- a/test/libPropertiesEnablePreview/TestWithDisabledPreview.java
+++ b/test/libPropertiesEnablePreview/TestWithDisabledPreview.java
@@ -23,13 +23,26 @@
 
 /*
  * @test
+ * @bug 7903813
+ * @enablePreview false
  * @library lib-with-preview
- * @build TestUsingPreviewLibrary WithPreview
- * @run main TestUsingPreviewLibrary
+ * @build TestWithDisabledPreview WithPreview
+ * @run main TestWithDisabledPreview
  */
-public class TestUsingPreviewLibrary {
-    public static void main(String... args) {
-        System.out.println(new TestUsingPreviewLibrary());
-        System.out.println(new WithPreview());
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TestWithDisabledPreview {
+    public static void main(String... args) throws Exception {
+        var location = TestWithDisabledPreview.class.getProtectionDomain().getCodeSource().getLocation();
+        var classFile = Path.of(location.toURI()).resolve(TestWithDisabledPreview.class.getSimpleName() + ".class");
+        try (var dis = new DataInputStream(new ByteArrayInputStream(Files.readAllBytes(classFile)))) {
+            dis.skipBytes(4); // 0xCAFEBABE
+            var minor = dis.readUnsignedShort();
+            if (minor != 0) throw new AssertionError("Unexpected minor version: " + minor);
+        }
     }
 }

--- a/test/libPropertiesEnablePreview/TestWithEnablePreview.java
+++ b/test/libPropertiesEnablePreview/TestWithEnablePreview.java
@@ -25,7 +25,7 @@
  * @test
  * @enablePreview
  * @library lib-without-preview
- * @build *
+ * @build TestWithEnablePreview WithoutPreview
  * @run main TestWithEnablePreview
  */
 public class TestWithEnablePreview {


### PR DESCRIPTION
Please review this change to let tests with `@enablePreview false` take precedence over libraries that require preview features being enabled.

Note that the [PreviewHiddenClass](https://github.com/openjdk/jdk/blob/f6d7e30b84fedbf42077526610ba7a5bcfaece4c/test/jdk/java/lang/invoke/defineHiddenClass/PreviewHiddenClass.java#L34-L35) test should receive an explicit `enablePreview=false` tag line (in addition to the comment).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903813](https://bugs.openjdk.org/browse/CODETOOLS-7903813): Tag enablePreview with false should take precedence (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/225/head:pull/225` \
`$ git checkout pull/225`

Update a local copy of the PR: \
`$ git checkout pull/225` \
`$ git pull https://git.openjdk.org/jtreg.git pull/225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 225`

View PR using the GUI difftool: \
`$ git pr show -t 225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/225.diff">https://git.openjdk.org/jtreg/pull/225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/225#issuecomment-2324893628)