### PR TITLE
7903988: IDEA plugin: temp directories don't work on Windows

### DIFF
--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
@@ -95,6 +95,13 @@ public class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableSt
         return TestSearchScope.SINGLE_MODULE;
     }
 
+    private static void forwardTempVar(JavaParameters parameters, String varName) {
+        String value = System.getenv(varName);
+        if (value != null) {
+            parameters.addEnv(varName, value);
+        }
+    }
+
     @Override
     protected JavaParameters createJavaParameters() throws ExecutionException {
 
@@ -112,9 +119,9 @@ public class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableSt
             // Forward temp dir related environment variables. On windows, these are needed to be able to accurately
             // find the temporary directory. (Otherwise we default to 'C:\WINDOWS', which is typically inaccessible).
             // See https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha#remarks
-            javaParameters.addEnv("TMP", System.getenv("TMP"));
-            javaParameters.addEnv("TEMP", System.getenv("TEMP"));
-            javaParameters.addEnv("USERPROFILE", System.getenv("USERPROFILE"));
+            forwardTempVar(javaParameters, "TMP");
+            forwardTempVar(javaParameters, "TEMP");
+            forwardTempVar(javaParameters, "USERPROFILE");
         }
 
         String jdkString = getConfiguration().getJDKString();

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
@@ -187,6 +187,10 @@ public class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableSt
     protected OSProcessHandler createHandler(Executor executor) throws ExecutionException {
         final OSProcessHandler processHandler = new KillableColoredProcessHandler(createCommandLine());
         ProcessTerminatedListener.attach(processHandler);
+        final SearchForTestsTask searchingForTestsTask = createSearchingForTestsTask();
+        if (searchingForTestsTask != null) {
+            searchingForTestsTask.attachTaskToProcess(processHandler);
+        }
         return processHandler;
     }
 
@@ -210,6 +214,12 @@ public class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableSt
      */
     protected boolean isSmRunnerUsed() {
         return true;
+    }
+
+    @Override
+    public SearchForTestsTask createSearchingForTestsTask() {
+        //todo add here test detection based on myConfiguration.getPackage(), for class configuration - do nothing
+        return null;
     }
 
     @NotNull

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
@@ -95,7 +95,7 @@ public class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableSt
         return TestSearchScope.SINGLE_MODULE;
     }
 
-    private static void forwardTempVar(JavaParameters parameters, String varName) {
+    private static void forwardEnvVar(JavaParameters parameters, String varName) {
         String value = System.getenv(varName);
         if (value != null) {
             parameters.addEnv(varName, value);
@@ -119,9 +119,9 @@ public class JTRegConfigurationRunnableState extends JavaTestFrameworkRunnableSt
             // Forward temp dir related environment variables. On windows, these are needed to be able to accurately
             // find the temporary directory. (Otherwise we default to 'C:\WINDOWS', which is typically inaccessible).
             // See https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha#remarks
-            forwardTempVar(javaParameters, "TMP");
-            forwardTempVar(javaParameters, "TEMP");
-            forwardTempVar(javaParameters, "USERPROFILE");
+            forwardEnvVar(javaParameters, "TMP");
+            forwardEnvVar(javaParameters, "TEMP");
+            forwardEnvVar(javaParameters, "USERPROFILE");
         }
 
         String jdkString = getConfiguration().getJDKString();

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/JTRegConfigurationRunnableState.java
@@ -38,11 +38,11 @@ import com.intellij.execution.testframework.SearchForTestsTask;
 import com.intellij.execution.testframework.TestSearchScope;
 import com.intellij.openapi.module.Module;
 import com.intellij.util.PathUtil;
-import com.oracle.plugin.jtreg.util.JTRegUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import com.oracle.plugin.jtreg.executors.JTRegDebuggerRunner;
 import com.oracle.plugin.jtreg.service.JTRegService;
+import com.oracle.plugin.jtreg.util.JTRegUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/util/JTRegUtils.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/util/JTRegUtils.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
  */
 public class JTRegUtils {
 
+    public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
     private static final Logger LOG = Logger.getInstance(JTRegUtils.class);
 
     /**


### PR DESCRIPTION
Copied from the JBS issue:

To find the temporary directory on Windows, one of the environment variables `TMP`, `TEMP`, or `USERPROFILE` is needed [1](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha#remarks). If these are not set, `C:\WINDOWS` is used as a fallback, but this directory is typically inaccessible (and generally not really a directory you want to leave temp files in).

The IDEA plugin currently doesn't forward these variables to the jtreg process that it starts, resulting in them being unset. For tests that e.g. create temporary files or directories, this result in an `AccessDeniedException` such as:

```
java.nio.file.AccessDeniedException: C:\\WINDOWS\\asdf12599356154200781179
  at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:89)
  at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
  at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
  at java.base/sun.nio.fs.WindowsFileSystemProvider.newByteChannel(WindowsFileSystemProvider.java:231)
  at java.base/java.nio.file.Files.newByteChannel(Files.java:357)
  at java.base/java.nio.file.Files.createFile(Files.java:609)
  at java.base/java.nio.file.TempFileHelper.create(TempFileHelper.java:132)
  at java.base/java.nio.file.TempFileHelper.createTempFile(TempFileHelper.java:150)
  at java.base/java.nio.file.Files.createTempFile(Files.java:842)
  at TestTempDir.testTempDir(TestTempDir.java:39)
```

The plugin should forward these environment variables on Windows, to make sure that the temporary directory can be found by tests.

Tested locally with a simple test that calls [`Files::createTempFile`](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)), and checked that these changes prevent an `AccessDeniedError` from being thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903988](https://bugs.openjdk.org/browse/CODETOOLS-7903988): IDEA plugin: temp directories don't work on Windows (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/258/head:pull/258` \
`$ git checkout pull/258`

Update a local copy of the PR: \
`$ git checkout pull/258` \
`$ git pull https://git.openjdk.org/jtreg.git pull/258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 258`

View PR using the GUI difftool: \
`$ git pr show -t 258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/258.diff">https://git.openjdk.org/jtreg/pull/258.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/258#issuecomment-2802186367)
</details>
