### PR TITLE
7904015: --verify-exclude fails to abort the test run when discovering failures

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1468,6 +1468,7 @@ public class Tool {
 
         if (hadErrors) {
             error("Cannot run because an exclude list had errors, printed above. Either resolve them or remove the exclude list.");
+            exit(EXIT_BAD_ARGS);
         }
     }
 

--- a/test/verifyexclude/VerifyExcludeTest.gmk
+++ b/test/verifyexclude/VerifyExcludeTest.gmk
@@ -43,6 +43,8 @@ $(BUILDTESTDIR)/verifyexclude.format.1.ok: \
 		|| (exit 0)
 	$(GREP) -s "Must follow:" $(@:%.ok=%/log)
 	$(GREP) -s "The fully qualified test must exist." $(@:%.ok=%/log) && exit 1 || exit 0
+	$(GREP) -s "Test results" $(@:%.ok=%/log) && \
+		(echo $@ failed, did not abort on exclude errors) && exit 1 || (exit 0)
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/verifyexclude.format.2.ok: \
@@ -63,6 +65,8 @@ $(BUILDTESTDIR)/verifyexclude.format.2.ok: \
 		|| (exit 0)
 	$(GREP) -s "Must follow:" $(@:%.ok=%/log)
 	$(GREP) -s "The fully qualified test must exist." $(@:%.ok=%/log) && exit 1 || exit 0
+	$(GREP) -s "Test results" $(@:%.ok=%/log) && \
+		(echo $@ failed, did not abort on exclude errors) && exit 1 || (exit 0)
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/verifyexclude.exist.ok: \
@@ -83,6 +87,8 @@ $(BUILDTESTDIR)/verifyexclude.exist.ok: \
 		|| (exit 0)
 	$(GREP) -s "Must follow:" $(@:%.ok=%/log) && exit 1 || exit 0
 	$(GREP) -s "The fully qualified test must exist." $(@:%.ok=%/log)
+	$(GREP) -s "Test results" $(@:%.ok=%/log) && \
+		(echo $@ failed, did not abort on exclude errors) && exit 1 || (exit 0)
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/verifyexclude.id.ok: \
@@ -99,9 +105,11 @@ $(BUILDTESTDIR)/verifyexclude.id.ok: \
 		--verify-exclude \
 		$(TESTDIR)/verifyexclude \
 		> $(@:%.ok=%/log) \
-	    && (cat $(@:%.ok=%/log) ; exit 1) \
+		&& (cat $(@:%.ok=%/log) ; exit 1) \
 		|| (exit 0)
 	$(GREP) -s "The fully qualified test must exist." $(@:%.ok=%/log)
+	$(GREP) -s "Test results" $(@:%.ok=%/log) && \
+		(echo $@ failed, did not abort on exclude errors) && exit 1 || (exit 0)
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/verifyexclude.format.whitespace.ok: \
@@ -155,6 +163,8 @@ $(BUILDTESTDIR)/verifyexclude.duplicate.ok: \
 	    && (cat $(@:%.ok=%/log) ; exit 1) \
 		|| (exit 0)
 	$(GREP) -s "Exclude file cannot contain duplicate entries." $(@:%.ok=%/log)
+	$(GREP) -s "Test results" $(@:%.ok=%/log) && \
+		(echo $@ failed, did not abort on exclude errors) && exit 1 || (exit 0)
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/verifyexclude.match.format.1.ok: \
@@ -175,6 +185,8 @@ $(BUILDTESTDIR)/verifyexclude.match.format.1.ok: \
 		|| (exit 0)
 	$(GREP) -s "Must follow:" $(@:%.ok=%/log)
 	$(GREP) -s "The fully qualified test must exist." $(@:%.ok=%/log) && exit 1 || exit 0
+	$(GREP) -s "Test results" $(@:%.ok=%/log) && \
+		(echo $@ failed, did not abort on exclude errors) && exit 1 || (exit 0)
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/verifyexclude.shortform.ok: \
@@ -194,6 +206,8 @@ $(BUILDTESTDIR)/verifyexclude.shortform.ok: \
 	    && (cat $(@:%.ok=%/log) ; exit 1) \
 		|| (exit 0)
 	$(GREP) -s "Must follow:" $(@:%.ok=%/log)
+	$(GREP) -s "Test results" $(@:%.ok=%/log) && \
+		(echo $@ failed, did not abort on exclude errors) && exit 1 || (exit 0)
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/verifyexclude.good.invoke.direct.ok: \


### PR DESCRIPTION
Exit after discovering errors in exclude files

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904015](https://bugs.openjdk.org/browse/CODETOOLS-7904015): --verify-exclude fails to abort the test run when discovering failures (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.org/jtreg.git pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/265.diff">https://git.openjdk.org/jtreg/pull/265.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/265#issuecomment-2897700318)
</details>
