### PR TITLE
7904077: IDEA plugin: Plugin crashes when using newest Ant plug

### DIFF
--- a/plugins/idea/gradle.properties
+++ b/plugins/idea/gradle.properties
@@ -4,8 +4,8 @@ ideVersion = 2024.2.0.2
 minBuild = IC-242.20224.419
 # https://plugins.jetbrains.com/plugin/23025-ant
 antSupportVersion = 242.20224.159
-pluginVersion = 1.18
+pluginVersion = 1.19
 javaLevel = 21
 notes = <ul>\
-<li>CODETOOLS-7903934: Add support for query strings to the IntelliJ plugin</li>\
+<li>CODETOOLS-7904077: IDEA plugin: Plugin crashes when using newest Ant plug</li>\
 </ul>

--- a/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/producers/JTRegConfigurationProducer.java
+++ b/plugins/idea/src/main/java/com/oracle/plugin/jtreg/configuration/producers/JTRegConfigurationProducer.java
@@ -39,6 +39,7 @@ import com.intellij.execution.junit.JavaRunConfigurationProducerBase;
 import com.intellij.lang.ant.config.*;
 import com.intellij.lang.ant.config.impl.AntBeforeRunTask;
 import com.intellij.lang.ant.config.impl.AntBeforeRunTaskProvider;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -357,13 +358,14 @@ public class JTRegConfigurationProducer extends JavaRunConfigurationProducerBase
     }
 
     public void initBeforeTaskActions(JTRegConfiguration configuration) {
-        AntConfigurationBase antConfiguration = (AntConfigurationBase)AntConfiguration.getInstance(configuration.getProject());
+        Project project = configuration.getProject();
+        AntConfigurationBase antConfiguration = (AntConfigurationBase)AntConfiguration.getInstance(project);
         antConfiguration.ensureInitialized();
-        List<AntBuildTarget> targets = JTRegService.getInstance(configuration.getProject()).getOptTargets(antConfiguration);
+        List<AntBuildTarget> targets = JTRegService.getInstance(project).getOptTargets(antConfiguration);
         if (!targets.isEmpty()) {
             List<BeforeRunTask> beforeTasks = targets.stream().map(target -> {
                 AntBeforeRunTask beforeTask =
-                        AntBeforeRunTaskProvider.getProvider(antConfiguration.getProject(), AntBeforeRunTaskProvider.ID)
+                        AntBeforeRunTaskProvider.getProvider(project, AntBeforeRunTaskProvider.ID)
                                 .createTask(configuration);
                 beforeTask.setTargetName(target.getName());
                 beforeTask.setAntFileUrl(target.getModel().getBuildFile().getVirtualFile().getUrl());
@@ -371,7 +373,7 @@ public class JTRegConfigurationProducer extends JavaRunConfigurationProducerBase
                 return beforeTask;
             }).collect(Collectors.toList());
 
-            RunManagerEx.getInstanceEx(configuration.getProject())
+            RunManagerEx.getInstanceEx(project)
                     .setBeforeRunTasks(configuration, beforeTasks, false);
         }
     }


### PR DESCRIPTION
The jtreg plugins calls some methods from the ant plugin configuration classes. In the newest version of the ant plugin, one of these methods has been removed:

https://github.com/JetBrains/intellij-community/commit/265fee5a6e051d9d8f49403d48c5694a557e522c

This causes the jtreg plugin to crash with a NoSuchMethodError, and running tests is no longer possible. 

The fix proposed by this patch is to use the `Project` instance we get from the jtreg configuration instance. They should point to the same object.