### PR TITLE
7903953: Use scratch directory for JUnit's TempDir annotation

### DIFF
--- a/test/junitTrace/JUnitTrace.gmk
+++ b/test/junitTrace/JUnitTrace.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ $(BUILDTESTDIR)/JUnitTrace.othervm.ok: \
 		$(TESTDIR)/junitTrace/  \
 			> $(@:%.ok=%/jt.log) 2>&1 || \
 			true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s 'Test results: passed: 2; failed: 2' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'Test results: passed: 3; failed: 2' $(@:%.ok=%/jt.log)  > /dev/null
 	$(GREP) -s "java.lang.NullPointerException: NPE" $(@:%.ok=%/work/NPE.jtr) > /dev/null
 	$(GREP) -s "Intentionally thrown before all" $(@:%.ok=%/work/JupiterLifecycle.jtr) > /dev/null
 	$(GREP) -s "Intentionally thrown after all" $(@:%.ok=%/work/JupiterLifecycle.jtr) > /dev/null

--- a/test/junitTrace/JupiterTempDir.java
+++ b/test/junitTrace/JupiterTempDir.java
@@ -21,13 +21,14 @@
  * questions.
  */
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /*
  * @test
@@ -36,13 +37,15 @@ import java.nio.file.Path;
  */
 class JupiterTempDir {
     @Test
-    @EnabledIfSystemProperty(named = "test.name", matches = "JupiterTempDir.java")
-    void test(@TempDir Path temporary) throws Exception {
+    void currentWorkingDirectoryIsParentOfTemporaryDirectory(@TempDir Path temporary) {
+        assumeTrue(System.getProperty("test.file") != null, "jtreg not running");
+
+        assertTrue(Files.isDirectory(temporary), "temporary directory expected");
+
         var currentWorkingDirectory = Path.of("");
         var expected = currentWorkingDirectory.toAbsolutePath().toString();
         var actual = temporary.getParent().toAbsolutePath().toString();
-        Assertions.assertEquals(expected, actual, "Unexpected root for temporary files");
 
-        Files.createTempFile(temporary, "temp-", ".temp");
+        assertEquals(expected, actual, "unexpected parent directory for temporary files");
     }
 }

--- a/test/junitTrace/JupiterTempDir.java
+++ b/test/junitTrace/JupiterTempDir.java
@@ -38,7 +38,9 @@ import org.junit.jupiter.api.io.TempDir;
 class JupiterTempDir {
     @Test
     void currentWorkingDirectoryIsParentOfTemporaryDirectory(@TempDir Path temporary) {
-        assumeTrue(System.getProperty("test.file") != null, "jtreg not running");
+        // Verify that this test was launched through jtreg launcher, which sets the `test.file`
+        // system property. Find a list of them at https://openjdk.org/jtreg/tag-spec.html#testvars
+        assumeTrue(System.getProperty("test.file") != null, "jtreg launched this test");
 
         assertTrue(Files.isDirectory(temporary), "temporary directory expected");
 

--- a/test/junitTrace/JupiterTempDir.java
+++ b/test/junitTrace/JupiterTempDir.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/*
+ * @test
+ * @bug 7903953
+ * @run junit JupiterTempDir
+ */
+class JupiterTempDir {
+    @Test
+    @EnabledIfSystemProperty(named = "test.name", matches = "JupiterTempDir.java")
+    void test(@TempDir Path temporary) throws Exception {
+        var currentWorkingDirectory = Path.of("");
+        var expected = currentWorkingDirectory.toAbsolutePath().toString();
+        var actual = temporary.getParent().toAbsolutePath().toString();
+        Assertions.assertEquals(expected, actual, "Unexpected root for temporary files");
+
+        Files.createTempFile(temporary, "temp-", ".temp");
+    }
+}


### PR DESCRIPTION
Please review this change to use `jtreg`'s scratch directory for JUnit's `@TempDir` annotation.

Prior to this change, the standard implementation of JUnit Jupiter using the system default temporary directory is active, effectively decoupling the location of "interesting on failure" files from `jtreg`:
> When `jtreg` executes a test, the current directory for the test is set to a scratch directory so that the test can easily write any temporary files.

Find more details about `jtreg`'s scratch directory at https://openjdk.org/jtreg/faq.html#scratch-directory

In addition to use the current working directory for `@TempDir` annotated paths, this change also switches off JUnit's built-in cleanup of temporary files - leaving it to `jtreg` to care about it, see for example the help message for  the `-retain` command-line option:

```
    -retain | -retain:<pass,fail,error,all,file-pattern>,...
                    Specify files to be retained after each test completes
                    executing. If -retain is not specified, only the files from
                    the last test executed will be retained. If -retain is
                    specified with no argument, all files will be retained.
                    Otherwise, the files may be described by one or more of the
                    following values:
        none            Do not retain any of the files generated by each test
        pass            Retain files generated by tests that pass
        fail            Retain files generated by tests that fail
        error           Retain files generated by tests that caused an error
        all             Retain all files generated by each test
        file-pattern    Retain files that match a specific filename. The name
                        may contain '*' to match any sequence of characters. For
                        example, result.* or *.err.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903953](https://bugs.openjdk.org/browse/CODETOOLS-7903953): Use scratch directory for JUnit's TempDir annotation (**Enhancement** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/248/head:pull/248` \
`$ git checkout pull/248`

Update a local copy of the PR: \
`$ git checkout pull/248` \
`$ git pull https://git.openjdk.org/jtreg.git pull/248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 248`

View PR using the GUI difftool: \
`$ git pr show -t 248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/248.diff">https://git.openjdk.org/jtreg/pull/248.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/248#issuecomment-2677711781)
</details>
