### PR TITLE
Rename WGET_OPTS to WGET_OPTIONS in build.sh

### DIFF
--- a/make/build.sh
+++ b/make/build.sh
@@ -75,7 +75,7 @@
 # WGET
 #     The wget-like executable to use when downloading files.
 #
-# WGET_OPTS (e.g. "-v")
+# WGET_OPTIONS (e.g. "-v")
 #     Additional arguments to pass to WGET when downloading files.
 #
 # CURL (e.g. "/path/to/my/wget")


### PR DESCRIPTION
Changed variable name `WGET_OPTS` to `WGET_OPTIONS` in the documentation block "Some noteworthy control variables" in `make/build.sh`.

`WGET_OPTIONS` is used in the download_using_wget() function in `make/build-support/build-common.sh`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/239/head:pull/239` \
`$ git checkout pull/239`

Update a local copy of the PR: \
`$ git checkout pull/239` \
`$ git pull https://git.openjdk.org/jtreg.git pull/239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 239`

View PR using the GUI difftool: \
`$ git pr show -t 239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/239.diff">https://git.openjdk.org/jtreg/pull/239.diff</a>

</details>
