### PR TITLE
7904086: Fix docs that JUnit tests need no `@build` for `@library` contents

### DIFF
--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -263,7 +263,7 @@ This is useful when a test depends on library classes during reflection for exam
 <p>
 The implicit usage might cause incomplete recompilation when a test or library code has been modified.
 
-<p>If a library directory is used by a directory of <a href="#TESTNG">TestNG</a> tests,
+<p>If a library directory is used by a directory of JUnit/<a href="#TESTNG">TestNG</a> tests,
 all the classes in a library directory will be automatically compiled by means of implicit
 <code>@build</code> tags.
 


### PR DESCRIPTION
If a library directory is used by a directory of TestNG **or JUnit** tests, all the classes in a library directory will be automatically compiled by means of implicit `@build` tags. Amend the docs accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904086](https://bugs.openjdk.org/browse/CODETOOLS-7904086): Fix docs that JUnit tests need no `@<!---->build` for `@<!---->library` contents (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/292/head:pull/292` \
`$ git checkout pull/292`

Update a local copy of the PR: \
`$ git checkout pull/292` \
`$ git pull https://git.openjdk.org/jtreg.git pull/292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 292`

View PR using the GUI difftool: \
`$ git pr show -t 292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/292.diff">https://git.openjdk.org/jtreg/pull/292.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/292#issuecomment-3333125320)
</details>
