### PR TITLE
7904183: Some "main" action jtreg tests fail to launch after CODETOOLS-7904141

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
@@ -188,7 +188,7 @@ public class MainActionHelper extends ActionHelper {
                 argTypes = new Class<?>[] { String[].class };
                 methodArgs = new Object[] { classArgsArray };
                 method = MainMethodHelper.isModernMainSupported()
-                        ? MainMethodHelper.findMainMethod(c)
+                        ? MainMethodHelper.requireMainMethod(c)
                         : c.getMethod("main", argTypes);
             }
 

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainMethodHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainMethodHelper.java
@@ -29,9 +29,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Objects;
 
 /**
  * Java program entry-point finder and runner.
@@ -46,7 +44,7 @@ final class MainMethodHelper {
     // Similar to sun.launcher.LauncherHelper#executeMainClass
     static void executeModernMainClass(Class<?> mainClass, String[] mainArgs) throws
             ReflectiveOperationException {
-        Method mainMethod = findMainMethod(mainClass);
+        Method mainMethod = requireMainMethod(mainClass);
         mainMethod.setAccessible(true);
         Object mainInstance = createMainInstanceOrNull(mainClass, mainMethod);
         if (mainMethod.getParameterCount() == 0) {
@@ -56,52 +54,88 @@ final class MainMethodHelper {
         }
     }
 
-    // Similar to jdk.internal.misc.MethodFinder#findMainMethod
-    static Method findMainMethod(Class<?> cls) throws NoSuchMethodException {
-        List<Method> methods = Stream.concat(
-                    Stream.of(cls.getDeclaredMethods()), // prefer "local" methods
-                    Stream.of(cls.getMethods()) // include public inherited methods
-                )
-                .filter(m -> "main".equals(m.getName()))
-                .distinct()
-                .collect(Collectors.toList()); // no .toList() with --release 8
-
-        // JLA.findMethod(cls, true, "main", String[].class);
-        Method mainMethod = methods.stream()
-                .filter(method -> Modifier.isPublic(method.getModifiers()))
-                .filter(method -> method.getParameterCount() == 1)
-                .filter(method -> method.getParameterTypes()[0] == String[].class)
-                .findAny()
-                .orElse(null);
-
-        if (mainMethod == null) {
-            // JLA.findMethod(cls, false, "main", String[].class);
-            mainMethod = methods.stream()
-                    .filter(method -> method.getParameterCount() == 1)
-                    .filter(method -> method.getParameterTypes()[0] == String[].class)
-                    .findAny()
-                    .orElse(null);
-        }
-
-        if (mainMethod == null || !isValidMainMethod(mainMethod)) {
-            // JLA.findMethod(cls, false, "main");
-            mainMethod = methods.stream()
-                    .filter(method -> method.getParameterCount() == 0)
-                    .findAny()
-                    .orElse(null);
-        }
-
-        if (mainMethod != null && isValidMainMethod(mainMethod)) {
-            mainMethod.setAccessible(true);
+    /**
+     * Return the first method that meets the requirements of an application main method.
+     * This behaves the same as {@link #findMainMethod(Class)}, except that if any main method
+     * isn't found, then this method throws a {@link NoSuchMethodException}.
+     *
+     * @param cls the class on which main method is being searched for
+     * @return the first method that meets the requirements of an application main method
+     * @throws NoSuchMethodException if the class doesn't have any method that qualifies as an
+     *                               application main method
+     */
+    static Method requireMainMethod(Class<?> cls) throws NoSuchMethodException {
+        Method mainMethod = findMainMethod(cls);
+        if (mainMethod != null) {
             return mainMethod;
         }
-        throw new NoSuchMethodException("main() nor main(String[])");
+        throw new NoSuchMethodException("No main method found in " + cls);
+    }
+
+    /**
+     * Return the first method that meets the requirements of an application main method
+     * {@code JLS 12.1.4}. The method must:
+     * <ul>
+     *  <li>be declared in this class's hierarchy</li>
+     *  <li>have the name "main"</li>
+     *  <li>have a single argument of type {@code String[]}, {@code String...} or no argument</li>
+     *  <li>have the return type of void</li>
+     *  <li>be public, protected or package private</li>
+     * </ul>
+     *
+     * @param cls the class on which main method is being searched for
+     * @return the first method that meets the requirements of an application main method, or null
+     * if none was found
+     */
+    // Similar to jdk.internal.misc.MethodFinder#findMainMethod
+    static Method findMainMethod(Class<?> cls) {
+        Method mainMethod = null;
+        // first try "public static/non-static void main(String[])"
+        try {
+            mainMethod = cls.getMethod("main", String[].class);
+        } catch (NoSuchMethodException ignored) {
+        }
+
+        if (mainMethod == null) {
+            // if not public method, try to lookup a non-public one
+            try {
+                mainMethod = cls.getDeclaredMethod("main", String[].class);
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
+
+        if (mainMethod == null || !isValidMainMethod(cls, mainMethod)) {
+            // if not found, then ignore the param types and search for
+            // any public/non-public method named "main"
+            Method[] declaredMethods = cls.getDeclaredMethods();
+            for (Method m : declaredMethods) {
+                if (m.getName().equals("main")) {
+                    mainMethod = m;
+                    break;
+                }
+            }
+        }
+        if (mainMethod == null || !isValidMainMethod(cls, mainMethod)) {
+            return null;
+        }
+        return mainMethod;
     }
 
     // Similar to jdk.internal.misc.MethodFinder#isValidMainMethod
-    private static boolean isValidMainMethod(Method mainMethodCandidate) {
+    private static boolean isValidMainMethod(Class<?> initialClass, Method mainMethodCandidate) {
         return mainMethodCandidate.getReturnType() == void.class &&
-               !Modifier.isPrivate(mainMethodCandidate.getModifiers());
+                !Modifier.isPrivate(mainMethodCandidate.getModifiers()) &&
+                (Modifier.isPublic(mainMethodCandidate.getModifiers()) ||
+                        Modifier.isProtected(mainMethodCandidate.getModifiers()) ||
+                        isInSameRuntimePackage(initialClass, mainMethodCandidate.getDeclaringClass()));
+    }
+
+    // Similar to jdk.internal.misc.MethodFinder#isInSameRuntimePackage
+    private static boolean isInSameRuntimePackage(Class<?> c1, Class<?> c2) {
+        String pkg1 = getPackageName(c1);
+        String pkg2 = getPackageName(c2);
+        return Objects.equals(pkg1, pkg2)
+                && c1.getClassLoader() == c2.getClassLoader();
     }
 
     // Similar to sun.launcher.LauncherHelper#checkAndLoadMain
@@ -115,5 +149,37 @@ final class MainMethodHelper {
         Constructor<?> constructor = mainClass.getDeclaredConstructor();
         constructor.setAccessible(true);
         return constructor.newInstance();
+    }
+
+    private static String getPackageName(final Class<?> klass) {
+        try {
+            return (String) LazyHolder.PACKAGE_NAME_METHOD.invoke(klass);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            // should never happen
+            throw new Error(e);
+        }
+    }
+
+    // Direct reference to Class.getPackageName() isn't possible because
+    // this MainMethodHelper class may run in Java 8 environments where that method isn't available.
+    // This is a convenience holder class which provides reflective access to that method and
+    // delays the reflective lookup to that method until after it's certain that the runtime
+    // environment is Java 25 or higher (where modern main methods are applicable)
+    private static final class LazyHolder {
+        // reflective access to Class.getPackageName() method which is only available on Java 9+
+        private static final Method PACKAGE_NAME_METHOD;
+
+        static {
+            Method m;
+            try {
+                m = Class.class.getMethod("getPackageName");
+            } catch (NoSuchMethodException e) {
+                // This should never happen because this static initializer will only
+                // be called on Java versions 25 or higher and those versions are
+                // expected to have the Class.getPackageName() method (it's there since Java 9)
+                throw new Error("Missing Class.getPackageName() method");
+            }
+            PACKAGE_NAME_METHOD = m;
+        }
     }
 }

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainMethodHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainMethodHelper.java
@@ -25,10 +25,14 @@
 
 package com.sun.javatest.regtest.agent;
 
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -45,7 +49,6 @@ final class MainMethodHelper {
     static void executeModernMainClass(Class<?> mainClass, String[] mainArgs) throws
             ReflectiveOperationException {
         Method mainMethod = requireMainMethod(mainClass);
-        mainMethod.setAccessible(true);
         Object mainInstance = createMainInstanceOrNull(mainClass, mainMethod);
         if (mainMethod.getParameterCount() == 0) {
             mainMethod.invoke(mainInstance);
@@ -54,10 +57,28 @@ final class MainMethodHelper {
         }
     }
 
+    // Similar to sun.launcher.LauncherHelper#checkAndLoadMain
+    static Object createMainInstanceOrNull(Class<?> mainClass, Method mainMethod) throws
+            NoSuchMethodException,
+            InvocationTargetException,
+            InstantiationException,
+            IllegalAccessException {
+        boolean isStatic = Modifier.isStatic(mainMethod.getModifiers());
+        if (isStatic) return null;
+        Constructor<?> constructor = mainClass.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
     /**
      * Return the first method that meets the requirements of an application main method.
-     * This behaves the same as {@link #findMainMethod(Class)}, except that if any main method
-     * isn't found, then this method throws a {@link NoSuchMethodException}.
+     * This behaves the same as {@link #findMainMethod(Class)}, except that:
+     * <ul>
+     *     <li>If no main method is found, then this method throws
+     *     a {@link NoSuchMethodException}</li>
+     *     <li>If a main method is found, then this method tries to set that method as accessible
+     *     by calling {@link Method#trySetAccessible()} on it</li>
+     * </ul>
      *
      * @param cls the class on which main method is being searched for
      * @return the first method that meets the requirements of an application main method
@@ -67,6 +88,10 @@ final class MainMethodHelper {
     static Method requireMainMethod(Class<?> cls) throws NoSuchMethodException {
         Method mainMethod = findMainMethod(cls);
         if (mainMethod != null) {
+            try {
+                LazyHolder.TRY_SET_ACCESSIBLE_METHOD.invoke(mainMethod);
+            } catch (ReflectiveOperationException ignored) {
+            }
             return mainMethod;
         }
         throw new NoSuchMethodException("No main method found in " + cls);
@@ -82,6 +107,8 @@ final class MainMethodHelper {
      *  <li>have the return type of void</li>
      *  <li>be public, protected or package private</li>
      * </ul>
+     * <p>
+     * This method may be called only if {@link #isModernMainSupported()} returns {@code true}.
      *
      * @param cls the class on which main method is being searched for
      * @return the first method that meets the requirements of an application main method, or null
@@ -90,34 +117,29 @@ final class MainMethodHelper {
     // Similar to jdk.internal.misc.MethodFinder#findMainMethod
     static Method findMainMethod(Class<?> cls) {
         Method mainMethod = null;
-        // first try "public static/non-static void main(String[])"
+        // find the most widely used "public static void main(String[])" first
         try {
             mainMethod = cls.getMethod("main", String[].class);
         } catch (NoSuchMethodException ignored) {
         }
 
         if (mainMethod == null) {
-            // if not public method, try to lookup a non-public one
-            try {
-                mainMethod = cls.getDeclaredMethod("main", String[].class);
-            } catch (NoSuchMethodException ignored) {
-            }
+            // if not public method, try to lookup a non-public one which takes
+            // a String[] parameter
+            mainMethod = findMainMethod(cls, false, String[].class);
         }
 
         if (mainMethod == null || !isValidMainMethod(cls, mainMethod)) {
-            // if not found, then ignore the param types and search for
-            // any public/non-public method named "main"
-            Method[] declaredMethods = cls.getDeclaredMethods();
-            for (Method m : declaredMethods) {
-                if (m.getName().equals("main")) {
-                    mainMethod = m;
-                    break;
-                }
-            }
+            // if not found, then look for public/non-public main method that
+            // doesn't take any parameters
+            mainMethod = findMainMethod(cls, false);
         }
+
         if (mainMethod == null || !isValidMainMethod(cls, mainMethod)) {
+            // no eligible main method found
             return null;
         }
+
         return mainMethod;
     }
 
@@ -138,18 +160,6 @@ final class MainMethodHelper {
                 && c1.getClassLoader() == c2.getClassLoader();
     }
 
-    // Similar to sun.launcher.LauncherHelper#checkAndLoadMain
-    static Object createMainInstanceOrNull(Class<?> mainClass, Method mainMethod) throws
-            NoSuchMethodException,
-            InvocationTargetException,
-            InstantiationException,
-            IllegalAccessException {
-        boolean isStatic = Modifier.isStatic(mainMethod.getModifiers());
-        if (isStatic) return null;
-        Constructor<?> constructor = mainClass.getDeclaredConstructor();
-        constructor.setAccessible(true);
-        return constructor.newInstance();
-    }
 
     private static String getPackageName(final Class<?> klass) {
         try {
@@ -160,26 +170,104 @@ final class MainMethodHelper {
         }
     }
 
-    // Direct reference to Class.getPackageName() isn't possible because
-    // this MainMethodHelper class may run in Java 8 environments where that method isn't available.
-    // This is a convenience holder class which provides reflective access to that method and
-    // delays the reflective lookup to that method until after it's certain that the runtime
+    private static Method findMainMethod(final Class<?> klass, final boolean publicOnly,
+                                         final Class<?>... parameterTypes) {
+        final List<Method> mainMethods = getMainMethodsRecursive(klass, parameterTypes,
+                true, publicOnly);
+        return mainMethods.isEmpty() ? null : mainMethods.get(0);
+    }
+
+    // this implementation is heavily borrowed from the JDK's Class.getMethodsRecursive()
+    private static List<Method> getMainMethodsRecursive(final Class<?> klass,
+                                                        final Class<?>[] parameterTypes,
+                                                        final boolean includeStatic,
+                                                        final boolean publicOnly) {
+        final List<Method> res = new ArrayList<>();
+        // first check declared methods
+        final Method[] methods = getDeclaredMethods(klass, publicOnly);
+        for (final Method m : methods) {
+            if (Modifier.isStatic(m.getModifiers()) && !includeStatic) {
+                // not an eligible method
+                continue;
+            }
+            if (!m.getName().equals("main")) {
+                // not an eligible method
+                continue;
+            }
+            if (!Arrays.equals(m.getParameterTypes(), parameterTypes)) {
+                // not an eligible method
+                continue;
+            }
+            // eligible method
+            res.add(m);
+        }
+        // if there is at least one match among declared methods, we need not
+        // search any further as such match surely overrides matching methods
+        // declared in superclass(es) or interface(s).
+        if (!res.isEmpty()) {
+            return res;
+        }
+
+        // if there was no match among declared methods,
+        // we must consult the superclass (if any) recursively
+        Class<?> superClass = klass.getSuperclass();
+        if (superClass != null) {
+            res.addAll(getMainMethodsRecursive(superClass, parameterTypes,
+                    includeStatic, publicOnly));
+        }
+        // now from directly implemented interfaces excluding static methods
+        for (final Class<?> intf : klass.getInterfaces()) {
+            res.addAll(getMainMethodsRecursive(intf, parameterTypes, false, publicOnly));
+        }
+        return res;
+    }
+
+    private static Method[] getDeclaredMethods(final Class<?> klass, final boolean publicOnly) {
+        final Method[] methods = klass.getDeclaredMethods();
+        if (!publicOnly) {
+            return methods;
+        }
+        final List<Method> publicMethods = new ArrayList<>();
+        for (final Method m : methods) {
+            if (Modifier.isPublic(m.getModifiers())) {
+                publicMethods.add(m);
+            }
+        }
+        return publicMethods.toArray(new Method[0]);
+    }
+
+    // Direct reference to Class.getPackageName() and AccessibleObject.trySetAccessible()
+    // isn't possible because this MainMethodHelper class may run in Java 8 environments where those
+    // methods aren't available.
+    // This is a convenience holder class which provides reflective access to those methods and
+    // delays the reflective lookup to them until after it's certain that the runtime
     // environment is Java 25 or higher (where modern main methods are applicable)
     private static final class LazyHolder {
         // reflective access to Class.getPackageName() method which is only available on Java 9+
         private static final Method PACKAGE_NAME_METHOD;
+        // reflective access to AccessibleObject.trySetAccessible() method which
+        // is only available on Java 9+
+        private static final Method TRY_SET_ACCESSIBLE_METHOD;
 
         static {
-            Method m;
             try {
-                m = Class.class.getMethod("getPackageName");
+                PACKAGE_NAME_METHOD = Class.class.getMethod("getPackageName");
             } catch (NoSuchMethodException e) {
                 // This should never happen because this static initializer will only
                 // be called on Java versions 25 or higher and those versions are
                 // expected to have the Class.getPackageName() method (it's there since Java 9)
                 throw new Error("Missing Class.getPackageName() method");
             }
-            PACKAGE_NAME_METHOD = m;
+
+            try {
+                TRY_SET_ACCESSIBLE_METHOD = AccessibleObject.class.getMethod("trySetAccessible");
+            } catch (NoSuchMethodException e) {
+                // This should never happen because this static initializer will only
+                // be called on Java versions 25 or higher and those versions are
+                // expected to have the AccessibleObject.trySetAccessible() method
+                // (it's there since Java 9)
+                throw new Error("Missing AccessibleObject.trySetAccessible() method");
+            }
         }
     }
 }

--- a/test/applicationMainMethod/ApplicationMainMethod.gmk
+++ b/test/applicationMainMethod/ApplicationMainMethod.gmk
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+$(BUILDTESTDIR)/applicationMainMethod.ok: \
+	    $(JTREG_IMAGEDIR)/lib/jtreg.jar \
+	    $(JTREG_IMAGEDIR)/bin/jtreg
+	$(RM) $(@:%.ok=%) ; $(MKDIR) $(@:%.ok=%)
+	$(JTREG_IMAGEDIR)/bin/jtreg $(JTREG_OPTS) \
+		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
+		-jdk:$(JDKHOME) \
+		-agentvm \
+		$(TESTDIR)/applicationMainMethod/  \
+			> $(@:%.ok=%/jt.log) 2>&1
+	$(GREP) -s 'Test results: passed: 1' $(@:%.ok=%/jt.log)  > /dev/null
+	echo "test passed at `date`" > $@
+
+TESTS.jtreg += $(BUILDTESTDIR)/applicationMainMethod.ok
+

--- a/test/applicationMainMethod/ReferNonExistentClassTest.java
+++ b/test/applicationMainMethod/ReferNonExistentClassTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary verify that an unused reference to a class that's unavailable at runtime,
+ *          doesn't cause a failure to launch the test
+ * @build ReferNonExistentClassTest
+ * @clean NotPresentAtRuntime
+ * @run main/othervm ReferNonExistentClassTest
+ * @run main ReferNonExistentClassTest
+ */
+public class ReferNonExistentClassTest {
+
+    public static void main(final String[] args) {
+        try {
+            printMessage(null);
+        } catch (NoClassDefFoundError e) {
+            // This could happen if the VM loads classes eagerly,
+            // but is not bad behavior.
+            System.out.println("Caught NoClassDefFoundError: " + e);
+        }
+        System.out.println("Done");
+    }
+
+    private static void printMessage(final NotPresentAtRuntime ignored) {
+        System.out.println("Good morning");
+    }
+}
+
+// Empty class, never instantiated. Deleted after compiling.
+class NotPresentAtRuntime {
+}
+


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the issue noted in https://bugs.openjdk.org/browse/CODETOOLS-7904183?

As noted in that issue, in a recent enhancement in jtreg 8.3, we introduced the ability to allow jtreg tests to run application main methods that follow the newer rules specified in JEP-512 https://openjdk.org/jeps/512 ("Compact Source Files and Instance Main Methods"). A major part of that feature involves identifying the "right" main method for a class.

Our implementation of that feature in jtreg was done through https://bugs.openjdk.org/browse/CODETOOLS-7904141. In that implementation we were cautious not to enable this feature for Java runtimes lesser than Java 25 (Java 25 delivered JEP-512). That way, the compatibility impact of this change would be minimal. Even so, we have now run into a few issues where some existing tests when running on Java 25 (or higher) may run into failures like the one reported in CODETOOLS-7904183. The underlying cause of this failure is due to how Java reflection may throw exceptions for unused class references when trying to lookup methods on a class. Details of that are noted in https://bugs.openjdk.org/browse/JDK-8351188. 

The commit in this PR addresses this failure by fixing the implementation of how we detect the main method. This implementation now closely matches with what the JDK's java launcher does when trying to lookup application main method. With this newer implementation, we prioritize the presence of a "public static void main(String[])" before doing additional reflective lookups on the class. That way, the vast majority of existing classes which have been coded to older style of main methods, continue to function normally.

A new self test has been introduced which reproduces the failure and verifies the fix.

One thing that these recent issues have shown is that, it might be better to make this feature an opt-in even when we detect Java 25 or higher runtime environments. The application main method detection logic has run into subtle failures even in the JDK, so I think it's a bit too early to enable this by default in jtreg. A separate enhancement request is being worked upon to make this a opt-in.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904183](https://bugs.openjdk.org/browse/CODETOOLS-7904183): Some "main" action jtreg tests fail to launch after CODETOOLS-7904141 (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.org/jtreg.git pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/322.diff">https://git.openjdk.org/jtreg/pull/322.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/322#issuecomment-4430913060)
</details>
