### PR TITLE
7903381: Remove temporary "Run with JUnit 4" flag from jtreg

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -67,8 +67,6 @@ import java.util.concurrent.locks.ReentrantLock;
 public class JUnitRunner implements MainActionHelper.TestRunner {
     // error message for when "NoClassDefFoundError" are raised accessing JUnit classes
     private static final String JUNIT_NO_DRIVER = "No JUnit driver -- install JUnit JAR file(s) next to jtreg.jar";
-    // this is a temporary flag while transitioning from JUnit 4 to 5
-    private static final boolean JUNIT_RUN_WITH_JUNIT_4 = Flags.get("runWithJUnit4");
 
     private static final String JUNIT_SELECT_PREFIX = "junit-select:";
 
@@ -104,34 +102,7 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
             cl = JUnitRunner.class.getClassLoader();
         }
         Class<?> mainClass = Class.forName(className, false, cl);
-        if (JUNIT_RUN_WITH_JUNIT_4) {
-            runWithJUnit4(mainClass);
-        } else {
-            runWithJUnitPlatform(mainClass);
-        }
-    }
-
-    private static void runWithJUnit4(Class<?> mainClass) throws Exception {
-        org.junit.runner.Result result;
-        try {
-            result = org.junit.runner.JUnitCore.runClasses(mainClass);
-        } catch (NoClassDefFoundError ex) {
-            throw new Exception(JUNIT_NO_DRIVER, ex);
-        }
-        if (!result.wasSuccessful()) {
-            for (org.junit.runner.notification.Failure failure : result.getFailures()) {
-                StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);
-                try {
-                    pw.println("JavaTest Message: JUnit Failure: " + failure);
-                    failure.getException().printStackTrace(pw);
-                } finally {
-                    pw.close();
-                }
-                System.err.println(sw.toString());
-            }
-            throw new Exception("JUnit test failure");
-        }
+        runWithJUnitPlatform(mainClass);
     }
 
     private static void runWithJUnitPlatform(Class<?> mainClass) throws Exception {


### PR DESCRIPTION
Please review this change removing an internal flag and unused code. Note, that the JUnit Platform still finds and runs tests using the JUnit 4 API since jtreg 7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903381](https://bugs.openjdk.org/browse/CODETOOLS-7903381): Remove temporary "Run with JUnit 4" flag from jtreg (**Task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.org/jtreg.git pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/281.diff">https://git.openjdk.org/jtreg/pull/281.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/281#issuecomment-3241402424)
</details>
