### PR TITLE
7903963: Fix "Run Configuration" Window Freeze Issue

### DIFF
--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/ui/JTRegConfigurable.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/ui/JTRegConfigurable.java
@@ -132,19 +132,19 @@ public class JTRegConfigurable<T extends JTRegConfiguration> extends SettingsEdi
      * @see org.jetbrains.jps.model.java.impl.JdkVersionDetectorImpl#detectJdkVersionInfo
      */
     private void applyEditorJrePathTo(@NotNull JTRegConfiguration configuration) {
-        final ComboBox<JrePathEditor.JreComboBoxItem> jreComboBox = jrePathEditor.getComponent();
-        final ComboBoxEditor jreComboBoxEditor = jreComboBox.getEditor();
-        final JBTextField jreTextField = (JBTextField) jreComboBoxEditor.getEditorComponent();
+        ComboBox<JrePathEditor.JreComboBoxItem> jreComboBox = jrePathEditor.getComponent();
+        ComboBoxEditor jreComboBoxEditor = jreComboBox.getEditor();
+        JBTextField jreTextField = (JBTextField) jreComboBoxEditor.getEditorComponent();
 
-        final String jrePathOrNameText = jreTextField.getText().trim();
-        final boolean inList = IntStream.range(0, jreComboBox.getItemCount())
+        String jrePathOrNameText = jreTextField.getText().trim();
+        boolean inList = IntStream.range(0, jreComboBox.getItemCount())
                 .mapToObj(jreComboBox::getItemAt)
                 .map(JrePathEditor.JreComboBoxItem::getPresentableText)
                 .filter(Objects::nonNull)
                 .anyMatch(pathOrName -> pathOrName.equals(jrePathOrNameText));
 
-        final String alternativeJrePath;
-        final boolean alternativeJREPathEnabled;
+        String alternativeJrePath;
+        boolean alternativeJREPathEnabled;
         if (inList) { // safe to get item from JRE path editor
             alternativeJrePath = jrePathEditor.getJrePathOrName();
             alternativeJREPathEnabled = jrePathEditor.isAlternativeJreSelected();


### PR DESCRIPTION
# When the Problem Occurs

The JTReg "Run Configuration" window freezes when the user selects a JRE that is not present in the project's SDK list.

# Why the Problem Occurs

There is a method `applyEditorTo` in the `JTRegConfigurable.java` class, which is called repeatedly while the "Run Configuration" window is open. Within this method, the method `jrePathEditor.getJrePathOrName()` is invoked. As a result, when this method is called for a JRE path not listed in IDEA, it attempts to determine the Java version. If the user has selected a raw JDK image, a Java process is launched, and the version is obtained from the process output (see [org.jetbrains.jps.model.java.impl.JdkVersionDetectorImpl#detectJdkVersionInfo](https://github.com/JetBrains/intellij-community/blob/baba77ecf93f44a2ccb34e5b206e03c60817d511/jps/model-impl/src/org/jetbrains/jps/model/java/impl/JdkVersionDetectorImpl.java#L40)). 

This call is too resource-intensive to be executed on the UI thread, causing the window to freeze.

# Steps to reproduce

1. Open a JDK project.  
2. Open the "Project Structure" window.  
3. Navigate to "Platform Settings → SDKs".
4. Remove the JDK that is used as the JRE for tests, or create a copy of this JDK on your file system.  
5. Create a new "JTReg Run Configuration".  
6. In the "JRE" field, select a JDK path that is not present in the Project SDK list (either the removed JDK or the copied one).  

## Actual result
- The window starts freezing, even after saving and reopening it.

# Implemented Changes

## JTRegConfigurable.java
- Fix Javadoc for the class.
- Remove unused class field: `jtregDir`.
- Add Javadoc to the methods: `createUIComponents`, `applyEditorTo`, `resetEditorFrom`
- Fix window freeze caused by `jrePathEditor` in the method `applyEditorTo`.
- Add method `applyEditorJrePathTo` to optimize data retrieval from `jrePathEditor`.

Since I implemented changes in this file, I also took the opportunity to clean up the code a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903963](https://bugs.openjdk.org/browse/CODETOOLS-7903963): Fix "Run Configuration" Window Freeze Issue (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/250/head:pull/250` \
`$ git checkout pull/250`

Update a local copy of the PR: \
`$ git checkout pull/250` \
`$ git pull https://git.openjdk.org/jtreg.git pull/250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 250`

View PR using the GUI difftool: \
`$ git pr show -t 250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/250.diff">https://git.openjdk.org/jtreg/pull/250.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/250#issuecomment-2706993787)
</details>
