### PR TITLE
7904088: Include the timestamp to the log message when a timeout is fired

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
+++ b/src/share/classes/com/sun/javatest/regtest/TimeoutHandler.java
@@ -29,11 +29,10 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 
 import com.sun.javatest.regtest.agent.Alarm;
-import com.sun.javatest.regtest.exec.Action;
+import static com.sun.javatest.regtest.agent.Utils.HOUR_MIN_SEC_MS_FORMAT;
 
 /**
  * Abstract superclass for timeout handlers.
@@ -43,10 +42,6 @@ import com.sun.javatest.regtest.exec.Action;
  * alternative implementation may be specified on the {@code jtreg} command line.
  */
 public abstract class TimeoutHandler {
-
-    // example "11:12:22.256"
-    private static final DateTimeFormatter HOUR_MIN_SEC_MS_FORMAT =
-            DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
     /**
      * The log to which messages should be written.

--- a/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/Alarm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,14 @@
 package com.sun.javatest.regtest.agent;
 
 import java.io.PrintWriter;
+import java.time.ZonedDateTime;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+
+import static com.sun.javatest.regtest.agent.Utils.HOUR_MIN_SEC_MS_FORMAT;
 
 /**
  * Provides a lightweight way of setting up and canceling timeouts.
@@ -141,11 +144,16 @@ public class Alarm  {
      * Shared logic for all Alarms
      */
     protected void run() {
+        ZonedDateTime now = ZonedDateTime.now();
         if (msgOut != null) {
             if (count == 0) {
-                msgOut.println(String.format("Timeout signalled after %d seconds", TimeUnit.SECONDS.convert(delay, delayUnit)));
+                msgOut.println(String.format("[%s] Timeout signalled after %d seconds",
+                        HOUR_MIN_SEC_MS_FORMAT.format(now),
+                        TimeUnit.SECONDS.convert(delay, delayUnit)));
             } else if (count % 100 == 0) {
-                msgOut.println(String.format("Timeout refired %d times", count));
+                msgOut.println(String.format("[%s] Timeout refired %d times",
+                        HOUR_MIN_SEC_MS_FORMAT.format(now),
+                        count));
             }
         }
         count++;

--- a/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/JUnitRunner.java
@@ -56,7 +56,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,6 +63,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static com.sun.javatest.regtest.agent.Utils.HOUR_MIN_SEC_MS_FORMAT;
 
 /**
  * TestRunner to run JUnit tests.
@@ -73,10 +74,6 @@ public class JUnitRunner implements MainActionHelper.TestRunner {
     private static final String JUNIT_NO_DRIVER = "No JUnit driver -- install JUnit JAR file(s) next to jtreg.jar";
 
     private static final String JUNIT_SELECT_PREFIX = "junit-select:";
-
-    // example "11:12:22.256"
-    private static final DateTimeFormatter HOUR_MIN_SEC_MS_FORMAT =
-            DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
     public static void main(String... args) throws Exception {
         main(null, args);

--- a/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/TestNGRunner.java
@@ -31,7 +31,6 @@ import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -51,6 +50,7 @@ import org.testng.TestNG;
 import org.testng.TestNGException;
 import org.testng.reporters.XMLReporter;
 
+import static com.sun.javatest.regtest.agent.Utils.HOUR_MIN_SEC_MS_FORMAT;
 import static org.testng.ITestResult.FAILURE;
 import static org.testng.ITestResult.SKIP;
 import static org.testng.ITestResult.SUCCESS;
@@ -60,10 +60,6 @@ import static org.testng.ITestResult.SUCCESS_PERCENTAGE_FAILURE;
  * TestRunner to run TestNG tests.
  */
 public class TestNGRunner implements MainActionHelper.TestRunner {
-
-    // example "11:12:22.256"
-    private static final DateTimeFormatter HOUR_MIN_SEC_MS_FORMAT =
-            DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
     public static void main(String... args) throws Exception {
         main(null, args);

--- a/src/share/classes/com/sun/javatest/regtest/agent/Utils.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/Utils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javatest.regtest.agent;
+
+import java.time.format.DateTimeFormatter;
+
+public final class Utils {
+
+    /**
+     * {@link DateTimeFormatter} for formatting into a string containing hour, minute, second
+     * and milliseconds. For example "11:12:22.256"
+     */
+    public static final DateTimeFormatter HOUR_MIN_SEC_MS_FORMAT =
+            DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+}


### PR DESCRIPTION
Can I please get a review of this trivial change which includes the timestamp for a log message when a test action times out?

Before this change, jtreg would log a message like:

> Timeout signalled after 120 seconds

Now it will also include a timestamp for that log message. This should help during investigations of timing out tests:

> [08:10:07.344] Timeout signalled after 120 seconds

The change is a one liner in `src/share/classes/com/sun/javatest/regtest/agent/Alarm.java`. Rest of the changes are mere refactoring to allow for using the same `DateTimeFormat` consistently in a couple of other places.