### PR TITLE
7904004: Run jtreg GHA workflows for FreeBSD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,6 @@ jobs:
             sysctl hw.physmem
             sysctl hw.usermem
             pw user add -n action -m
-            su action -c 'git config --global --add safe.directory /home/runner/work/jtreg/jtreg'
+            su action -c 'git config --global --add safe.directory $(pwd)'
             su action -c 'bash make/build.sh --jdk /usr/local/openjdk21'
             su action -c 'bash build/make.sh test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,4 +70,6 @@ jobs:
             sysctl hw.physmem
             sysctl hw.usermem
             pw user add -n action -m
-            su action -c 'git config --global --add safe.directory /home/runner/work/jtreg/jtreg && bash make/build.sh --jdk /usr/local/openjdk21 && bash build/make.sh test'
+            su action -c 'git config --global --add safe.directory /home/runner/work/jtreg/jtreg'
+            su action -c 'bash make/build.sh --jdk /usr/local/openjdk21'
+            su action -c 'bash build/make.sh test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,30 @@ jobs:
         HEADLESS: 1
       run: |
         bash make/build.sh --skip-download
+
+  freebsd-x64:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests in FreeBSD
+        id: test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          prepare: |
+            pkg install -y bash curl git gmake gnugrep openjdk21 zip
+            mount -t fdescfs fdesc /dev/fd
+            mount -t procfs proc /proc
+
+          run: |
+            pwd
+            ls -lah
+            whoami
+            env
+            freebsd-version
+            sysctl hw.model
+            sysctl hw.ncpu
+            sysctl hw.physmem
+            sysctl hw.usermem
+            pw user add -n action -m
+            su action -c 'git config --global --add safe.directory /home/runner/work/jtreg/jtreg && bash make/build.sh --jdk /usr/local/openjdk21 && bash build/make.sh test'


### PR DESCRIPTION
GitHub Actions does not natively support FreeBSD, so we use the vmactions/freebsd-vm action as a base to run the tests in a VM under an Ubuntu runner.

This work is sponsored by The FreeBSD Foundation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904004](https://bugs.openjdk.org/browse/CODETOOLS-7904004): Run jtreg GHA workflows for FreeBSD (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - Author)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/262/head:pull/262` \
`$ git checkout pull/262`

Update a local copy of the PR: \
`$ git checkout pull/262` \
`$ git pull https://git.openjdk.org/jtreg.git pull/262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 262`

View PR using the GUI difftool: \
`$ git pr show -t 262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/262.diff">https://git.openjdk.org/jtreg/pull/262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/262#issuecomment-2854473436)
</details>
