### PR TITLE
7903872: Option testThreadFactoryPath support relativepath

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
@@ -1288,7 +1288,7 @@ public final class RegressionParameters
     private String testThreadFactory;
 
     public void setTestThreadFactoryPath(String testThreadFactoryPath) {
-        this.testThreadFactoryPath = testThreadFactoryPath;
+        this.testThreadFactoryPath = new File(testThreadFactoryPath).getAbsolutePath();
     }
 
     public String getTestThreadFactoryPath() {

--- a/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/RegressionParameters.java
@@ -1288,7 +1288,7 @@ public final class RegressionParameters
     private String testThreadFactory;
 
     public void setTestThreadFactoryPath(String testThreadFactoryPath) {
-        this.testThreadFactoryPath = new File(testThreadFactoryPath).getAbsolutePath();
+        this.testThreadFactoryPath = Path.of(testThreadFactoryPath).toAbsolutePath().toString();
     }
 
     public String getTestThreadFactoryPath() {

--- a/test/testThreadFactory/TestThreadFactory.gmk
+++ b/test/testThreadFactory/TestThreadFactory.gmk
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,7 +26,7 @@
 
 #----------------------------------------------------------------------
 
-$(BUILDTESTDIR)/TestThreadFactory.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+$(BUILDTESTDIR)/TestThreadFactoryAbsolutePath.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 	$(JDKJAVAC) \
@@ -50,4 +51,30 @@ $(BUILDTESTDIR)/TestThreadFactory.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testThreadFactory
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += $(BUILDTESTDIR)/TestThreadFactory.ok
+$(BUILDTESTDIR)/TestThreadFactoryRelativePath.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(JDKJAVAC) \
+		-d $(@:%.ok=%)/classes \
+		$(TESTDIR)/testThreadFactory/TestThreadFactory.java
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-jdk:$(JDKHOME) \
+		-w:$(@:%.ok=%)/cmd.othervm/work \
+		-r:$(@:%.ok=%)/cmd.othervm/report \
+		-verbose:fail \
+		-testThreadFactory:TestThreadFactory \
+		-testThreadFactoryPath:../build/test/TestThreadFactoryRelativePath/classes \
+		$(TESTDIR)/testThreadFactory
+	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-jdk:$(JDKHOME) \
+                -agentvm \
+		-w:$(@:%.ok=%)/cmd.agentvm/work \
+		-r:$(@:%.ok=%)/cmd.agentvm/report \
+		-verbose:fail \
+		-testThreadFactory:TestThreadFactory \
+		-testThreadFactoryPath:../build/test/TestThreadFactoryRelativePath/classes \
+		$(TESTDIR)/testThreadFactory
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/TestThreadFactoryAbsolutePath.ok \
+               $(BUILDTESTDIR)/TestThreadFactoryRelativePath.ok


### PR DESCRIPTION
Hi all,
Currently, the jtreg option `-testThreadFactoryPath` doesn't support relativepath.
I think jtreg can support relativepath for option `-testThreadFactoryPath`, same like to `-jdk` or `-nativepath`.
Change has been verified locally, risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903872](https://bugs.openjdk.org/browse/CODETOOLS-7903872): Option testThreadFactoryPath support relativepath (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/233/head:pull/233` \
`$ git checkout pull/233`

Update a local copy of the PR: \
`$ git checkout pull/233` \
`$ git pull https://git.openjdk.org/jtreg.git pull/233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 233`

View PR using the GUI difftool: \
`$ git pr show -t 233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/233.diff">https://git.openjdk.org/jtreg/pull/233.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/233#issuecomment-2426191987)
</details>
