### PR TITLE
7904199: On MSys2, jtreg defaults to using wsl to run shell tests

### DIFF
--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2338,8 +2338,8 @@ public class Tool {
     }
 
     /**
-     * Returns whether MSys is available, by examining whether the `MSYSTEM`
-     * environment variable is non-empty.
+     * Returns whether MSys is available, by examining whether the
+     * {@code MSYSTEM} environment variable is non-empty.
      */
     private boolean isMSysDetected() {
         if (isWindows()) {

--- a/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
+++ b/src/share/classes/com/sun/javatest/regtest/tool/Tool.java
@@ -682,6 +682,9 @@ public class Tool {
                 if (isCygwinDetected()) {
                     out.println(i18n.getString("main.warn.wsl.specified.found.cygwin"));
                 }
+                if (isMSysDetected()) {
+                    out.println(i18n.getString("main.warn.wsl.specified.found.msys"));
+                }
                 useWindowsSubsystemForLinux = true;
             }
         },
@@ -1197,7 +1200,7 @@ public class Tool {
             if (useWindowsSubsystemForLinux == null) {
                 // The test for Cygwin is more specific than the test for WSL,
                 // and so we give priority to Cygwin if both are detected.
-                useWindowsSubsystemForLinux = !isCygwinDetected() && isWindowsSubsystemForLinuxDetected();
+                useWindowsSubsystemForLinux = !isCygwinDetected() && !isMSysDetected() && isWindowsSubsystemForLinuxDetected();
             }
         } else {
             useWindowsSubsystemForLinux = false;
@@ -2329,6 +2332,19 @@ public class Tool {
         if (isWindows()) {
             String PATH = System.getenv("PATH");
             return (PATH != null) && PATH.matches("(?i).*;[a-z]:[^;]*\\\\cygwin.*");
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Returns whether MSys is available, by examining whether the `MSYSTEM`
+     * environment variable is non-empty.
+     */
+    private boolean isMSysDetected() {
+        if (isWindows()) {
+            String msystem = System.getenv("MSYSTEM");
+            return msystem != null && !msystem.isEmpty();
         } else {
             return false;
         }

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
+++ b/src/share/classes/com/sun/javatest/regtest/tool/i18n.properties
@@ -516,6 +516,7 @@ main.nativePathNotDir=The -nativepath path is not a directory: {0}
 main.nativePathMultiplePath=The argument to -nativepath cannot be more than one path.
 main.requiredVersion=The testsuite at {0} requires jtreg version {1} or higher and this is jtreg version {2}.
 main.warn.wsl.specified.found.cygwin=Warning: -wsl specified, but Cygwin detected
+main.warn.wsl.specified.found.msys=Warning: -wsl specified, but MSys detected
 main.warn.cygwin.specified.found.wsl=Warning: -cygwin specified, but WSL detected
 main.windowsOnly=This option is only for use on Windows: {0}
 


### PR DESCRIPTION
Before this patch, jtreg chose to execute shell tests using WSL when
Cygwin was unavailable, but this breaks when jtreg is run using MSys,
since jtreg then incorrectly concludes that it needs to use WSL, even
though the "sh" binary is available under MSys.  This patch fixes the
problem so that jtreg chooses to use WSL only when _both_ Cygwin and
MSys are unavailable (in addition to checking whether WSL is detected).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904199](https://bugs.openjdk.org/browse/CODETOOLS-7904199): On MSys2, jtreg defaults to using wsl to run shell tests (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/326/head:pull/326` \
`$ git checkout pull/326`

Update a local copy of the PR: \
`$ git checkout pull/326` \
`$ git pull https://git.openjdk.org/jtreg.git pull/326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 326`

View PR using the GUI difftool: \
`$ git pr show -t 326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/326.diff">https://git.openjdk.org/jtreg/pull/326.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/326#issuecomment-5110326170)
</details>
