### PR TITLE
7903816: Improve messages in test report when a test completes after the timeout has already fired

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
+++ b/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
@@ -28,9 +28,12 @@ package com.sun.javatest.regtest;
 import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 
 import com.sun.javatest.regtest.agent.Alarm;
+import com.sun.javatest.regtest.exec.Action;
 
 /**
  * Abstract superclass for timeout handlers.
@@ -40,6 +43,10 @@ import com.sun.javatest.regtest.agent.Alarm;
  * alternative implementation may be specified on the {@code jtreg} command line.
  */
 public abstract class TimeoutHandler {
+
+    // example "11:12:22.256"
+    private static final DateTimeFormatter HOUR_MIN_SEC_MS_FORMAT =
+            DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
     /**
      * The log to which messages should be written.
@@ -111,6 +118,8 @@ public abstract class TimeoutHandler {
      */
     public final void handleTimeout(Process proc) {
         log.println("Timeout information:");
+        final String startedAt = HOUR_MIN_SEC_MS_FORMAT.format(ZonedDateTime.now());
+        log.println("[" + startedAt + "] starting timeout handler action(s)");
         final long pid = proc.pid();
         Alarm a = (timeout <= 0)
                 ? Alarm.NONE
@@ -122,6 +131,8 @@ public abstract class TimeoutHandler {
             log.println("Timeout handler interrupted: ");
             ex.printStackTrace(log);
         } finally {
+            final String endedAt = HOUR_MIN_SEC_MS_FORMAT.format(ZonedDateTime.now());
+            log.println("[" + endedAt + "] timeout handler action(s) completed");
             a.cancel();
         }
 

--- a/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/Agent.java
@@ -87,11 +87,13 @@ public class Agent {
     }
 
     // represents a timeout that occurred while executing
-    // a test action within an agentvm
+    // a test action within an agentvm.
+    // This is an internal class and doesn't get propagated to applications
+    // nor is relevant for serialization.
     static final class ActionTimeout extends Exception {
         private static final long serialVersionUID = 7956108605006221253L;
 
-        private final Status suppressedStatus;
+        private transient final Status suppressedStatus;
 
         private ActionTimeout() {
             this(null);

--- a/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/CompileAction.java
@@ -723,8 +723,12 @@ public class CompileAction extends Action {
                     timeoutHandler,
                     section);
         } catch (Agent.ActionTimeout te) {
-            final String msg = "\"" + getName() + "\" action timed out with a timeout of "
+            String msg = "\"" + getName() + "\" action timed out with a timeout of "
                     + timeout + " seconds on agent " + agent.id;
+            if (te.getSuppressedStatus().isPresent()) {
+                Status suppressed = te.getSuppressedStatus().get();
+                msg += "; but completed after timeout - suppressed status: \"" + suppressed + "\"";
+            }
             status = error(msg);
         } catch (Agent.Fault e) {
             if (e.getCause() instanceof IOException)

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -719,9 +719,13 @@ public class MainAction extends Action
                     timeout,
                     timeoutHandler,
                     section);
-        } catch (Agent.ActionTimeout e) {
-            final String msg = "\"" + getName() + "\" action timed out with a timeout of "
+        } catch (Agent.ActionTimeout te) {
+            String msg = "\"" + getName() + "\" action timed out with a timeout of "
                     + timeout + " seconds on agent " + agent.id;
+            if (te.getSuppressedStatus().isPresent()) {
+                Status suppressed = te.getSuppressedStatus().get();
+                msg += "; but completed after timeout - suppressed status: \"" + suppressed + "\"";
+            }
             status = error(msg);
         } catch (Agent.Fault e) {
             if (e.getCause() instanceof IOException)


### PR DESCRIPTION
Can I please get a review of this enhancement which improves the messages in test reports when a test times out? This addresses https://bugs.openjdk.org/browse/CODETOOLS-7903816.

jtreg runs configured (or default) diagnostic commands when a test times out. It can so happen that when these commands are being run, the test may actually complete (either as a success or failure or error). When that happens, there's no clear indiciation in the jtreg report to state that the test completed when the timeout action handler's were being run. This can cause confusion because the log messages from the test itself may state that the test has completed, where as the jtreg report states that it timed out.

The change in this PR improves this reporting by including additional text to state that the test's original status has been suppressed in preference for the timed out status. This new message will be printed only if the test completed after the timeout had fired:

> result: Error. "main" action timed out with a timeout of 120 seconds on agent 2; but completed after timeout - suppressed status: "Passed. Execution successful"

(the "but completed after timeout ..." part is the new text).

Furthermore, in order to easily identify when the timeout handler(s) started and finished, a couple of new messages with a timestamp will be reported in the jtreg report:

```
Timeout signalled after 1 seconds
Timeout information:
[15:58:22.083] starting timeout handler action(s)
...
[15:58:22.310] timeout handler action(s) completed
--- Timeout information end.
```

Given the nature of this logging change, no new self test has been introduced. I have verified that existing tests pass and I've also manually verified against JDK tests that this message is indeed printed when a test completes after timing out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903816](https://bugs.openjdk.org/browse/CODETOOLS-7903816): Improve messages in test report when a test completes after the timeout has already fired (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/287/head:pull/287` \
`$ git checkout pull/287`

Update a local copy of the PR: \
`$ git checkout pull/287` \
`$ git pull https://git.openjdk.org/jtreg.git pull/287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 287`

View PR using the GUI difftool: \
`$ git pr show -t 287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/287.diff">https://git.openjdk.org/jtreg/pull/287.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/287#issuecomment-3264330355)
</details>
