### PR TITLE
7903971: Restore propagation of preview flag into library code

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -363,11 +363,7 @@ public class CompileAction extends Action {
             }
         }
 
-        if (runJavac
-                && !script.disablePreview()
-                && !seenEnablePreview
-                && (script.enablePreview())
-                && (libLocn == null || libLocn.isTest())) {
+        if (runJavac && script.enablePreview() && !seenEnablePreview) {
             String version = script.getTestJDKVersion().name();
             // always prepend in order to not mess with variadic arguments
             if (!seenSourceOrRelease) {

--- a/test/libBuildArgs/lib/LIBRARY.properties
+++ b/test/libBuildArgs/lib/LIBRARY.properties
@@ -1,1 +1,0 @@
-enablePreview = true

--- a/test/preview/PreviewTest.gmk
+++ b/test/preview/PreviewTest.gmk
@@ -32,7 +32,7 @@ $(BUILDTESTDIR)/PreviewTest_good.ok: \
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		-javacoptions:-XDforcePreview
+		-javacoptions:-XDforcePreview \
 		'-k:!bad' \
 		$(TESTDIR)/preview/  \
 			> $(@:%.ok=%/jt.log)
@@ -46,7 +46,7 @@ $(BUILDTESTDIR)/PreviewTest_bad.ok: \
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
-		-javacoptions:-XDforcePreview
+		-javacoptions:-XDforcePreview \
 		'-k:bad' \
 		$(TESTDIR)/preview/  \
 			> $(@:%.ok=%/jt.log) || \

--- a/test/preview/PreviewTest.gmk
+++ b/test/preview/PreviewTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,14 @@
 
 #----------------------------------------------------------------------
 
-ifdef JDK14HOME
-
 $(BUILDTESTDIR)/PreviewTest_good.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
-		-jdk:$(JDK14HOME) \
+		-jdk:$(JDKHOME) \
+		-javacoptions:-XDforcePreview
 		'-k:!bad' \
 		$(TESTDIR)/preview/  \
 			> $(@:%.ok=%/jt.log)
@@ -46,7 +45,8 @@ $(BUILDTESTDIR)/PreviewTest_bad.ok: \
 	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	JTREG_JAVA=$(JDKJAVA) $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
-		-jdk:$(JDK14HOME) \
+		-jdk:$(JDKHOME) \
+		-javacoptions:-XDforcePreview
 		'-k:bad' \
 		$(TESTDIR)/preview/  \
 			> $(@:%.ok=%/jt.log) || \
@@ -56,5 +56,3 @@ $(BUILDTESTDIR)/PreviewTest_bad.ok: \
 
 TESTS.jtreg += $(BUILDTESTDIR)/PreviewTest_good.ok
 TESTS.jtreg += $(BUILDTESTDIR)/PreviewTest_bad.ok
-
-endif

--- a/test/preview/TEST.ROOT
+++ b/test/preview/TEST.ROOT
@@ -1,2 +1,6 @@
+#
+# Run `jtreg` with `-javacoptions:-XDforcePreview` to not rely JDK-specific preview features
+#
+
 keys = bad
 allowSmartActionArgs = true

--- a/test/previewLeaking/TEST.ROOT
+++ b/test/previewLeaking/TEST.ROOT
@@ -1,0 +1,3 @@
+#
+# Run `jtreg` with `-javacoptions:-XDforcePreview` to not rely JDK-specific preview features
+#

--- a/test/previewLeaking/TestPreviewLeaking.gmk
+++ b/test/previewLeaking/TestPreviewLeaking.gmk
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#----------------------------------------------------------------------
+#
+# Verify preview flag leaks into library class compilation
+
+$(BUILDTESTDIR)/PreviewLeaking.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-va \
+		-javacoptions:-XDforcePreview
+		$(TESTDIR)/previewLeaking
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += \
+	$(BUILDTESTDIR)/TestPreviewLeaking.ok
+

--- a/test/previewLeaking/TestPreviewLeaking.gmk
+++ b/test/previewLeaking/TestPreviewLeaking.gmk
@@ -34,8 +34,8 @@ $(BUILDTESTDIR)/PreviewLeakingTest.ok: \
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
+		-javacoptions:-XDforcePreview \
 		-va \
-		-javacoptions:-XDforcePreview
 		$(TESTDIR)/previewLeaking/
 	echo "test passed at `date`" > $@
 

--- a/test/previewLeaking/TestPreviewLeaking.gmk
+++ b/test/previewLeaking/TestPreviewLeaking.gmk
@@ -27,17 +27,16 @@
 #
 # Verify preview flag leaks into library class compilation
 
-$(BUILDTESTDIR)/PreviewLeaking.ok: \
+$(BUILDTESTDIR)/PreviewLeakingTest.ok: \
 	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
 	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
 	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDKHOME) \
 		-va \
 		-javacoptions:-XDforcePreview
-		$(TESTDIR)/previewLeaking
+		$(TESTDIR)/previewLeaking/
 	echo "test passed at `date`" > $@
 
-TESTS.jtreg += \
-	$(BUILDTESTDIR)/TestPreviewLeaking.ok
-
+TESTS.jtreg += $(BUILDTESTDIR)/PreviewLeakingTest.ok

--- a/test/previewLeaking/lib/Lib.java
+++ b/test/previewLeaking/lib/Lib.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+record Lib() {}

--- a/test/previewLeaking/tag/PreviewTest.java
+++ b/test/previewLeaking/tag/PreviewTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @library /lib
+ * @build Lib PreviewTest
+ * @run main PreviewTest
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+
+public class PreviewTest {
+  public static void main(String... args) {
+    System.err.println(new Lib());
+    var model = parseClassModel(Lib.class);
+    if (model.minorVersion() != ClassFile.PREVIEW_MINOR_VERSION) {
+      throw new AssertionError(Lib.class + " not in preview: " + model.toDebugString());
+    }
+  }
+
+  static ClassModel parseClassModel(Class<?> type) {
+    return parseClassModel(type, ClassFile.of());
+  }
+
+  static ClassModel parseClassModel(Class<?> type, ClassFile context) {
+    var name = type.getName().replace('.', '/') + ".class";
+    try (var in = type.getClassLoader().getResourceAsStream(name)) {
+      if (in == null) throw new RuntimeException("Resource not found: " + name);
+      var out = new ByteArrayOutputStream(1024);
+      in.transferTo(out);
+      return context.parse(out.toByteArray());
+    } catch (Exception exception) {
+      throw new RuntimeException("Reading resource failed: " + name, exception);
+    }
+  }
+}


### PR DESCRIPTION
Please review this change restoring the propagation of the preview flag into compilation of library code.

This will complete the removal of the problematic `LIBRARY.properties` implementation started with [CODETOOLS-7903940](https://bugs.openjdk.org/browse/CODETOOLS-7903940)

See: https://github.com/openjdk/jtreg/blob/9d253be7d40d9fa4ab671066b959711566942485/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java#L366

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903971](https://bugs.openjdk.org/browse/CODETOOLS-7903971): Restore propagation of preview flag into library code (**Sub-task** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [0e33b2bd](https://git.openjdk.org/jtreg/pull/255/files/0e33b2bd4309320d317e18f25baf1c2694ebd93f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/255/head:pull/255` \
`$ git checkout pull/255`

Update a local copy of the PR: \
`$ git checkout pull/255` \
`$ git pull https://git.openjdk.org/jtreg.git pull/255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 255`

View PR using the GUI difftool: \
`$ git pr show -t 255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/255.diff">https://git.openjdk.org/jtreg/pull/255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/255#issuecomment-2757614460)
</details>
