### PR TITLE
7903519 : jtreg/jtharness is missing features for basic crash testing

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/StatusTransformer.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/StatusTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javatest.regtest.exec;
+
+import com.sun.javatest.Status;
+import com.sun.javatest.TestDescription;
+
+/**
+ * Enables users to create their own status modifications for purposes of different testing strategies.
+ * This allows user to omit certain kinds of failures or pinpoint tests that passed even though the jvm
+ * crashed in the process without being intended to.
+ */
+public interface StatusTransformer {
+    public Status transform(Status originalStatus, TestDescription td);
+}
+


### PR DESCRIPTION
provides SPI for enabling external status transformations of failed tests

this is a continuation of efforts after https://github.com/openjdk/jtharness/pull/59 

Requires newest jtharness build (not even tagged yet) that includes above mentioned change to be compiled succesfully

The main idea is to provide a unified StatusTransformer interface, that can be externally implemented by users and added to a classpath in a separate jar to allow modifications of test execution status based on some elementary analysis. This can be easily used for crashtesting (filtering out only tests with jvm crashes).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903519](https://bugs.openjdk.org/browse/CODETOOLS-7903519): jtreg/jtharness is missing features for basic crash testing (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.org/jtreg.git pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/235.diff">https://git.openjdk.org/jtreg/pull/235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/235#issuecomment-2458539420)
</details>
