### PR TITLE
7903871: Typo bug in doc/building.md of 'Rebuilding faster'

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -43,7 +43,7 @@ _make/build-support/version-numbers_ and _make/build-support/*/version-numbers_ 
 ### Rebuilding faster with `build/make.sh`
 
 After you have run `make/build.sh` once, if you wish to rebuild after making some
-changes, you can run `build/make.sh`. It skips the steps to download and build
+changes, you can run `build/make.sh --skip-download`. It skips the steps to download and build
 the dependencies, and so should be significantly faster.
 
 ## Building `jtreg` with GNU Make


### PR DESCRIPTION
Hi all,
The document of `doc/building.md` at chapter `Rebuilding faster with build/make.sh` has a typo bug, which may cause misunderstand.
Anyone wants to skip download dependencies, the option `--skip-download` should passed to `make/build.sh` explicitly. Because the default valune of variable `SKIP_DOWNLOAD` in [build-common.sh](https://github.com/openjdk/jtreg/blob/master/make/build-support/build-common.sh#L155) is empty, unless execute `make/build.sh` with `--skip-download` option.
Only fix the document bug, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903871](https://bugs.openjdk.org/browse/CODETOOLS-7903871): Typo bug in doc/building.md of 'Rebuilding faster' (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.org/jtreg.git pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/232.diff">https://git.openjdk.org/jtreg/pull/232.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/232#issuecomment-2425970031)