### PR TITLE
7903920: Support building jtreg on FreeBSD

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -182,9 +182,17 @@ else
 TIDY	= /usr/bin/tidy
 endif
 TOUCH 	= /usr/bin/touch
+ifeq ($(SYSTEM_UNAME), FreeBSD)
+UNZIP	= /usr/local/bin/unzip
+else
 UNZIP 	= /usr/bin/unzip
+endif
 WC 	= /usr/bin/wc
+ifeq ($(SYSTEM_UNAME), FreeBSD)
+ZIP	= /usr/local/bin/zip
+else
 ZIP 	= /usr/bin/zip
+endif
 
 
 #----------------------------------------------------------------------

--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -141,7 +141,15 @@ CP 	= /bin/cp
 DIFF 	= /usr/bin/diff
 ECHO	= /bin/echo
 FIND	= /usr/bin/find
+ifeq ($(SYSTEM_UNAME), FreeBSD)
+GREP  := $(shell if [ -r /usr/local/bin/ggrep ]; then \
+    echo /usr/local/bin/ggrep ; \
+  else \
+    echo $(ECHO) "GNU grep is required, but was not found" ; \
+  fi )
+else
 GREP 	:= $(shell if [ -r /bin/grep ]; then echo /bin/grep ; else echo /usr/bin/grep ; fi )
+endif
 LN	= /bin/ln
 LS	= /bin/ls
 MKDIR 	= /bin/mkdir

--- a/make/Platform.gmk
+++ b/make/Platform.gmk
@@ -56,6 +56,11 @@ ifeq ($(UNAME_S), Linux)
   endif
   OS_VERSION := $(shell $(UNAME) -r)
 endif
+ifeq ($(UNAME_S), FreeBSD)
+  OS_NAME     = freebsd
+  OS_ARCH    := $(shell $(UNAME) -m)
+  OS_VERSION := $(shell $(UNAME) -r)
+endif
 ifeq ($(UNAME_S), Darwin)
   OS_NAME     = macosx
   OS_ARCH    := $(shell $(UNAME) -m)

--- a/make/build.sh
+++ b/make/build.sh
@@ -765,13 +765,23 @@ if [ -n "${SKIP_MAKE:-}" ]; then
     exit
 fi
 
+MAKE=$(which make)
+setup_make() {
+    case `uname` in
+      FreeBSD )
+          MAKE=/usr/local/bin/gmake ;;
+    esac
+}
+setup_make
+check_file "${MAKE}"
+
 # save make command for possible later reuse, bypassing this script
 mkdir -p ${BUILD_DIR}
 cat > ${BUILD_DIR}/make.sh << EOF
 #!/bin/sh
 
 cd "${ROOT}/make"
-make ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
+${MAKE} ASMTOOLS_JAR="${ASMTOOLS_JAR}"                           \\
      ASMTOOLS_NOTICES="${ASMTOOLS_NOTICES}"                   \\
      BUILDDIR="${BUILD_DIR}"                                  \\
      BUILD_MILESTONE="${JTREG_BUILD_MILESTONE}"               \\


### PR DESCRIPTION
On FreeBSD we need to use GNU gmake instead of the BSD make program.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903920](https://bugs.openjdk.org/browse/CODETOOLS-7903920): Support building jtreg on FreeBSD (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - Author)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/237/head:pull/237` \
`$ git checkout pull/237`

Update a local copy of the PR: \
`$ git checkout pull/237` \
`$ git pull https://git.openjdk.org/jtreg.git pull/237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 237`

View PR using the GUI difftool: \
`$ git pr show -t 237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/237.diff">https://git.openjdk.org/jtreg/pull/237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/237#issuecomment-2613356188)
</details>
