### PR TITLE
7904067: Include the millisecond part in the start and end times reported in each action's section

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/Action.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Action.java
@@ -34,9 +34,10 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -390,8 +391,8 @@ public abstract class Action extends ActionHelper {
                         System.nanoTime() - startNanos).toMillis();
             }
         }
-        Date startDate = new Date();
-        startTime = startDate.getTime();
+        ZonedDateTime startedAt = ZonedDateTime.now();
+        startTime = startedAt.toInstant().toEpochMilli();
         String name = getName();
         section = script.getTestResult().createSection(name);
 
@@ -407,7 +408,7 @@ public abstract class Action extends ActionHelper {
             // log the time spent (in seconds) waiting for exclusiveAccess
             pw.println(LOG_EXCLUSIVE_ACCESS_TIME + ((double) exclusiveAccessWaitMillis / 1000.0));
         }
-        pw.println(LOG_STARTED + startDate);
+        pw.println(LOG_STARTED + DATE_TIME_FORMATTER.format(startedAt));
     }
 
     /**
@@ -418,10 +419,10 @@ public abstract class Action extends ActionHelper {
      */
     protected void endAction(Status status) {
         try {
-            Date endDate = new Date();
-            long elapsedTime = endDate.getTime() - startTime;
+            ZonedDateTime endedAt = ZonedDateTime.now();
+            long elapsedTime = endedAt.toInstant().toEpochMilli() - startTime;
             PrintWriter pw = section.getMessageWriter();
-            pw.println(LOG_FINISHED + endDate);
+            pw.println(LOG_FINISHED + DATE_TIME_FORMATTER.format(endedAt));
             pw.println(LOG_ELAPSED_TIME + ((double) elapsedTime / 1000.0));
             recorder.close();
             section.setStatus(status);
@@ -883,6 +884,9 @@ public abstract class Action extends ActionHelper {
     protected static final boolean showCmd = Flags.get("showCmd");
     protected static final boolean showMode = Flags.get("showMode");
     protected static final boolean showJDK = Flags.get("showJDK");
+    // used for logging start/end date time in the report, example "Fri Aug 22 11:12:22.256 UTC 2025"
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss.SSS zzz yyyy");
 }
 
 


### PR DESCRIPTION
Can I please get a review of this trivial change which updates the reporting of start and end dates of each action to also include the millisecond part? 

As noted in https://bugs.openjdk.org/browse/CODETOOLS-7904067, this detail can sometimes help during debugging when comparing other log files which typically have the millisecond part.

Existing self tests continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904067](https://bugs.openjdk.org/browse/CODETOOLS-7904067): Include the millisecond part in the start and end times reported in each action's section (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/275/head:pull/275` \
`$ git checkout pull/275`

Update a local copy of the PR: \
`$ git checkout pull/275` \
`$ git pull https://git.openjdk.org/jtreg.git pull/275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 275`

View PR using the GUI difftool: \
`$ git pr show -t 275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/275.diff">https://git.openjdk.org/jtreg/pull/275.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/275#issuecomment-3216713924)
</details>
