### PR TITLE
7904172: JTReg should add --enable-native-access=ALL-UNNAMED in /native actions

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -236,6 +236,7 @@ public class MainAction extends Action
         }
 
         if (nativeCode && !seenEnableNativeAccess) {
+            // TODO Only add argument on Test JDK 17 or higher
             testJavaArgs.add("--enable-native-access=ALL-UNNAMED");
             if (!othervm) {
                 othervmOverrideReasons.add("/native test requires --enable-native-access=ALL-UNNAMED");

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -237,6 +237,9 @@ public class MainAction extends Action
 
         if (nativeCode && !seenEnableNativeAccess) {
             testJavaArgs.add("--enable-native-access=ALL-UNNAMED");
+            if (!othervm) {
+                othervmOverrideReasons.add("/native test requires --enable-native-access=ALL-UNNAMED");
+            }
         }
 
         if (!script.disablePreview()) { // test with explicit `@enablePreview false` take precedence

--- a/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/MainAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,6 +188,7 @@ public class MainAction extends Action
             othervmOverrideReasons.add("test or library uses bootclasspath");
         }
 
+        boolean seenEnableNativeAccess = false;
         boolean seenEnablePreview = false;
         // separate the arguments into the options to java, the
         // classname and the parameters to the named class
@@ -195,6 +196,9 @@ public class MainAction extends Action
             String arg = args.get(i);
             if (testClassName == null) {
                 if (arg.startsWith("-")) {
+                    if (arg.startsWith("--enable-native-access")) {
+                        seenEnableNativeAccess = true;
+                    }
                     if (arg.equals("--enable-preview")) {
                         seenEnablePreview = true;
                     }
@@ -229,6 +233,10 @@ public class MainAction extends Action
                 throw new ParseException(PARSE_POLICY_OTHERVM);
             if (secureCN != null)
                 throw new ParseException(PARSE_SECURE_OTHERVM);
+        }
+
+        if (nativeCode && !seenEnableNativeAccess) {
+            testJavaArgs.add("--enable-native-access=ALL-UNNAMED");
         }
 
         if (!script.disablePreview()) { // test with explicit `@enablePreview false` take precedence

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -52,7 +52,7 @@
 <p>Comments and questions to:
 <a href="mailto:jtreg-use@openjdk.org">jtreg-use@openjdk.org</a>.
 <br>
-1.48, 20 February, 2026
+1.49, 7 May 2026
 </div>
 
 <p>This is a specification document, not a tutorial.  For more basic information
@@ -498,6 +498,10 @@ assumed.
 <dd>
 <p>The test uses native code, which must be provided separately, in a precompiled library,
 when the test is run.
+The jtreg tool adds <code>--enable-native-access=ALL-UNNAMED</code> to the list of Java test
+runtime command-line arguments for actions with <code>/native</code> tag -- unless
+there is one or more explicit custom <code>--enable-native-access</code> argument(s) present
+in the list of test runtime arguments.
 
 </dl>
 

--- a/test/nativepath/NativeAccessEnabled.java
+++ b/test/nativepath/NativeAccessEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,29 +23,15 @@
 
 /*
  * @test
- * @run main/native NativesOK
+ * @bug 7904172
+ * @requires jdk.version.major >= 22
+ * @run main/native NativeAccessEnabled
  */
 
-import java.io.File;
-import java.util.Arrays;
-
-public class NativesOK {
+public class NativeAccessEnabled {
     public static void main(String[] args) {
-        String j_l_path = System.getProperty("java.library.path");
-        String t_native = System.getProperty("test.nativepath");
-        String c_native = System.getProperty("correct.nativepath").replace("/", File.separator);
-
-        System.out.println("java.library.path: " + j_l_path);
-        System.out.println("test.nativepath: " + t_native);
-        System.out.println("correct.nativepath: " + c_native);
-
-        if (!t_native.equals(c_native))
-            throw new Error("System property 'test.nativepath' not set correctly");
-        if (j_l_path == null)
-            throw new Error("System property 'java.library.path' not set");
-
-        String[] paths = j_l_path.split("\\"+File.pathSeparator);
-        if (!Arrays.asList(paths).contains(t_native))
-            throw new Error("System property 'test.nativepath' is not part of 'java.library.path'");
+        var module = NativeAccessEnabled.class.getClassLoader().getUnnamedModule();
+        if (!module.isNativeAccessEnabled()) // Module#isNativeAccessEnabled requires Java 22+
+            throw new Error("ALL-UNNAMED modules should have native access enabled");
     }
 }

--- a/test/nativepath/NativesOK.java
+++ b/test/nativepath/NativesOK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 7901983 7904172
  * @run main/native NativesOK
  */
 
@@ -47,5 +48,8 @@ public class NativesOK {
         String[] paths = j_l_path.split("\\"+File.pathSeparator);
         if (!Arrays.asList(paths).contains(t_native))
             throw new Error("System property 'test.nativepath' is not part of 'java.library.path'");
+
+        if (!NativesOK.class.getClassLoader().getUnnamedModule().isNativeAccessEnabled())
+            throw new Error("ALL-UNNAMED modules should have native access enabled");
     }
 }

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -139,6 +139,20 @@ $(BUILDTESTDIR)/TestRelativeNativePath.ok: \
 
 	echo "$@ test passed at `date`" > $@
 
+TESTS.jtreg += \
+    $(BUILDTESTDIR)/TestNativePath.ok \
+    $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
+    $(BUILDTESTDIR)/TestNativePath.othervm.ok \
+    $(BUILDTESTDIR)/TestRelativeNativePath.ok
+
+testnativepath: \
+    $(BUILDTESTDIR)/TestNativePath.ok \
+    $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
+    $(BUILDTESTDIR)/TestNativePath.othervm.ok \
+    $(BUILDTESTDIR)/TestRelativeNativePath.ok
+
+ifdef JDK25HOME
+
 # verify that --enable-native-access=ALL-UNNAMED is added
 # for a test with the /native argument
 $(BUILDTESTDIR)/TestNativeAccessEnabled.ok: \
@@ -156,16 +170,7 @@ $(BUILDTESTDIR)/TestNativeAccessEnabled.ok: \
 
 	echo "$@ test passed at `date`" > $@
 
-TESTS.jtreg += \
-    $(BUILDTESTDIR)/TestNativePath.ok \
-    $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
-    $(BUILDTESTDIR)/TestNativePath.othervm.ok \
-    $(BUILDTESTDIR)/TestRelativeNativePath.ok \
-	$(BUILDTESTDIR)/TestNativeAccessEnabled.ok
+TESTS.jtreg += $(BUILDTESTDIR)/TestNativeAccessEnabled.ok
+testnativepath += $(BUILDTESTDIR)/TestNativeAccessEnabled.ok
 
-testnativepath: \
-    $(BUILDTESTDIR)/TestNativePath.ok \
-    $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
-    $(BUILDTESTDIR)/TestNativePath.othervm.ok \
-    $(BUILDTESTDIR)/TestRelativeNativePath.ok \
-	$(BUILDTESTDIR)/TestNativeAccessEnabled.ok
+endif

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -136,6 +136,23 @@ $(BUILDTESTDIR)/TestRelativeNativePath.ok: \
 		-r:$(@:%.ok=%nativepath.relative)/report \
 		-verbose:fail \
 		$(ABS_TESTDIR)/nativepath/NativesOK.java
+
+	echo "$@ test passed at `date`" > $@
+
+# verify that --enable-native-access=ALL-UNNAMED is added
+# for a test with the /native argument
+$(BUILDTESTDIR)/TestNativeAccessEnabled.ok: \
+                $(JTREG_IMAGEDIR)/lib/javatest.jar \
+		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
+		$(JTREG_IMAGEDIR)/bin/jtreg
+
+	cd $(BUILDTESTDIR); $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-jdk:$(JDKHOME) \
+		-nativepath:$(NATIVEPATH) \ \
+		-w:$(@:%.ok=%nativeaccessenabled)/work \
+		-r:$(@:%.ok=%nativeaccessenabled)/report \
+		-verbose:fail \
+		$(ABS_TESTDIR)/nativepath/NativeAccessEnabled.java
 
 	echo "$@ test passed at `date`" > $@
 

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -148,7 +148,7 @@ $(BUILDTESTDIR)/TestNativeAccessEnabled.ok: \
 
 	cd $(BUILDTESTDIR); $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
 		-jdk:$(JDKHOME) \
-		-nativepath:$(NATIVEPATH) \ \
+		-nativepath:$(NATIVEPATH) \
 		-w:$(@:%.ok=%nativeaccessenabled)/work \
 		-r:$(@:%.ok=%nativeaccessenabled)/report \
 		-verbose:fail \
@@ -160,10 +160,12 @@ TESTS.jtreg += \
     $(BUILDTESTDIR)/TestNativePath.ok \
     $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
     $(BUILDTESTDIR)/TestNativePath.othervm.ok \
-    $(BUILDTESTDIR)/TestRelativeNativePath.ok
+    $(BUILDTESTDIR)/TestRelativeNativePath.ok \
+	$(BUILDTESTDIR)/TestNativeAccessEnabled.ok
 
 testnativepath: \
     $(BUILDTESTDIR)/TestNativePath.ok \
     $(BUILDTESTDIR)/TestNativePath.agentvm.ok \
     $(BUILDTESTDIR)/TestNativePath.othervm.ok \
-    $(BUILDTESTDIR)/TestRelativeNativePath.ok
+    $(BUILDTESTDIR)/TestRelativeNativePath.ok \
+	$(BUILDTESTDIR)/TestNativeAccessEnabled.ok

--- a/test/nativepath/TestNativePath.gmk
+++ b/test/nativepath/TestNativePath.gmk
@@ -161,7 +161,7 @@ $(BUILDTESTDIR)/TestNativeAccessEnabled.ok: \
 		$(JTREG_IMAGEDIR)/bin/jtreg
 
 	cd $(BUILDTESTDIR); $(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
-		-jdk:$(JDKHOME) \
+		-jdk:$(JDK25HOME) \
 		-nativepath:$(NATIVEPATH) \
 		-w:$(@:%.ok=%nativeaccessenabled)/work \
 		-r:$(@:%.ok=%nativeaccessenabled)/report \


### PR DESCRIPTION
Please review this change adding `--enable-native-access=ALL-UNNAMED` to the list of Java test runtime command-line arguments for actions with `/native` option -- unless there is one or more explicit custom `--enable-native-access` arguments present.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904172](https://bugs.openjdk.org/browse/CODETOOLS-7904172): JTReg should add --enable-native-access=ALL-UNNAMED in /native actions (**Enhancement** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - no project role) ⚠️ Review applies to [897d6823](https://git.openjdk.org/jtreg/pull/319/files/897d68239fc7c584149f77deec0d616d99ab283e)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [897d6823](https://git.openjdk.org/jtreg/pull/319/files/897d68239fc7c584149f77deec0d616d99ab283e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/319/head:pull/319` \
`$ git checkout pull/319`

Update a local copy of the PR: \
`$ git checkout pull/319` \
`$ git pull https://git.openjdk.org/jtreg.git pull/319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 319`

View PR using the GUI difftool: \
`$ git pr show -t 319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/319.diff">https://git.openjdk.org/jtreg/pull/319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/319#issuecomment-4222413967)
</details>
