### PR TITLE
7904084: Unset javaOpts and jtregOpts in jtreg.sh

### DIFF
--- a/src/share/bin/jtreg.sh
+++ b/src/share/bin/jtreg.sh
@@ -162,6 +162,8 @@ DUALCASE=1  # for MKS: make case statement case-sensitive (6709498)
 saveIFS="$IFS"
 nl='
 '
+unset javaOpts
+unset jtregOpts
 for i in "$@" ; do
     IFS=
     if [ -n "$driveDir" ]; then i=`echo $i | sed -e 's|/'$driveDir'/\([A-Za-z]\)/|\1:/|'` ; fi


### PR DESCRIPTION
Hi all,

In jtreg.sh it will combine all the java options and jtreg options in the `for i in "$@"` loop. SHELL use javaOpts and jtregOpts as global virable by default, this means jtreg.sh will receive the value of javaOpts and jtregOpts outside. I think this unexpected.
To avoid this siutation, I think we should unset javaOpts and jtregOpts before use it.