### PR TITLE
7903955: jtreg doesn't support .jasm in patch module

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -210,7 +210,7 @@ public class CompileAction extends Action {
 
             if (currArg.endsWith(".java")) {
                 foundJavaFile = true;
-            } else if (currArg.endsWith(".jasm") || currArg.endsWith("jcod")) {
+            } else if (currArg.endsWith(".jasm") || currArg.endsWith(".jcod")) {
                 foundAsmFile = true;
             }
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -210,6 +210,11 @@ public class CompileAction extends Action {
 
             if (currArg.endsWith(".java")) {
                 foundJavaFile = true;
+            } else if (currArg.endsWith(".jasm") || currArg.endsWith("jcod")) {
+                foundAsmFile = true;
+            }
+
+            if (foundJavaFile || foundAsmFile) {
                 File sourceFile = new File(currArg.replace('/', File.separatorChar));
                 if (!sourceFile.isAbsolute()) {
                     // User must have used @compile, so file must be
@@ -217,22 +222,6 @@ public class CompileAction extends Action {
                     if (multiModule)
                         addModule(currArg);
                     Path absSourceFile = locations.absTestSrcFile(module, sourceFile);
-                    if (!Files.exists(absSourceFile))
-                        throw new ParseException(CANT_FIND_SRC + currArg);
-                    args.set(i, absSourceFile.toString());
-                }
-            } else if (currArg.endsWith(".jasm") || currArg.endsWith("jcod")) {
-                if (module != null) {
-                    throw new ParseException(COMPILE_OPT_DISALLOW);
-                }
-                foundAsmFile = true;
-                File sourceFile = new File(currArg.replace('/', File.separatorChar));
-                if (!sourceFile.isAbsolute()) {
-                    // User must have used @compile, so file must be
-                    // in the same directory as the defining file.
-                    if (multiModule)
-                        addModule(currArg);
-                    Path absSourceFile = locations.absTestSrcFile(null, sourceFile);
                     if (!Files.exists(absSourceFile))
                         throw new ParseException(CANT_FIND_SRC + currArg);
                     args.set(i, absSourceFile.toString());

--- a/test/modlibs/ModLibsTest.gmk
+++ b/test/modlibs/ModLibsTest.gmk
@@ -45,9 +45,6 @@ $(BUILDTESTDIR)/ModLibsTest.agentvm.ok: \
 	echo "test passed at `date`" > $@
 
 
-ifdef JDK9HOME
 TESTS.jtreg += \
 	$(BUILDTESTDIR)/ModLibsTest.othervm.ok \
 	$(BUILDTESTDIR)/ModLibsTest.agentvm.ok
-endif
-

--- a/test/modlibs/ModLibsTest.gmk
+++ b/test/modlibs/ModLibsTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ $(BUILDTESTDIR)/ModLibsTest.agentvm.ok: \
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-J-Djavatest.regtest.allowTrailingBuild=true \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
-		-jdk:$(JDK9HOME) \
+		-jdk:$(JDKHOME) \
 		$(@:$(BUILDTESTDIR)/ModLibsTest.%.ok=-%) \
 		$(TESTDIR)/modlibs
 	( cd $(@:%.ok=%)/work ; $(FIND) . -name \*.class ) | \

--- a/test/modlibs/compileAction/patch/java.base/java/io/IOHelper2.jasm
+++ b/test/modlibs/compileAction/patch/java.base/java/io/IOHelper2.jasm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,9 @@
  * questions.
  */
 
-/*
- * @test
- * @compile/module=java.base java/io/IOHelper.java
- * @compile/module=java.base java/io/IOHelper2.jasm
- */
+package java/io;
+
+public class IOHelper2
+    version 58:0
+{
+} // end class IOHelper2

--- a/test/modlibs/expect-classes.txt
+++ b/test/modlibs/expect-classes.txt
@@ -16,6 +16,7 @@
 ./classes/buildAction/usermods/BuildUserModPackage.d/modules/um4/um4_p1/um4_q1/um4_r1/um4_p1_q1_r1_B2.class
 ./classes/compileAction/packages/CompilePkg.d/p/C.class
 ./classes/compileAction/patch/CompilePatch.d/patches/java.base/java/io/IOHelper.class
+./classes/compileAction/patch/CompilePatch.d/patches/java.base/java/io/IOHelper2.class
 ./classes/compileAction/usermods/CompileUserMod.d/modules/um1/module-info.class
 ./classes/compileAction/usermods/CompileUserMod.d/modules/um1/um1_p1/um1_p1_C.class
 ./classes/compileAction/usermods/CompileUserMods.d/modules/um2/module-info.class


### PR DESCRIPTION
Please review this change to support compilation of `.jasm` in patched modules.

Prior to this commit an extra check for `module != null` was the only difference when treating `.java` source files and JASM-related files. With that check removed, the handling of both types of source files could be merged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903955](https://bugs.openjdk.org/browse/CODETOOLS-7903955): jtreg doesn't support .jasm in patch module (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.org/jtreg.git pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/249.diff">https://git.openjdk.org/jtreg/pull/249.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/249#issuecomment-2690280365)
</details>
