### PR TITLE
7903809: Invalid source release N with --enable-preview

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -327,11 +327,12 @@ public class CompileAction extends Action {
         List<String> jcodArgs = new ArrayList<>();
         boolean runJavac = process;
 
-        String sourceOrReleaseVersion = "not-seen";
+        String sourceOrReleaseVersion = null;
         boolean seenSourceOrRelease = false;
         boolean seenEnablePreview = false;
 
-        for (String currArg : args) {
+        for (int i = 0; i < args.size(); i++) {
+            String currArg = args.get(i);
             if (currArg.endsWith(".java")) {
                 if (!(new File(currArg)).exists())
                     throw new TestRunException(CANT_FIND_SRC + currArg);
@@ -346,21 +347,17 @@ public class CompileAction extends Action {
                 switch (eq == -1 ? currArg : currArg.substring(0, eq)) {
                     case "--enable-preview":
                         seenEnablePreview = true;
-                        break;
+                        break; // switch
                     case "-source":
                     case "--source":
                     case "--release":
-                        seenSourceOrRelease= true;
+                        seenSourceOrRelease = true;
                         if (eq != -1) {
                             sourceOrReleaseVersion = currArg.substring(eq + 1).trim();
                         } else {
-                            sourceOrReleaseVersion = "next-argument";
+                            sourceOrReleaseVersion = args.size() > i + 1 ? args.get(i + 1) : null;
                         }
-                        javacArgs.add(currArg);
-                        continue; // with next argument
-                }
-                if (sourceOrReleaseVersion.equals("next-argument")) {
-                    sourceOrReleaseVersion = currArg;
+                        break; // switch
                 }
                 javacArgs.add(currArg);
             }

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -327,7 +327,7 @@ public class CompileAction extends Action {
         List<String> jcodArgs = new ArrayList<>();
         boolean runJavac = process;
 
-        int sourceOrReleaseFeatureNumber = -1;
+        String sourceOrReleaseVersion = "not-seen";
         boolean seenSourceOrRelease = false;
         boolean seenEnablePreview = false;
 
@@ -352,16 +352,15 @@ public class CompileAction extends Action {
                     case "--release":
                         seenSourceOrRelease= true;
                         if (eq != -1) {
-                            var number = currArg.substring(eq + 1).trim();
-                            sourceOrReleaseFeatureNumber = Integer.parseInt(number);
+                            sourceOrReleaseVersion = currArg.substring(eq + 1).trim();
                         } else {
-                            sourceOrReleaseFeatureNumber = -2;
+                            sourceOrReleaseVersion = "next-argument";
                         }
                         javacArgs.add(currArg);
                         continue; // with next argument
                 }
-                if (sourceOrReleaseFeatureNumber == -2) {
-                    sourceOrReleaseFeatureNumber = Integer.parseInt(currArg);
+                if (sourceOrReleaseVersion.equals("next-argument")) {
+                    sourceOrReleaseVersion = currArg;
                 }
                 javacArgs.add(currArg);
             }
@@ -372,14 +371,14 @@ public class CompileAction extends Action {
                 && !seenEnablePreview
                 && (script.enablePreview() || usesLibraryCompiledWithPreviewEnabled())
                 && (libLocn == null || libLocn.isTest())) {
-            int major = script.getTestJDKVersion().major;
+            String version = script.getTestJDKVersion().name();
             // always prepend in order to not mess with variadic arguments
             if (!seenSourceOrRelease) {
-                javacArgs.add(0, String.valueOf(major));
+                javacArgs.add(0, version);
                 javacArgs.add(0, "-source");
             }
             // 7903809: prevent invalid source release errors
-            if (!seenSourceOrRelease || major == sourceOrReleaseFeatureNumber) {
+            if (!seenSourceOrRelease || version.equals(sourceOrReleaseVersion)) {
                 javacArgs.add(0, "--enable-preview");
             }
         }

--- a/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
+++ b/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
@@ -26,6 +26,8 @@
  * @bug 7903809
  * @library lib-with-preview
  * @compile --release 11 TestUsingPreviewLibrary.java
+ * @compile  -source 1.8 TestUsingPreviewLibrary.java
+ * @compile --source 1.8 TestUsingPreviewLibrary.java
  * @build TestUsingPreviewLibrary WithPreview
  * @run main TestUsingPreviewLibrary
  */

--- a/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
+++ b/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 7903809
  * @library lib-with-preview
- * @compile --release 21 TestUsingPreviewLibrary.java
+ * @compile --release 11 TestUsingPreviewLibrary.java
  * @build TestUsingPreviewLibrary WithPreview
  * @run main TestUsingPreviewLibrary
  */

--- a/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
+++ b/test/libPropertiesEnablePreview/TestUsingPreviewLibrary.java
@@ -23,7 +23,9 @@
 
 /*
  * @test
+ * @bug 7903809
  * @library lib-with-preview
+ * @compile --release 21 TestUsingPreviewLibrary.java
  * @build TestUsingPreviewLibrary WithPreview
  * @run main TestUsingPreviewLibrary
  */


### PR DESCRIPTION
Please review this change to prevent "invalid source release N with --enable-preview" errors for when an explicit compile task targets a different JDK feature release number then the JDK under test (running the compilation).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903809](https://bugs.openjdk.org/browse/CODETOOLS-7903809): Invalid source release N with --enable-preview (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [bb9bb6e3](https://git.openjdk.org/jtreg/pull/226/files/bb9bb6e314e2665d94b42c89f9184d25b0a5b095)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/jtreg.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/226.diff">https://git.openjdk.org/jtreg/pull/226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/226#issuecomment-2344091972)