### PR TITLE
7904076: Include timestamp in the summary logs for junit and testng tests

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -228,7 +228,7 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void executionStarted(TestIdentifier identifier) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             startNanosByUniqueId.put(identifier.getUniqueIdObject(), System.nanoTime());
             if (verbose.passMode == AgentVerbose.Mode.NONE) return;
             if (identifier.isTest()) {
@@ -248,7 +248,7 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void executionFinished(TestIdentifier identifier, TestExecutionResult result) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             TestExecutionResult.Status status = result.getStatus();
             if (status == TestExecutionResult.Status.SUCCESSFUL) {
                 if (verbose.passMode == AgentVerbose.Mode.NONE) return;

--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -209,7 +209,7 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void executionSkipped(TestIdentifier identifier, String reason) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             if (verbose.passMode == AgentVerbose.Mode.NONE) return;
             if (identifier.isTest()) {
                 String skippedTime = now.format(HOUR_MIN_SEC_MS_FORMAT);

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -147,21 +147,21 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void onTestSuccess(ITestResult itr) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             successCount.incrementAndGet();
             report(now, InfoKind.TEST, itr);
         }
 
         @Override
         public void onTestFailure(ITestResult itr) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             failureCount.incrementAndGet();
             report(now, InfoKind.TEST, itr);
         }
 
         @Override
         public void onTestSkipped(ITestResult itr) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             Throwable t = itr.getThrowable();
             if (t != null && !(t instanceof SkipException)) {
                 onTestFailure(itr);
@@ -173,7 +173,7 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void onTestFailedButWithinSuccessPercentage(ITestResult itr) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             failedButWithinSuccessPercentageCount.incrementAndGet();
             report(now, InfoKind.TEST, itr);
         }
@@ -188,21 +188,21 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void onConfigurationSuccess(ITestResult itr) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             configSuccessCount.incrementAndGet();
             report(now, InfoKind.CONFIG, itr);
         }
 
         @Override
         public void onConfigurationFailure(ITestResult itr) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             configFailureCount.incrementAndGet();
             report(now, InfoKind.CONFIG, itr);
         }
 
         @Override
         public void onConfigurationSkip(ITestResult itr) {
-            final ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now();
             configSkippedCount.incrementAndGet();
             report(now, InfoKind.CONFIG, itr);
         }

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -58,6 +60,10 @@ import static org.testng.ITestResult.SUCCESS_PERCENTAGE_FAILURE;
  * TestRunner to run TestNG tests.
  */
 public class TestNGRunner implements MainActionHelper.TestRunner {
+
+    // example "11:12:22.256"
+    private static final DateTimeFormatter HOUR_MIN_SEC_MS_FORMAT =
+            DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
     public static void main(String... args) throws Exception {
         main(null, args);
@@ -141,31 +147,35 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void onTestSuccess(ITestResult itr) {
+            final ZonedDateTime now = ZonedDateTime.now();
             successCount.incrementAndGet();
-            report(InfoKind.TEST, itr);
+            report(now, InfoKind.TEST, itr);
         }
 
         @Override
         public void onTestFailure(ITestResult itr) {
+            final ZonedDateTime now = ZonedDateTime.now();
             failureCount.incrementAndGet();
-            report(InfoKind.TEST, itr);
+            report(now, InfoKind.TEST, itr);
         }
 
         @Override
         public void onTestSkipped(ITestResult itr) {
+            final ZonedDateTime now = ZonedDateTime.now();
             Throwable t = itr.getThrowable();
             if (t != null && !(t instanceof SkipException)) {
                 onTestFailure(itr);
                 return;
             }
             skippedCount.incrementAndGet();
-            report(InfoKind.TEST, itr);
+            report(now, InfoKind.TEST, itr);
         }
 
         @Override
         public void onTestFailedButWithinSuccessPercentage(ITestResult itr) {
+            final ZonedDateTime now = ZonedDateTime.now();
             failedButWithinSuccessPercentageCount.incrementAndGet();
-            report(InfoKind.TEST, itr);
+            report(now, InfoKind.TEST, itr);
         }
 
         @Override
@@ -178,23 +188,26 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
 
         @Override
         public void onConfigurationSuccess(ITestResult itr) {
+            final ZonedDateTime now = ZonedDateTime.now();
             configSuccessCount.incrementAndGet();
-            report(InfoKind.CONFIG, itr);
+            report(now, InfoKind.CONFIG, itr);
         }
 
         @Override
         public void onConfigurationFailure(ITestResult itr) {
+            final ZonedDateTime now = ZonedDateTime.now();
             configFailureCount.incrementAndGet();
-            report(InfoKind.CONFIG, itr);
+            report(now, InfoKind.CONFIG, itr);
         }
 
         @Override
         public void onConfigurationSkip(ITestResult itr) {
+            final ZonedDateTime now = ZonedDateTime.now();
             configSkippedCount.incrementAndGet();
-            report(InfoKind.CONFIG, itr);
+            report(now, InfoKind.CONFIG, itr);
         }
 
-        void report(InfoKind k, ITestResult itr) {
+        void report(ZonedDateTime reportedAt, InfoKind k, ITestResult itr) {
             Throwable t = itr.getThrowable();
             String suffix;
             if (t != null  && itr.getStatus() != SUCCESS) {
@@ -214,7 +227,8 @@ public class TestNGRunner implements MainActionHelper.TestRunner {
                     ? Duration.ZERO
                     : Duration.ofNanos(System.nanoTime() - startNanos);
             long durationMillis = duration.toMillis();
-            System.out.print(k.toString().toLowerCase()
+            System.out.print("[" + reportedAt.format(HOUR_MIN_SEC_MS_FORMAT) + "]"
+                    + " " + k.toString().toLowerCase()
                     + " " + itr.getMethod().getConstructorOrMethod().getDeclaringClass().getName()
                     + "." + itr.getMethod().getMethodName()
                     + formatParams(itr)

--- a/test/testngQueryTest/TestNGQueryTest.gmk
+++ b/test/testngQueryTest/TestNGQueryTest.gmk
@@ -39,10 +39,12 @@ $(BUILDTESTDIR)/TestNGQueryTest.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-va \
 		$(TESTDIR)/testngQueryTest/ \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m11(): success test Test1.m12(): success test Test1.m13(): success test Test2.m21(): success test Test2.m22(): success test Test2.m23(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
-	fi
+	$(GREP) -s 'test Test1.m11(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test1.m12(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test1.m13(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test2.m21(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test2.m22(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test2.m23(): success' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.all.ok
@@ -63,10 +65,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-va \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m12(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
-	fi
+	$(GREP) -s 'test Test1.m12(): success' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.m12.ok
@@ -90,10 +89,10 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test2.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m12(): success test Test2.m21(): success test Test2.m22(): success test Test2.m23(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
-	fi
+	$(GREP) -s 'test Test1.m12(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test2.m21(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test2.m22(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test2.m23(): success' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.m12.Test2.ok
@@ -116,10 +115,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m13.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m12(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
-	fi
+	$(GREP) -s 'test Test1.m12(): success' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.m13.m12.ok
@@ -142,10 +138,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.m12.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m12 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m13(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
-	fi
+	$(GREP) -s 'test Test1.m13(): success' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.m12.m13.ok
@@ -168,10 +161,9 @@ $(BUILDTESTDIR)/TestNGQueryTest.m13.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m11(): success test Test1.m12(): success test Test1.m13(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
-	fi
+	$(GREP) -s 'test Test1.m11(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test1.m12(): success' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'test Test1.m13(): success' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.m13.all.ok
@@ -194,10 +186,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java \
 		$(TESTDIR)/testngQueryTest/a/b/c/Test1.java?m13 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD  | $(GREP) -o "^test.*success ") ) ; \
-	if [ "$$OUT" != "test Test1.m13(): success" ]; then \
-	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
-	fi
+	$(GREP) -s 'test Test1.m13(): success' $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.all.m13.ok


### PR DESCRIPTION
Can I please get a review of this change which enhances the log messages printed by jtreg when summarizing the test execution?

With this change, the started/finished log messages will now look like:

For testng:
```
[09:10:12.473] test p.q.Pass.m1(): success [10ms]
[09:10:13.123] test p.q.Pass.m2(): success [202ms]
```

For junit:
```
[09:55:22.278] STARTED    p.JUnitTest::test 'test'
[09:55:22.279] SUCCESSFUL p.JUnitTest::test 'test' [1ms]
```

The timestamp associated with these logs would help during investigating test failures or test timeouts. No new self test has been added given the nature of this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904076](https://bugs.openjdk.org/browse/CODETOOLS-7904076): Include timestamp in the summary logs for junit and testng tests (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/286/head:pull/286` \
`$ git checkout pull/286`

Update a local copy of the PR: \
`$ git checkout pull/286` \
`$ git pull https://git.openjdk.org/jtreg.git pull/286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 286`

View PR using the GUI difftool: \
`$ git pr show -t 286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/286.diff">https://git.openjdk.org/jtreg/pull/286.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/286#issuecomment-3262202454)
</details>
