### PR TITLE
7904021: Parsing group files(TEST.GROUPS) on non-UTF-8 encoding platforms fails with java.nio.charset.MalformedInputException

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/config/ExtraPropDefns.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/ExtraPropDefns.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -306,7 +307,7 @@ public class ExtraPropDefns {
 
     private String getClassNameFromFile(Path file) throws Fault {
         try {
-            return getClassNameFromSource(Files.readString(file));
+            return getClassNameFromSource(Files.readString(file, Charset.defaultCharset()));
         } catch (IOException e) {
             throw new Fault("Problem reading " + file, e);
         }

--- a/src/share/classes/com/sun/javatest/regtest/config/GroupManager.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/GroupManager.java
@@ -29,6 +29,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -99,7 +100,7 @@ public class GroupManager {
             }
 
 
-            try (BufferedReader in = Files.newBufferedReader(file)){
+            try (BufferedReader in = Files.newBufferedReader(file, Charset.defaultCharset())){
                 Properties p = new Properties();
                 p.load(in);
                 for (Map.Entry<Object,Object> e: p.entrySet()) {


### PR DESCRIPTION
7904021: Parsing group files(TEST.GROUPS) on non-UTF-8 encoding platforms fails with java.nio.charset.MalformedInputException

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904021](https://bugs.openjdk.org/browse/CODETOOLS-7904021): Parsing group files(TEST.GROUPS) on non-UTF-8 encoding platforms fails with java.nio.charset.MalformedInputException (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.org/jtreg.git pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/266.diff">https://git.openjdk.org/jtreg/pull/266.diff</a>

</details>
