### PR TITLE
7903969: Update year in copyright message

### DIFF
--- a/src/share/classes/com/sun/javatest/diff/Help.java
+++ b/src/share/classes/com/sun/javatest/diff/Help.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,7 +143,6 @@ public class Help {
          */
 
         out.println(i18n.getString("help.version.txt", versionArgs));
-        out.println(i18n.getString("help.copyright.txt"));
     }
 
     private File getDocDir() {
@@ -284,8 +283,6 @@ public class Help {
             ww.write(i18n.getString("help.cmd.tail"));
             ww.write("\n\n");
             ww.write(i18n.getString("help.cmd.ant"));
-            ww.write("\n\n");
-            ww.write(i18n.getString("help.copyright.txt"));
             ww.write("\n\n");
 
             ww.flush();

--- a/src/share/classes/com/sun/javatest/diff/i18n.properties
+++ b/src/share/classes/com/sun/javatest/diff/i18n.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ help.cmd.noEntriesFound=No entries were found that matched your query.
 help.cmd.proto=Usage:\n\t{0} options... [directory|file]...
 help.cmd.summaryHead=Information is available for the following topics:
 help.cmd.tail=
-help.copyright.txt=Copyright (c) 2008, 2013 Oracle and/or its affiliates. \
+help.copyright.txt=Copyright (c) 2008, 2025 Oracle and/or its affiliates. \
     All rights reserved.\nUse is subject to license terms.
 
 help.compare.name=Compare Options

--- a/src/share/classes/com/sun/javatest/regtest/tool/Help.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Help.java
@@ -241,7 +241,6 @@ public class Help {
          */
 
         out.println(i18n.getString("help.version.txt", versionArgs));
-        out.println(i18n.getString("help.copyright.txt"));
         for (VersionHelper h: versionHelpers)
             h.showVersion(out);
     }
@@ -401,8 +400,6 @@ public class Help {
                 }
             }
 
-            ww.write('\n');
-            ww.write(i18n.getString("help.copyright.txt"));
             ww.write("\n\n");
 
             ww.flush();

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ help.cmd.introHead=For brief details about a topic, use "-help <term> ...". \
     available for the following topics.\n
 help.cmd.fullHead=
 help.cmd.summaryHead=Information is available for the following topics:
-help.copyright.txt=Copyright (c) 1999, 2022, Oracle and/or its affiliates. \
+help.copyright.txt=Copyright (c) 1999, 2025, Oracle and/or its affiliates. \
     All rights reserved.\nUse is subject to license terms.
 help.cmd.noEntriesFound=No entries were found that matched your query.
 


### PR DESCRIPTION
Please review this change updating the second year of the copyright to 2025.

This PR also removes the copyright from command-line printouts of `jtreg` and `jtdiff`, for example in `jtreg --help` calls.