### PR TITLE
7904062: Release jtreg 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-7.5.2+1...master)
+## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-8+1...master)
+
+_nothing noteworthy, yet_
+
+## [8](https://git.openjdk.org/jtreg/compare/jtreg-7.5.2+1...jtreg-8+1)
 
 * Require JDK 17 to build `jtreg` tool. [CODETOOLS-7904000](https://bugs.openjdk.org/browse/CODETOOLS-7904000)
 
@@ -7,6 +11,8 @@
   * JUnit 5.13.3 [CODETOOLS-7904055](https://bugs.openjdk.org/browse/CODETOOLS-7904055)
 
 * Fix `--verify-exclude` to abort test runs when discovering failures [CODETOOLS-7904015](https://bugs.openjdk.org/browse/CODETOOLS-7904015)
+
+* Fix to use default charset when reading group files [CODETOOLS-7904021](https://bugs.openjdk.org/browse/CODETOOLS-7904021)
 
 ## [7.5.2](https://git.openjdk.org/jtreg/compare/jtreg-7.5.1+1...jtreg-7.5.2+1)
 


### PR DESCRIPTION
Please review this change preparing the release of jtreg 8.

This commit only updates the `CHANGELOG.md` file to include
a selected set of noteworthy changes under the new *8* section.

The `make/build-support/version-numbers` file is already good
to go for the initial 8.x release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904062](https://bugs.openjdk.org/browse/CODETOOLS-7904062): Release jtreg 8 (**Task** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/273/head:pull/273` \
`$ git checkout pull/273`

Update a local copy of the PR: \
`$ git checkout pull/273` \
`$ git pull https://git.openjdk.org/jtreg.git pull/273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 273`

View PR using the GUI difftool: \
`$ git pr show -t 273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/273.diff">https://git.openjdk.org/jtreg/pull/273.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/273#issuecomment-3057914568)
</details>
