### PR TITLE
7904071: JTReg should report stats of test collections

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/report/RegressionReporter.java
+++ b/src/share/classes/com/sun/javatest/regtest/report/RegressionReporter.java
@@ -111,12 +111,12 @@ public class RegressionReporter {
                 if (testStats != null)
                     testStats.report(r);
 
-                for (var sr : List.of(
-                        SummaryReporter.forTestNG(params.getWorkDirectory()),
-                        SummaryReporter.forJUnit(params.getWorkDirectory()))) {
-                    if (!sr.isEmpty()) {
-                        sr.writeReport(rd);
-                    }
+                int countTestNG = SummaryReporter.forTestNG(params.getWorkDirectory()).writeReport(rd);
+                int countJUnit = SummaryReporter.forJUnit(params.getWorkDirectory()).writeReport(rd);
+                int sumOfCounts = countTestNG + countJUnit;
+                if (sumOfCounts > 0) {
+                    log.println(String.format("Framework-based tests: %d, TestNG: %d, JUnit: %d",
+                            sumOfCounts, countTestNG, countJUnit));
                 }
             }
             fixupReports(rd, wd);


### PR DESCRIPTION
Please review this change accumulating the count numbers of TestNG's and JUnit's text report files and prints them after a test run as follows:

> `Framework-based tests: 188, TestNG: 104, JUnit: 84`

Note that an internal, yet public, API of `SummaryReporter` was changed to be package-private now.