### PR TITLE
7903964: Fix NPE in JTRegConfiguration.getJDKString

### DIFF
--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfiguration.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfiguration.java
@@ -84,7 +84,7 @@ public class JTRegConfiguration extends JavaTestConfigurationBase {
     }
 
     @Override
-    public void setEnvs(Map<String, String> map) {
+    public void setEnvs(@NotNull Map<String, String> map) {
     }
 
     @NotNull
@@ -120,14 +120,14 @@ public class JTRegConfiguration extends JavaTestConfigurationBase {
     }
 
     @Override
-    public void readExternal(Element element) throws InvalidDataException {
+    public void readExternal(@NotNull Element element) throws InvalidDataException {
         super.readExternal(element);
         XmlSerializer.deserializeInto(this, element);
     }
 
 
     @Override
-    public void writeExternal(Element element) throws WriteExternalException {
+    public void writeExternal(@NotNull Element element) throws WriteExternalException {
         super.writeExternal(element);
 
         XmlSerializer.serializeInto(this, element);
@@ -152,7 +152,7 @@ public class JTRegConfiguration extends JavaTestConfigurationBase {
     }
 
     @Override
-    public SMTRunnerConsoleProperties createTestConsoleProperties(Executor executor) {
+    public @NotNull SMTRunnerConsoleProperties createTestConsoleProperties(@NotNull Executor executor) {
         //produces some additional benefits for rerun failed tests, etc
         return new JTRegConfigurationConsoleProperties(executor, JTRegConfiguration.this);
     }
@@ -193,19 +193,31 @@ public class JTRegConfiguration extends JavaTestConfigurationBase {
         }
     }
 
-    String getJDKString() {
+    /**
+     * Returns the path to the JDK used by JTReg.
+     *
+     * @return the JDK path, or {@code null} if no JDK is selected or if it is invalid.
+     */
+    @Nullable String getJDKString() {
         String jdkString = null;
-        if (isAlternativeJrePathEnabled()) {
-            String jdkPathString = getAlternativeJrePath();
-            Sdk sdk = ProjectJdkTable.getInstance().findJdk(jdkPathString);
-            if (sdk != null) {
-                jdkString = sdk.getHomePath();
-            } else if (JdkUtil.checkForJdk(jdkPathString)) {
-                jdkString = jdkPathString;
+        final ProjectJdkTable projectJdkTable = ProjectJdkTable.getInstance();
+        if (alternativeJrePathEnabled) {
+            if (null != alternativeJrePath) {
+                final Sdk sdk = projectJdkTable.findJdk(alternativeJrePath);
+                if (null != sdk) {
+                    jdkString = sdk.getHomePath();
+                } else if (JdkUtil.checkForJdk(alternativeJrePath)) {
+                    jdkString = alternativeJrePath;
+                }
             }
-        } else {
-            String defaultJdk = DefaultJreSelector.projectSdk(getProject()).getNameAndDescription().first;
-            jdkString = ProjectJdkTable.getInstance().findJdk(defaultJdk).getHomePath();
+        } else { // Default SDK is chosen
+            final String defaultJDKName = DefaultJreSelector.projectSdk(getProject()).getNameAndDescription().first;
+            if (null != defaultJDKName) {
+                final Sdk projectSDK = projectJdkTable.findJdk(defaultJDKName);
+                if (null != projectSDK) {
+                    jdkString = projectSDK.getHomePath();
+                }
+            }
         }
         return jdkString;
     }

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfiguration.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfiguration.java
@@ -200,10 +200,10 @@ public class JTRegConfiguration extends JavaTestConfigurationBase {
      */
     @Nullable String getJDKString() {
         String jdkString = null;
-        final ProjectJdkTable projectJdkTable = ProjectJdkTable.getInstance();
+        ProjectJdkTable projectJdkTable = ProjectJdkTable.getInstance();
         if (alternativeJrePathEnabled) {
             if (null != alternativeJrePath) {
-                final Sdk sdk = projectJdkTable.findJdk(alternativeJrePath);
+                Sdk sdk = projectJdkTable.findJdk(alternativeJrePath);
                 if (null != sdk) {
                     jdkString = sdk.getHomePath();
                 } else if (JdkUtil.checkForJdk(alternativeJrePath)) {
@@ -211,9 +211,9 @@ public class JTRegConfiguration extends JavaTestConfigurationBase {
                 }
             }
         } else { // Default SDK is chosen
-            final String defaultJDKName = DefaultJreSelector.projectSdk(getProject()).getNameAndDescription().first;
+            String defaultJDKName = DefaultJreSelector.projectSdk(getProject()).getNameAndDescription().first;
             if (null != defaultJDKName) {
-                final Sdk projectSDK = projectJdkTable.findJdk(defaultJDKName);
+                Sdk projectSDK = projectJdkTable.findJdk(defaultJDKName);
                 if (null != projectSDK) {
                     jdkString = projectSDK.getHomePath();
                 }

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
@@ -56,7 +56,7 @@ import java.util.stream.Stream;
 /**
  * This class tells the IDE how a given configuration should be translated into an actual command line invocation.
  */
-class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableState<JTRegConfiguration> {
+public class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableState<JTRegConfiguration> {
 
     private final JTRegConfiguration myConfiguration;
 


### PR DESCRIPTION
# This bug appears when
- The user removes the "Build" target from "Before launch" in the Run Configuration.
- The user unsets or does not set the Project SDK, or if it has been removed from the file system.

# Steps to reproduce

1. Open a JDK project.
2. Open "Project Structure".
3. Select an SDK in the Project tab.
4. Navigate to "Settings → jtreg".
5. Set "JRE = "Default".
6. Run a test to automatically create a run configuration, or manually create one with "JRE = Default".
7. Open Project Structure again.
8. Set SDK = "&lt;No SDK&gt;".
9. Edit the previously created Run Configuration and remove the "Build" target from "Before launch".
10. Run the previously created Run Configuration.

## Expected
- Error message appeared: "No valid JDK configured for running jtreg tests"

## Actual:
- Nothing happened

# Implemented Changes

## JTRegConfiguration.java
- Add the `@NotNull` annotation to methods that are missing it but have it in the parent method.
- Add javadoc to `getJDKString`.
- Refactor `getJDKString`:
  - Fix method getJDKString, to prevent NPE when Default SDK for the project was not set

## JTRegConfigurationRunnableState.java
- Change visibility to `public` to eliminate the warning in `JTRegConfiguration#getState`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903964](https://bugs.openjdk.org/browse/CODETOOLS-7903964): Fix NPE in JTRegConfiguration.getJDKString (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/251/head:pull/251` \
`$ git checkout pull/251`

Update a local copy of the PR: \
`$ git checkout pull/251` \
`$ git pull https://git.openjdk.org/jtreg.git pull/251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 251`

View PR using the GUI difftool: \
`$ git pr show -t 251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/251.diff">https://git.openjdk.org/jtreg/pull/251.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/251#issuecomment-2706879943)
</details>
