### PR TITLE
7904016: preserve XAUTHORITY env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-8+2...master)
 
-_nothing noteworthy, yet_
+* `XAUTHORITY` environment variable is now preserved when launching tests on Unix-like platforms.
+  [CODETOOLS-7904016](https://bugs.openjdk.org/browse/CODETOOLS-7904016)
 
 ## [8](https://git.openjdk.org/jtreg/compare/jtreg-7.5.2+1...jtreg-8+2)
 

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -2460,7 +2460,8 @@ public class Tool {
             "PRINTER",
             "TZ",
             "WAYLAND_DISPLAY",
-            "XMODIFIERS"
+            "XMODIFIERS",
+            "XAUTHORITY"
     };
 
     private static final String[] DEFAULT_WINDOWS_ENV_VARS = {

--- a/src/share/doc/javatest/regtest/faq.md
+++ b/src/share/doc/javatest/regtest/faq.md
@@ -2410,22 +2410,31 @@ automatically propagated into the test's JVM are:
 * Linux and Solaris:
     * `PATH` is set to `/bin:/usr/bin:/usr/sbin`
     * The following are propagated from the user's environment:
+        `DBUS_SESSION_BUS_ADDRESS`,
+        `DESKTOP_SESSION`,
         `DISPLAY`,
+        `GDMSESSION`,
+        `GNOME_DESKTOP_SESSION_ID`,
+        `GNOME_SHELL_SESSION_MODE`,
         `HOME`
         `LANG`,
         `LC_ALL`,
         `LC_CTYPE`,
         `LPDEST`,
         `PRINTER`,
-        `TZ` and
-        `XMODIFIERS`
-
+        `TZ`,
+        `WAYLAND_DISPLAY`,
+        `XMODIFIERS`,
+        `XAUTHORITY`
 * Windows:
 
     * `PATH` is set to the MKS or Cygwin toolkit binary directory
     * The following are propagated from the user's environment:
         `SystemDrive`,
-        `SystemRoot`
+        `SystemRoot`,
+        `TMP`,
+        `TEMP`,
+        `TZ`,
         `windir`
 
 If your test needs to provide more environment variables or

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -1410,16 +1410,22 @@ system components will be set.
 and the following variables will be propagated if they are set:
 
 <ul>
+<li><code>DBUS_SESSION_BUS_ADDRESS</code>,
+<li><code>DESKTOP_SESSION</code>,
 <li><code>DISPLAY</code>,
+<li><code>GDMSESSION</code>,
 <li><code>GNOME_DESKTOP_SESSION_ID</code>,
+<li><code>GNOME_SHELL_SESSION_MODE</code>,
 <li><code>HOME</code>,
 <li><code>LANG</code>,
 <li><code>LC_ALL</code>,
 <li><code>LC_CTYPE</code>,
 <li><code>LPDEST</code>,
 <li><code>PRINTER</code>,
-<li><code>TZ</code> and
-<li><code>XMODIFIERS</code>.
+<li><code>TZ</code>,
+<li><code>WAYLAND_DISPLAY</code>,
+<li><code>XMODIFIERS</code>,
+<li><code>XAUTHORITY</code>
 </ul>
 
 <p>On Windows systems, the following variables will be propagated if they are set:

--- a/test/env/EnvTest.gmk
+++ b/test/env/EnvTest.gmk
@@ -83,6 +83,19 @@ $(BUILDTESTDIR)/EnvTest.full.ok: $(ENV.files) \
 	    ( cat $(@:%.ok=%/jt.log) ; exit 1 )
 	echo "test passed at `date`" > $@
 
+$(BUILDTESTDIR)/EnvTest.assert.envs.ok: \
+		$(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+
+	PRINTER=foo XAUTHORITY=bar DESKTOP_SESSION=foobar \
+	SystemRoot=barfoo windir=hello \
+		$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+            -jdk:$(JDKHOME) \
+            -w $(@:%.ok=%)/work/ \
+            -r $(@:%.ok=%)/report/ \
+            -verbose:fail \
+            $(TESTDIR)/env/EnvVarAssertTest.java
 
 ifneq ($(OS_NAME), windows)
 ifdef JDK8HOME
@@ -93,3 +106,5 @@ TESTS.jtreg += \
 endif
 endif
 endif
+
+TESTS.jtreg += $(BUILDTESTDIR)/EnvTest.assert.envs.ok

--- a/test/env/EnvVarAssertTest.java
+++ b/test/env/EnvVarAssertTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.Map;
+import java.util.Set;
+
+/*
+ * @test
+ * @run main EnvVarAssertTest
+ */
+public class EnvVarAssertTest {
+
+    private static final Set<String> UNIX_EXPECTED_ENV_VARS = Set.of(
+            "XAUTHORITY", "PRINTER", "DESKTOP_SESSION"
+    );
+
+    private static final Set<String> WINDOWS_EXPECTED_ENV_VARS = Set.of(
+            "SystemRoot", "windir"
+    );
+
+    public static void main(final String[] args) throws Exception {
+        final String os = System.getProperty("os.name");
+        if (os.startsWith("Linux") || os.startsWith("Mac")) {
+            assertEnvVars(UNIX_EXPECTED_ENV_VARS);
+        } else if (os.startsWith("Windows")) {
+            assertEnvVars(WINDOWS_EXPECTED_ENV_VARS);
+        } else {
+            throw new jtreg.SkippedException("Skipping test on OS: " + os);
+        }
+    }
+
+    private static void assertEnvVars(final Set<String> expected) {
+        final Map<String, String> actual = System.getenv();
+        for (final String envVar : expected) {
+            if (!actual.containsKey(envVar)) {
+                throw new AssertionError("environment variable \"" + envVar + "\" is not set");
+            }
+            final String val = actual.get(envVar);
+            if (val == null) {
+                throw new AssertionError("null value for environment variable \"" + envVar);
+            }
+            System.out.println("found expected environment variable \""
+                    + envVar + "\", set to \"" + val + "\"");
+        }
+    }
+}

--- a/test/env/jtreg/SkippedException.java
+++ b/test/env/jtreg/SkippedException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jtreg;
+
+public class SkippedException extends Exception {
+    public SkippedException(final String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which enhances the jtreg tool to preserve the `XAUTHORITY` environment variable, if set, when launching a test?

This was requested in https://bugs.openjdk.org/browse/CODETOOLS-7904016.

A new self test has been introduced to verify this and other environment variables in a test. The documentation has also been refreshed to list the up-to-date environment variables that are preserved by jtreg.
