### PR TITLE
7904184: Introduce a jtreg property which allows for compact source and instance main methods feature to be enabled/disabled

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
@@ -134,7 +134,7 @@ public class MainActionHelper extends ActionHelper {
         SaveState saved = new SaveState();
 
         Properties p = System.getProperties();
-        boolean allowModernMain = false;
+        boolean allowModernMain = true; // enabled by default
         for (Map.Entry<String, String> e : props.entrySet()) {
             String name = e.getKey();
             String value = e.getValue();

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainActionHelper.java
@@ -134,12 +134,15 @@ public class MainActionHelper extends ActionHelper {
         SaveState saved = new SaveState();
 
         Properties p = System.getProperties();
+        boolean allowModernMain = false;
         for (Map.Entry<String, String> e : props.entrySet()) {
             String name = e.getKey();
             String value = e.getValue();
             if (name.equals("test.class.path.prefix")) {
                 SearchPath cp = new SearchPath(value, System.getProperty("java.class.path"));
                 p.put("java.class.path", cp.toString());
+            } else if (name.equals("test.allowModernMain")) {
+                allowModernMain = Boolean.parseBoolean(value);
             } else {
                 p.put(e.getKey(), e.getValue());
             }
@@ -187,7 +190,7 @@ public class MainActionHelper extends ActionHelper {
                 // Normal case: marker interface not found; use standard main method
                 argTypes = new Class<?>[] { String[].class };
                 methodArgs = new Object[] { classArgsArray };
-                method = MainMethodHelper.isModernMainSupported()
+                method = allowModernMain && MainMethodHelper.isModernMainSupported()
                         ? MainMethodHelper.requireMainMethod(c)
                         : c.getMethod("main", argTypes);
             }

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
@@ -134,8 +134,9 @@ public class MainWrapper
 
                 // RUN JAVA PROGRAM
                 Class<?> c = Class.forName(className, false, cl);
-                boolean allowModernMain = Boolean.getBoolean("test.allowModernMain");
-                if (allowModernMain && MainMethodHelper.isModernMainSupported()) {
+                // enabled by default
+                String allowModernMain = System.getProperty("test.allowModernMain", "true");
+                if (Boolean.parseBoolean(allowModernMain) && MainMethodHelper.isModernMainSupported()) {
                     MainMethodHelper.executeModernMainClass(c, args);
                 } else {
                     Method mainMethod = c.getMethod("main", String[].class);

--- a/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
+++ b/src/share/classes/com/sun/javatest/regtest/agent/MainWrapper.java
@@ -134,13 +134,13 @@ public class MainWrapper
 
                 // RUN JAVA PROGRAM
                 Class<?> c = Class.forName(className, false, cl);
-                if (MainMethodHelper.isModernMainSupported()) {
+                boolean allowModernMain = Boolean.getBoolean("test.allowModernMain");
+                if (allowModernMain && MainMethodHelper.isModernMainSupported()) {
                     MainMethodHelper.executeModernMainClass(c, args);
-                    return;
+                } else {
+                    Method mainMethod = c.getMethod("main", String[].class);
+                    mainMethod.invoke(null, (Object) args);
                 }
-                Method mainMethod = c.getMethod("main", String[].class);
-                mainMethod.invoke(null, (Object) args);
-
             } catch (InvocationTargetException e) {
                 Throwable throwable = e.getTargetException();
                 throwable.printStackTrace(System.err);

--- a/src/share/classes/com/sun/javatest/regtest/config/TestProperties.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,6 +176,17 @@ public class TestProperties {
         return getEntry(file).disallowedActions;
     }
 
+    /**
+     * Returns true if compact source and instance main method is allowed
+     * for the given {@code file}, false otherwise.
+     *
+     * @param file the test file
+     * @return true if compact source and instance main method is allowed, false otherwise
+     */
+    public final boolean isModernMainAllowed(File file) {
+        return getEntry(file).allowModernMain;
+    }
+
     boolean getAllowSmartActionArgs(File file) {
         return getEntry(file).allowSmartActionArgs;
     }
@@ -237,6 +248,9 @@ public class TestProperties {
             final boolean enablePreview;
             final Duration defaultTimeout;
             final Set<String> disallowedActions;
+            // whether compact java source files and "modern" instance
+            // main methods, as specified by JEP-512, allowed
+            final boolean allowModernMain;
 
             Entry(Entry parent, File dir) {
                 this.parent = parent;
@@ -301,6 +315,9 @@ public class TestProperties {
 
                     // test actions that aren't allowed in the test definition
                     disallowedActions = initDisallowedActions(parent);
+
+                    // JEP-512 support for "compat source files and instance main methods"
+                    allowModernMain = initModernMainSupport(parent);
                 } else {
                     if (parent == null)
                         throw new IllegalStateException("TEST.ROOT not found");
@@ -322,6 +339,7 @@ public class TestProperties {
                     allowSmartActionArgs = parent.allowSmartActionArgs;
                     enablePreview = parent.enablePreview;
                     this.disallowedActions = parent.disallowedActions;
+                    allowModernMain = parent.allowModernMain;
                 }
 
                 useBootClassPath= initUseBootClassPath(parent, dir);
@@ -551,6 +569,17 @@ public class TestProperties {
                     return parent.shareLibraries;
                 }
 
+                return false;
+            }
+
+            private boolean initModernMainSupport(Entry parent) {
+                final String val = properties.getProperty("allowCompactSourceInstanceMainMethod");
+                if ("true".equals(val)) {
+                    return true;
+                }
+                if (parent != null) {
+                    return parent.allowModernMain;
+                }
                 return false;
             }
 

--- a/src/share/classes/com/sun/javatest/regtest/config/TestProperties.java
+++ b/src/share/classes/com/sun/javatest/regtest/config/TestProperties.java
@@ -574,13 +574,13 @@ public class TestProperties {
 
             private boolean initModernMainSupport(Entry parent) {
                 final String val = properties.getProperty("allowCompactSourceInstanceMainMethod");
-                if ("true".equals(val)) {
-                    return true;
+                if ("false".equals(val)) {
+                    return false;
                 }
                 if (parent != null) {
                     return parent.allowModernMain;
                 }
-                return false;
+                return true; // enabled by default
             }
 
             private File toFile(File baseDir, String v) {

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -1182,8 +1182,8 @@ public class RegressionScript extends Script {
             p.put("test.enable.preview", "false");
         }
         File testDefinitionFile = td.getFile();
-        if (properties.isModernMainAllowed(testDefinitionFile)) {
-            p.put("test.allowModernMain", "true");
+        if (!properties.isModernMainAllowed(testDefinitionFile)) {
+            p.put("test.allowModernMain", "false");
         }
         p.put("test.root", getTestRootDir().getPath());
         return Collections.unmodifiableMap(p);

--- a/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
+++ b/src/share/classes/com/sun/javatest/regtest/exec/RegressionScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1180,6 +1180,10 @@ public class RegressionScript extends Script {
         }
         if (disablePreview()) {
             p.put("test.enable.preview", "false");
+        }
+        File testDefinitionFile = td.getFile();
+        if (properties.isModernMainAllowed(testDefinitionFile)) {
+            p.put("test.allowModernMain", "true");
         }
         p.put("test.root", getTestRootDir().getPath());
         return Collections.unmodifiableMap(p);

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -1035,6 +1035,13 @@ See <a href="#requires_names">Appendix 1</a>.
 features and that the necessary compile-time and run-time options should be provided automatically.
 The default value can be overridden in individual tests using the <code>@enablePreview</code>
 declarative tag.
+
+<dt id="allowCompactSourceInstanceMainMethod"><code>allowCompactSourceInstanceMainMethod <var>&lt;true|false&gt;</var></code>
+<dd>Specify whether the "main" action tests in this directory and any subdirectories may use compact
+source and instance main methods. If not specified, this property defaults to true. Compact
+source and instance main methods is applicable only in Java 25 and higher versions. Setting this
+property for test JDK versions lesser than Java 25 plays no role in how jtreg determines the main
+method to launch.
 </dl>
 
 

--- a/src/share/doc/javatest/regtest/tag-spec.html
+++ b/src/share/doc/javatest/regtest/tag-spec.html
@@ -52,7 +52,7 @@
 <p>Comments and questions to:
 <a href="mailto:jtreg-use@openjdk.org">jtreg-use@openjdk.org</a>.
 <br>
-1.49, 7 May 2026
+1.50, 26 May 2026
 </div>
 
 <p>This is a specification document, not a tutorial.  For more basic information

--- a/test/compactsourcefile/CompactSourceFileTest.gmk
+++ b/test/compactsourcefile/CompactSourceFileTest.gmk
@@ -53,8 +53,10 @@ $(BUILDTESTDIR)/CompactSourceFile25.agentvm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK25HOME) \
 		$(TESTDIR)/compactsourcefile \
-			> $(@:%.ok=%/jt.log) 2>&1
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+		true "non-zero exit code from JavaTest intentionally ignored"
 	$(GREP) -s 'Test results: passed: 7' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s "test result: Error. Can't find \`main' method" $(@:%.ok=%/work/disabled/InstanceMainNotExpectedToLaunch.jtr)  > /dev/null
 	echo "test passed at `date`" > $@
 
 $(BUILDTESTDIR)/CompactSourceFile25.othervm.ok: \
@@ -66,8 +68,10 @@ $(BUILDTESTDIR)/CompactSourceFile25.othervm.ok: \
 		-w:$(@:%.ok=%)/work -r:$(@:%.ok=%)/report \
 		-jdk:$(JDK25HOME) \
 		$(TESTDIR)/compactsourcefile \
-			> $(@:%.ok=%/jt.log) 2>&1
+			> $(@:%.ok=%/jt.log) 2>&1 || \
+		true "non-zero exit code from JavaTest intentionally ignored"
 	$(GREP) -s 'Test results: passed: 7' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s "test result: Error. Can't find \`main' method" $(@:%.ok=%/work/disabled/InstanceMainNotExpectedToLaunch.jtr)  > /dev/null
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/CompactSourceFile25.agentvm.ok

--- a/test/compactsourcefile/TEST.ROOT
+++ b/test/compactsourcefile/TEST.ROOT
@@ -1,1 +1,1 @@
-allowCompactSourceInstanceMainMethod=true
+

--- a/test/compactsourcefile/TEST.ROOT
+++ b/test/compactsourcefile/TEST.ROOT
@@ -1,0 +1,1 @@
+allowCompactSourceInstanceMainMethod=true

--- a/test/compactsourcefile/disabled/InstanceMainNotExpectedToLaunch.java
+++ b/test/compactsourcefile/disabled/InstanceMainNotExpectedToLaunch.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Not expected to launch because compact source instance main method is disabled
+ * @run main InstanceMainNotExpectedToLaunch
+ * @run driver InstanceMainNotExpectedToLaunch
+ */
+public class InstanceMainNotExpectedToLaunch {
+    void main() {
+        System.out.println("hello world");
+    }
+}

--- a/test/compactsourcefile/disabled/TEST.properties
+++ b/test/compactsourcefile/disabled/TEST.properties
@@ -1,0 +1,1 @@
+allowCompactSourceInstanceMainMethod=false

--- a/test/tag-spec/TestTagSpec.gmk
+++ b/test/tag-spec/TestTagSpec.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ $(BUILDTESTDIR)/TestTagSpec_sysProps.ok: \
 	$(GREP) -oh '\(.put(\|put(map, \)"test.[^"]*' $(JAVAFILES.com.sun.javatest.regtest-tools) | \
 		$(GREP) -v "test.class.path.prefix" | \
 		$(GREP) -v "test.thread.factory" | \
+		$(GREP) -v "test.allowModernMain" | \
 		$(SED) -e 's/.*"//' | $(SORT) -u > $(@:%.ok=%.src)
 	$(GREP) -o '<code>test[^<]*</code>' $(JTREG_TAGSPEC) | \
 		$(SED) -e 's/<[^>]*>//g' | $(SORT) -u > $(@:%.ok=%.spec)


### PR DESCRIPTION
Can I please get a review of this change which addresses https://bugs.openjdk.org/browse/CODETOOLS-7904184?

A new jtreg property `allowCompactSourceInstanceMainMethod` has been introduced to allow projects to optionally disable the compact source and instance main method detection feature that we recently introduced in jtreg through https://bugs.openjdk.org/browse/CODETOOLS-7904141. This should allow projects to optionally disable this feature for specific tests if there are any unforeseen issues in the implementation of CODETOOLS-7904141 and at the same this feature will start getting usage in newer versions of the JDK.

I haven't documented the user facing `allowCompactSourceInstanceMainMethod` property, and that's intentional. I expect this property to be removed once we have seen enough usage of jtreg with this feature enabled (by default).

Jon @jonathan-gibbons, if you have a few moments, I would like your inputs on how this is implemented in this PR. The `main` action (through `MainAction` class) needs to propagate the "allow modern main methods" detail to the agent VM or the newly launched other VM. That detail is derived from TEST.ROOT/TEST.properties file. In the current proposed implementation, once the jtreg process has parsed that detail for the test, it propagates this detail to the agent VM and/or the other VM, through a new internal system property `test.allowModernMain`. That system property value is then read by the other process (either an agent or a new JVM) before the main method detection logic is invoked. I haven't found any other way, other than passing a system property, to achieve this co-ordination. Are there other ways to do this?




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904184](https://bugs.openjdk.org/browse/CODETOOLS-7904184): Introduce a jtreg property which allows for compact source and instance main methods feature to be enabled/disabled (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/323/head:pull/323` \
`$ git checkout pull/323`

Update a local copy of the PR: \
`$ git checkout pull/323` \
`$ git pull https://git.openjdk.org/jtreg.git pull/323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 323`

View PR using the GUI difftool: \
`$ git pr show -t 323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/323.diff">https://git.openjdk.org/jtreg/pull/323.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/323#issuecomment-4441905175)
</details>
