### PR TITLE
7904002: @compile directives with args after file name fail after 7903955

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -208,13 +208,17 @@ public class CompileAction extends Action {
             // note: in the following code, some args are overwritten in place
             String currArg = args.get(i);
 
+            boolean isSourceFile = false;
+
             if (currArg.endsWith(".java")) {
                 foundJavaFile = true;
+                isSourceFile = true;
             } else if (currArg.endsWith(".jasm") || currArg.endsWith(".jcod")) {
                 foundAsmFile = true;
+                isSourceFile = true;
             }
 
-            if (foundJavaFile || foundAsmFile) {
+            if (isSourceFile) {
                 File sourceFile = new File(currArg.replace('/', File.separatorChar));
                 if (!sourceFile.isAbsolute()) {
                     // User must have used @compile, so file must be

--- a/test/javacVMOptions/Test.java
+++ b/test/javacVMOptions/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/javacVMOptions/Test.java
+++ b/test/javacVMOptions/Test.java
@@ -25,6 +25,7 @@
  * @test
  * @compile Test.java
  * @compile -J-DmyProperty=123 -processor Test -proc:only Test.java
+ * @compile Test.java -XDrawDiagnostic
  */
 
 import java.util.Objects;

--- a/test/javacVMOptions/Test.java
+++ b/test/javacVMOptions/Test.java
@@ -23,6 +23,9 @@
 
 /*
  * @test
+ * @bug 7902510 7904002
+ * @comment Test passing VM options to javac when compiling test cases
+ *
  * @compile Test.java
  * @compile -J-DmyProperty=123 -processor Test -proc:only Test.java
  * @compile Test.java -XDrawDiagnostic


### PR DESCRIPTION
This work is sponsored by The FreeBSD Foundation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904002](https://bugs.openjdk.org/browse/CODETOOLS-7904002): @<!---->compile directives with args after file name fail after 7903955 (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.org/jtreg.git pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/261.diff">https://git.openjdk.org/jtreg/pull/261.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/261#issuecomment-2853953416)
</details>
