### PR TITLE
7904078: Mute JUnit logging to warning level

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -60,6 +60,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * TestRunner to run JUnit tests.
@@ -133,6 +135,7 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
             SummaryGeneratingListener summaryGeneratingListener = new SummaryGeneratingListener();
 
             AgentVerbose verbose = AgentVerbose.ofStringRepresentation(System.getProperty("test.verbose"));
+            Logger.getLogger("org.junit").setLevel(Level.WARNING);
 
             LauncherConfig launcherConfig = LauncherConfig.builder()
                 .addTestExecutionListeners(new PrintingListener(System.err, verbose))

--- a/test/junitTrace/JUnitTrace.gmk
+++ b/test/junitTrace/JUnitTrace.gmk
@@ -44,6 +44,9 @@ $(BUILDTESTDIR)/JUnitTrace.othervm.ok: \
 	if $(GREP) -s "^\s\s*at " $(@:%.ok=%/work/Pass.jtr) > /dev/null ; then \
 		echo "unexpected text"; exit 1; \
 	fi
+	if $(GREP) -s "^\s\s*CleanupMode.NEVER" $(@:%.ok=%/work/JupiterTempDir.jtr) > /dev/null ; then \
+		echo "unexpected text"; exit 1; \
+	fi
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \

--- a/test/junitTrace/JupiterTempDir.java
+++ b/test/junitTrace/JupiterTempDir.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /*
  * @test
- * @bug 7903953
+ * @bug 7903953 7904078
  * @run junit JupiterTempDir
  */
 class JupiterTempDir {


### PR DESCRIPTION
Please review this small change to configure JUnit's built-in logging severity to warning level.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904078](https://bugs.openjdk.org/browse/CODETOOLS-7904078): Mute JUnit logging to warning level (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/289/head:pull/289` \
`$ git checkout pull/289`

Update a local copy of the PR: \
`$ git checkout pull/289` \
`$ git pull https://git.openjdk.org/jtreg.git pull/289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 289`

View PR using the GUI difftool: \
`$ git pr show -t 289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/289.diff">https://git.openjdk.org/jtreg/pull/289.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/289#issuecomment-3269372178)
</details>
