### PR TITLE
7904182: Release jtreg 8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
-## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-8.2.1+1...master)
+## [Unreleased](https://git.openjdk.org/jtreg/compare/jtreg-8.3+1...master)
+
+_nothing noteworthy, yet_
+
+## [8.3](https://git.openjdk.org/jtreg/compare/jtreg-8.2.1+1...jtreg-8.3+1)
 
 * Support [Compact Source Files and Instance Main Methods](https://openjdk.org/jeps/512) in main tests [CODETOOLS-7904141](https://bugs.openjdk.org/browse/CODETOOLS-7904141)
+
+* Add `--enable-native-access=ALL-UNNAMED` for actions tagged with `/native` [CODETOOLS-7904172](https://bugs.openjdk.org/browse/CODETOOLS-7904172)
+
+* Enhanced support in driver mode for tests using `@enablePreview` [CODETOOLS-7904149](https://bugs.openjdk.org/browse/CODETOOLS-7904149)
+
+* XML reports now include crash log data  [CODETOOLS-7904153](https://bugs.openjdk.org/browse/CODETOOLS-7904153)
 
 ## [8.2.1](https://git.openjdk.org/jtreg/compare/jtreg-8.2+1...jtreg-8.2.1+1)
 


### PR DESCRIPTION
Please review this change to update the `CHANGELOG.md` file to include a section about `jtreg` **8.3**

Note that URL targets used in the `CHANGELOG.md` file will start to work after the resulting commit was tagged. For example: https://git.openjdk.org/jtreg/compare/jtreg-8.3+1...master

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904182](https://bugs.openjdk.org/browse/CODETOOLS-7904182): Release jtreg 8.3 (**Task** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/321/head:pull/321` \
`$ git checkout pull/321`

Update a local copy of the PR: \
`$ git checkout pull/321` \
`$ git pull https://git.openjdk.org/jtreg.git pull/321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 321`

View PR using the GUI difftool: \
`$ git pr show -t 321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/321.diff">https://git.openjdk.org/jtreg/pull/321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/321#issuecomment-4405010874)
</details>
