### PR TITLE
7903930: Support running individual parameterized tests and @Nested test classes

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -173,6 +173,7 @@ TIDY 	:= $(shell if [ -r /usr/local/bin/tidy ]; then \
 else
 TIDY	= /usr/bin/tidy
 endif
+TR      = /usr/bin/tr
 TOUCH 	= /usr/bin/touch
 UNZIP 	= /usr/bin/unzip
 WC 	= /usr/bin/wc

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestQuery.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestQuery.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javatest.regtest.agent;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TestQuery {
+    private final String className;
+    private final String methodName;
+    private final List<String> paramTypeNames;
+
+    private TestQuery(String className, String methodName, List<String> paramTypeNames) {
+        this.className = Objects.requireNonNull(className);
+        this.methodName = methodName;
+        this.paramTypeNames = paramTypeNames;
+    }
+
+    // <class name>[::<method name>[([<param type>[...,<param type>]])]]
+    public static TestQuery parse(String queryString) {
+        String[] parts = queryString.split("::", 2);
+        String className = parts[0];
+        String methodName = null;
+        List<String> paramTypeNames = null;
+        if (parts.length > 1) { // method name present
+            parts = parts[1].split("\\(", 2);
+            if (parts.length != 2) {
+                throw new IllegalArgumentException("Invalid query format: " + queryString);
+            }
+            methodName = parts[0];
+            String types = parts[1].substring(0, parts[1].length() - 1); // drop trailing ')'
+            if (types.isEmpty()) {
+                paramTypeNames = Collections.emptyList();
+            } else {
+                String[] typeNames = types.split(",");
+                paramTypeNames = Collections.unmodifiableList(Arrays.asList(typeNames));
+            }
+        }
+
+        return new TestQuery(className, methodName, paramTypeNames);
+    }
+
+    public String className() {
+        return className;
+    }
+
+    public Optional<String> methodName() {
+        return Optional.ofNullable(methodName);
+    }
+
+    public Optional<List<String>> paramTypeNames() {
+        return Optional.ofNullable(paramTypeNames);
+    }
+
+    @Override
+    public String toString() {
+        return className()
+                + methodName().map(mn -> "::" + mn).orElse("")
+                + paramTypeNames().map(pn -> '(' + String.join(",", pn) + ')').orElse("");
+    }
+}

--- a/test/junitQueryTest/JUnitQueryTest.gmk
+++ b/test/junitQueryTest/JUnitQueryTest.gmk
@@ -40,17 +40,17 @@ $(BUILDTESTDIR)/JUnitQueryTest.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/junitQueryTest/ \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
-	if [ "$$OUT" != "Test1.m11 Test1.m12 Test1.m13 Test2.m21 Test2.m22 Test2.m23" ]; then \
+	if [ "$$OUT" != "Test1.parameterized Test1.m11 Test1.m12 Test1.m13 Test1.nested Test2.m21 Test2.m22 Test2.m23" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
-	$(GREP) "a/b/c/ .* tests: 6, skipped: 0, started: 6, succeeded: 6, failed: 0, aborted: 0" $(@:%.ok=%)/report/text/junit.txt
+	$(GREP) "a/b/c/ .* tests: 8, skipped: 0, started: 8, succeeded: 8, failed: 0, aborted: 0" $(@:%.ok=%)/report/text/junit.txt
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.all.ok
 
 #----------------------------------------------------------------------
 #
-# Execute a single specific method (Test1.m12) using the query syntax  Test1.java?m12
+# Execute a single specific method (Test1.m12) using the query syntax  Test1.java?Test1::m12()
 
 $(BUILDTESTDIR)/JUnitQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
@@ -62,7 +62,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m12()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
 	if [ "$$OUT" != "Test1.m12" ]; then \
@@ -76,7 +76,7 @@ TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.m12.ok
 #----------------------------------------------------------------------
 #
 # Execute a mixture of 4 tests:
-# - a single specific method (Test1.m12) using the query syntax  Test1.java?m12
+# - a single specific method (Test1.m12) using the query syntax  Test1.java?Test1::m12()
 # - all (3) test methods in Test2.java
 
 $(BUILDTESTDIR)/JUnitQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
@@ -89,7 +89,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar 
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m12()" \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test2.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
@@ -116,8 +116,8 @@ $(BUILDTESTDIR)/JUnitQueryTest.m13.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m13()" \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m12()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
 	if [ "$$OUT" != "Test1.m12" ]; then \
@@ -143,8 +143,8 @@ $(BUILDTESTDIR)/JUnitQueryTest.m12.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m12()" \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m13()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
 	if [ "$$OUT" != "Test1.m13" ]; then \
@@ -170,14 +170,14 @@ $(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m13()" \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
-	if [ "$$OUT" != "Test1.m11 Test1.m12 Test1.m13" ]; then \
+	if [ "$$OUT" != "Test1.parameterized Test1.m11 Test1.m12 Test1.m13 Test1.nested" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
-	$(GREP) "a/b/c/ .* tests: 3, skipped: 0, started: 3, succeeded: 3, failed: 0, aborted: 0" $(@:%.ok=%)/report/text/junit.txt
+	$(GREP) "a/b/c/ .* tests: 5, skipped: 0, started: 5, succeeded: 5, failed: 0, aborted: 0" $(@:%.ok=%)/report/text/junit.txt
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok
@@ -198,7 +198,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-jdk:$(JDKHOME) \
 		-va \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m13()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
 	if [ "$$OUT" != "Test1.m13" ]; then \
@@ -208,6 +208,56 @@ $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok
+
+#----------------------------------------------------------------------
+#
+# parameterizedTest
+
+$(BUILDTESTDIR)/JUnitQueryTest.parameterized.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::parameterized(java.lang.String,Test1\$$NestedClass,boolean,byte,char,short,int,long,float,double,[Ljava.lang.String;,[Z,[B,[C,[S,[I,[J,[F,[D)" \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.parameterized" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ .* tests: 1, skipped: 0, started: 1, succeeded: 1, failed: 0, aborted: 0" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.parameterized.ok
+
+#----------------------------------------------------------------------
+#
+# nested class
+
+$(BUILDTESTDIR)/JUnitQueryTest.nested.class.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1\$$NestedTests" \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ "$$OUT" != "Test1.nested" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	$(GREP) "a/b/c/ .* tests: 1, skipped: 0, started: 1, succeeded: 1, failed: 0, aborted: 0" $(@:%.ok=%)/report/text/junit.txt
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.nested.class.ok
 
 #----------------------------------------------------------------------
 #
@@ -223,10 +273,10 @@ $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok: $(JTREG_IMAGEDIR)/lib/javatest.j
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/junitQueryTest/a/b/c?m13 \
+		"$(TESTDIR)/junitQueryTest/a/b/c?Test1::m13()" \
 			> $(@:%.ok=%)/jt.log 2>&1 || \
 		true "non-zero exit code from jtreg intentionally ignored"
-	$(GREP) -s "Error: Invalid use of query component: a/b/c?m13" $(@:%.ok=%)/jt.log
+	$(GREP) -s "Error: Invalid use of query component: a/b/c?Test1::m13()" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok
@@ -246,7 +296,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.invalidMethod.ok: $(JTREG_IMAGEDIR)/lib/javatest.
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m14 \
+		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?Test1::m14()" \
 			> $(@:%.ok=%)/jt.log 2>&1 || \
 		true "non-zero exit code from jtreg intentionally ignored"
 	$(GREP) -s 'Could not find method with name \[m14] in class \[Test1]' $(@:%.ok=%)/jt.log
@@ -267,5 +317,7 @@ junit-query-tests: \
     $(BUILDTESTDIR)/JUnitQueryTest.m12.m13.ok \
     $(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok \
     $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.parameterized.ok \
+    $(BUILDTESTDIR)/JUnitQueryTest.nested.class.ok \
     $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok \
     $(BUILDTESTDIR)/JUnitQueryTest.invalidMethod.ok

--- a/test/junitQueryTest/a/b/c/Test1.java
+++ b/test/junitQueryTest/a/b/c/Test1.java
@@ -21,7 +21,15 @@
  * questions.
  */
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * A collection of test methods, to help exercise the query mechanism.
@@ -41,5 +49,37 @@ public class Test1 {
     @Test
     public void m13() {
         System.out.println("Test1.m13");
+    }
+
+    @ParameterizedTest
+    @MethodSource("params")
+    public void parameterized(String str,
+                              NestedClass nested,
+                              boolean z, byte b, char c, short s, int i, long l, float f, double d,
+                              String[] stra,
+                              boolean[] za, byte[] ba, char[] ca, short[] sa, int[] ia, long[] la, float[] fa, double[] da) {
+        System.out.println("Test1.parameterized");
+    }
+
+    static Stream<Arguments> params() {
+        return Stream.of(
+            arguments(
+                    "a",
+                    new NestedClass(),
+                    true, (byte) 42, 'x', (short) 42, 42, 42L, 42.0F, 42.0D,
+                    new String[0],
+                    new boolean[0], new byte[0], new char[0], new short[0], new int[0], new long[0], new float[0], new double[0]
+            )
+        );
+    }
+
+    static class NestedClass {}
+
+    @Nested
+    class NestedTests {
+        @Test
+        public void nested() {
+            System.out.println("Test1.nested");
+        }
     }
 }

--- a/test/testngQueryTest/TestNGQueryTest.gmk
+++ b/test/testngQueryTest/TestNGQueryTest.gmk
@@ -40,8 +40,9 @@ $(BUILDTESTDIR)/TestNGQueryTest.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/ \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m11(): success test Test1.m12(): success test Test1.m13(): success test Test2.m21(): success test Test2.m22(): success test Test2.m23(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	RAN_TESTS=$$( $(ECHO) $$OUT | $(GREP) -oP "(?<=test )[^(]*" | $(TR) '\n' ' ' ) ; \
+	if [ "$$RAN_TESTS" != "Test1.m11 Test1.m12 Test1.m13 Test1.parameterized Test2.m21 Test2.m22 Test2.m23 " ]; then \
+	    echo "unexpected set of tests run: $$RAN_TESTS"; exit 1 ; \
 	fi
 	echo $@ passed at `date` > $@
 
@@ -49,7 +50,7 @@ TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.all.ok
 
 #----------------------------------------------------------------------
 #
-# Execute a single specific method (Test1.m12) using the query syntax  Test1.java?m12
+# Execute a single specific method (Test1.m12) using the query syntax  Test1.java?Test1::m12()
 
 $(BUILDTESTDIR)/TestNGQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
@@ -61,7 +62,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m12()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m12(): success" ]; then \
@@ -74,7 +75,7 @@ TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.m12.ok
 #----------------------------------------------------------------------
 #
 # Execute a mixture of 4 tests:
-# - a single specific method (Test1.m12) using the query syntax  Test1.java?m12
+# - a single specific method (Test1.m12) using the query syntax  Test1.java?Test1::m12()
 # - all (3) test methods in Test2.java
 
 $(BUILDTESTDIR)/TestNGQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
@@ -87,7 +88,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m12()" \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test2.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
@@ -113,8 +114,8 @@ $(BUILDTESTDIR)/TestNGQueryTest.m13.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m13()" \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m12()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m12(): success" ]; then \
@@ -139,8 +140,8 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m12()" \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m13()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m13(): success" ]; then \
@@ -165,12 +166,13 @@ $(BUILDTESTDIR)/TestNGQueryTest.m13.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m13()" \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m11(): success test Test1.m12(): success test Test1.m13(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	RAN_TESTS=$$( $(ECHO) $$OUT | $(GREP) -oP "(?<=test )[^(]*" | $(TR) '\n' ' ' ) ; \
+	if [ "$$RAN_TESTS" != "Test1.m11 Test1.m12 Test1.m13 Test1.parameterized " ]; then \
+	    echo "unexpected set of tests run: $$RAN_TESTS"; exit 1 ; \
 	fi
 	echo $@ passed at `date` > $@
 
@@ -192,7 +194,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-jdk:$(JDKHOME) \
 		-va \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m13()" \
 		 > $(@:%.ok=%)/jt.log 2>&1
 	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
 	if [ "$$OUT" != "test Test1.m13(): success" ]; then \
@@ -201,6 +203,30 @@ $(BUILDTESTDIR)/TestNGQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.all.m13.ok
+
+#----------------------------------------------------------------------
+#
+# parameterizedTest
+
+$(BUILDTESTDIR)/TestNGQueryTest.parameterized.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%)
+	$(MKDIR) $(@:%.ok=%)
+	JT_JAVA=$(JDKHOME) JTHOME=$(JTREG_IMAGEDIR) \
+	    $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::parameterized(java.lang.String,Test1\$$NestedClass,boolean,byte,char,short,int,long,float,double,[Ljava.lang.String;,[Z,[B,[C,[S,[I,[J,[F,[D)" \
+		 > $(@:%.ok=%)/jt.log 2>&1
+	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	if [ -n "$${OUT%%Test1.parameterized*}" ]; then \
+	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
+	fi
+	echo $@ passed at `date` > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.parameterized.ok
 
 #----------------------------------------------------------------------
 #
@@ -216,10 +242,10 @@ $(BUILDTESTDIR)/TestNGQueryTest.invalidQuery.ok: $(JTREG_IMAGEDIR)/lib/javatest.
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/testngQueryTest/a/b/c?m13 \
+		"$(TESTDIR)/testngQueryTest/a/b/c?Test1::m13()" \
 			> $(@:%.ok=%)/jt.log 2>&1 || \
 		true "non-zero exit code from jtreg intentionally ignored"
-	$(GREP) -s "Error: Invalid use of query component: a/b/c?m13" $(@:%.ok=%)/jt.log
+	$(GREP) -s "Error: Invalid use of query component: a/b/c?Test1::m13()" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.invalidQuery.ok
@@ -239,11 +265,11 @@ $(BUILDTESTDIR)/TestNGQueryTest.invalidMethod.ok: $(JTREG_IMAGEDIR)/lib/javatest
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
-		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m14 \
+		"$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?Test1::m14()" \
 			> $(@:%.ok=%)/jt.log 2>&1 || \
 		true "non-zero exit code from jtreg intentionally ignored"
-	$(GREP) -s 'Could not find method with name \[m14] in class \[Test1]' $(@:%.ok=%)/jt.log
-	$(GREP) -s "TEST RESULT: Failed. Execution failed: .*TestNGException: Could not find method with name" $(@:%.ok=%)/jt.log
+	$(GREP) -s 'Could not find method with query \[Test1::m14()]' $(@:%.ok=%)/jt.log
+	$(GREP) -s "TEST RESULT: Failed. Execution failed: .*TestNGException: Could not find method with query" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.invalidMethod.ok
 
@@ -259,5 +285,6 @@ testng-query-tests: \
     $(BUILDTESTDIR)/TestNGQueryTest.m12.m13.ok \
     $(BUILDTESTDIR)/TestNGQueryTest.m13.all.ok \
     $(BUILDTESTDIR)/TestNGQueryTest.all.m13.ok \
+    $(BUILDTESTDIR)/TestNGQueryTest.parameterized.ok \
     $(BUILDTESTDIR)/TestNGQueryTest.invalidQuery.ok \
     $(BUILDTESTDIR)/TestNGQueryTest.invalidMethod.ok

--- a/test/testngQueryTest/a/b/c/Test1.java
+++ b/test/testngQueryTest/a/b/c/Test1.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -42,4 +43,28 @@ public class Test1 {
     public void m13() {
         System.out.println("Test1.m13");
     }
+
+    @Test(dataProvider = "params")
+    public void parameterized(String str,
+                              NestedClass nested,
+                              boolean z, byte b, char c, short s, int i, long l, float f, double d,
+                              String[] stra,
+                              boolean[] za, byte[] ba, char[] ca, short[] sa, int[] ia, long[] la, float[] fa, double[] da) {
+        System.out.println("Test1.parameterized");
+    }
+
+    @DataProvider
+    static Object[][] params() {
+        return new Object[][]{
+                new Object[]{
+                        "a",
+                        new NestedClass(),
+                        true, (byte) 42, 'x', (short) 42, 42, 42L, 42.0F, 42.0D,
+                        new String[0],
+                        new boolean[0], new byte[0], new char[0], new short[0], new int[0], new long[0], new float[0], new double[0]
+                }
+        };
+    }
+
+    static class NestedClass {}
 }


### PR DESCRIPTION
See the JBS issue for an extended problem description.

This PR adds support for running individual parameterized JUnit test methods, as well as nested test classes, by extending the format that a query string can have. The new proposed format is as follows:

```
<class name>[::<method name>([<param type>[...,<param type>]])]
```

For example, running a method `foo` that takes no parameters would be done using `<test name>?TestClass::foo()`. If `foo` has parameters, then at least for JUnit tests they have to be specified as a comma separated list of binary names between the parentheses. For example:

```
TestDowncallScope::testDowncall(int,java.lang.String,CallGeneratorHelper$Ret,java.util.List,java.util.List)
```

The delimiting characters I choose here `::` and `(...)` have to be quoted when passed through most shells. If this is deemed to be an issue, we could also change the separators for class name/method name/parameters to simple hyphens. Although, in cases where a `$` sign appears in the binary name of a nested class, quoting would be needed either way. (I would personally choose to always quote the argument, just to be sure, so I don't mind using `::` and `(...)`).

Testing, I've added additional tests for the new cases (as far as I know, TestNG does not support nested test classes though). I've also been using a PoC of this feature as the basis for similar support in the intellij plugin that I'm working on.