### PR TITLE
7903884: jtreg -nativepath should support relative path

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1816,7 +1816,7 @@ public class Tool {
             }
 
             if (nativeDirArg != null)
-                rp.setNativeDir(nativeDirArg);
+                rp.setNativeDir(nativeDirArg.toAbsolutePath());
 
             rp.setUseWindowsSubsystemForLinux(useWindowsSubsystemForLinux);
 

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 
 
 NATIVEPATH := $(call FullPath, $(shell cd $(BUILDDIR); pwd))
+ABS_TESTDIR := $(call FullPath, $(TESTDIR))
 
 $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
 $(BUILDTESTDIR)/TestNativePath.othervm.ok: \
@@ -117,14 +118,36 @@ $(BUILDTESTDIR)/TestNativePath.ok: \
 
 	echo "$@ test passed at `date`" > $@
 
+# verify that a relative path value to -nativepath option
+# is correctly resolved to an absolute path by jtreg at runtime
+$(BUILDTESTDIR)/TestRelativeNativePath.ok: \
+                $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+
+	$(RM) $(BUILDTESTDIR)/nativepath.relative/
+	$(MKDIR) $(BUILDTESTDIR)/nativepath.relative/foobar/hello/world
+
+	cd $(BUILDTESTDIR); $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-jdk:$(JDKHOME) \
+		-nativepath:nativepath.relative/foobar/hello/world \
+		-vmoption:-Dcorrect.nativepath=$(BUILDTESTDIR)/nativepath.relative/foobar/hello/world \
+		-w:$(BUILDTESTDIR)/nativepath.relative/work \
+		-r:$(BUILDTESTDIR)/nativepath.relative/report \
+		-verbose:fail \
+		$(ABS_TESTDIR)/nativepath/NativesOK.java
+
+	echo "$@ test passed at `date`" > $@
 
 TESTS.jtreg += \
     $(BUILDTESTDIR)/TestNativePath.ok \
     $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
-    $(BUILDTESTDIR)/TestNativePath.othervm.ok
+    $(BUILDTESTDIR)/TestNativePath.othervm.ok \
+    $(BUILDTESTDIR)/TestRelativeNativePath.ok
 
 testnativepath: \
     $(BUILDTESTDIR)/TestNativePath.ok \
     $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
-    $(BUILDTESTDIR)/TestNativePath.othervm.ok
+    $(BUILDTESTDIR)/TestNativePath.othervm.ok \
+    $(BUILDTESTDIR)/TestRelativeNativePath.ok
 


### PR DESCRIPTION
Can I please get a review of this change which addresses https://bugs.openjdk.org/browse/CODETOOLS-7903884?

jtreg supports the `-nativepath` option. When set, this represents the directory in which native libraries can be located by a test. In one part of the code, jtreg uses this value to configure the operating system specific library path environment variables (for example `DYLD_LIBRARY_PATH` environment variable on macos). The issue here is that when setting this value, the path that was provided to `-nativepath` isn't converted to an absolute path. That causes native library lookup failures when a test requiring those native libraries is run.

The commit in this PR addresses the issue by making sure that the path is converted to an absolute path when setting it on the `RegressionParameters`. This then allows the rest of the jtreg code to consistently use an absolute path for that option.

A new self test has been introduced to verify this behaviour. This and the existing self tests continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903884](https://bugs.openjdk.org/browse/CODETOOLS-7903884): jtreg -nativepath should support relative path (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.org/jtreg.git pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/278.diff">https://git.openjdk.org/jtreg/pull/278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/278#issuecomment-3217999963)
</details>
