### PR TITLE
Default to no error if existing, make parent directories as needed

### DIFF
--- a/make/Defs.gmk
+++ b/make/Defs.gmk
@@ -152,7 +152,7 @@ GREP 	:= $(shell if [ -r /bin/grep ]; then echo /bin/grep ; else echo /usr/bin/g
 endif
 LN	= /bin/ln
 LS	= /bin/ls
-MKDIR 	= /bin/mkdir
+MKDIR 	= /bin/mkdir -p
 MV 	= /bin/mv
 PANDOC  := $(shell if [ -r /usr/bin/pandoc ]; then \
 		echo /usr/bin/pandoc ; \


### PR DESCRIPTION
Prior this change, most usages of the `$(MKDIR)` variable in jtreg's self-tests had to add `-p` in order to not fail with an "error if existing, make parent directories as needed". Many usages are lacking the flag and in concurrent test scenarios, this leads to flaky tests.

This PR appends `-p` to each expansion of `$(MKDIR)`. Hard-coded `-p` will be removed; stray/duplicate `-p` flag don't seem to be a problem for `mkdir`'s option parser. I didn't see any "-p specifed more than once" warnings.