### PR TITLE
7903765: wget failed in build.sh in jtreg

### DIFF
--- a/make/build-support/asmtools/build.sh
+++ b/make/build-support/asmtools/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ setup_asmtools_src() {
     check_arguments "${FUNCNAME}" 1 $#
 
     local dir="$1"
-
-    local ASMTOOLS_LOCAL_SRC_ARCHIVE="${dir}/../source.zip"
+    local src_archive_dir="$(builtin  cd ${dir}/..; pwd)"
+    local ASMTOOLS_LOCAL_SRC_ARCHIVE="${src_archive_dir}/source.zip"
     if [ "${ASMTOOLS_SRC_TAG}" = "tip" -o "${ASMTOOLS_SRC_TAG}" = "master" ]; then
         local BRANCH="master"
         get_archive_no_checksum "${CODE_TOOLS_URL_BASE}/asmtools/archive/${BRANCH}.zip" "${ASMTOOLS_LOCAL_SRC_ARCHIVE}" "${dir}"
@@ -58,6 +58,7 @@ build_asmtools() {
     check_arguments "${FUNCNAME}" 0 $#
 
     local ASMTOOLS_SRC_DIR_BASE="${BUILD_DIR}/src"
+    mkdir -p "${ASMTOOLS_SRC_DIR_BASE}"
     setup_asmtools_src "${ASMTOOLS_SRC_DIR_BASE}"
 
     local ASMTOOLS_DIST="${BUILD_DIR}/build"

--- a/make/build-support/build-common.sh
+++ b/make/build-support/build-common.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -311,8 +311,8 @@ if [ -z "${log_module:-}" ]; then
     error "log_module not set in caller (line/file): $(caller)"
     exit 1
 fi
-
-ROOT="$(abspath ${ROOT:-${mydir}/..})"
+DEFAULT_ROOT="$(builtin cd ${mydir}/..; pwd)"
+ROOT="$(abspath ${ROOT:-${DEFAULT_ROOT}})"
 BUILD_DIR="$(abspath "${BUILD_DIR:-${ROOT}/build}")"
 DEPS_DIR="${BUILD_DIR}/deps"
 

--- a/make/build-support/jcov/build.sh
+++ b/make/build-support/jcov/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,8 @@ setup_jcov_src() {
     local dir="$1"
 
     # Build jcov
-    local JCOV_LOCAL_SRC_ARCHIVE="${dir}/../source.zip"
+    local src_archive_dir="$(builtin  cd ${dir}/..; pwd)"
+    local JCOV_LOCAL_SRC_ARCHIVE="${src_archive_dir}/source.zip"
     if [ "${JCOV_SRC_TAG}" = "tip" -o "${JCOV_SRC_TAG}" = "master" ]; then
         local BRANCH="master"
         get_archive_no_checksum "${CODE_TOOLS_URL_BASE}/jcov/archive/${BRANCH}.zip" "${JCOV_LOCAL_SRC_ARCHIVE}" "${dir}"

--- a/make/build-support/jtharness/build.sh
+++ b/make/build-support/jtharness/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ setup_jtharness_source() {
     local dir="$1"
 
     # Build jtharness
-    local JTHARNESS_LOCAL_SRC_ARCHIVE="${dir}/../source.zip"
+    local src_archive_dir="$(builtin  cd ${dir}/..; pwd)"
+    local JTHARNESS_LOCAL_SRC_ARCHIVE="${src_archive_dir}/source.zip"
     if [ "${JTHARNESS_SRC_TAG}" = "tip" -o "${JTHARNESS_SRC_TAG}" = "master" ]; then
         local BRANCH="master"
         get_archive_no_checksum "${CODE_TOOLS_URL_BASE}/jtharness/archive/${BRANCH}.zip" "${JTHARNESS_LOCAL_SRC_ARCHIVE}" "${dir}"
@@ -61,6 +62,7 @@ build_jtharness() {
     check_arguments "${FUNCNAME}" 0 $#
 
     local JTHARNESS_SRC_DIR_BASE="${BUILD_DIR}/src"
+    mkdir -p "${JTHARNESS_SRC_DIR_BASE}"
     setup_jtharness_source "${JTHARNESS_SRC_DIR_BASE}"
 
     local JTHARNESS_DIST="${BUILD_DIR}/build"


### PR DESCRIPTION
Hi, this is a backport of the original https://github.com/openjdk/jtreg/pull/214 into the 6.1+x branch, since the branch is not currently buildable using make/build.sh script due to reasons in https://bugs.openjdk.org/browse/CODETOOLS-7903765

I also added jcov dependency fix for the same issue as part of the backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (no review required)

### Issue
 * [CODETOOLS-7903765](https://bugs.openjdk.org/browse/CODETOOLS-7903765): wget failed in build.sh in jtreg (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.org/jtreg.git pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/234.diff">https://git.openjdk.org/jtreg/pull/234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/234#issuecomment-2451826836)
</details>
