### PR TITLE
7904200: Several tests fail to run on Cygwin/Windows

### DIFF
--- a/test/autovm/AutoVMTests.gmk
+++ b/test/autovm/AutoVMTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ $(BUILDTESTDIR)/autovm.ok: $(AUTOVM_FILES) \
 	cd $(BUILDTESTDIR)/autovm/jtreg ; find mode.*/ts.*/work -name \*.jtr | \
 	    grep -v Shell | while read file ; do \
 	    	echo $$file `grep '^Mode:' $$file | sort -u` ; \
-		found=`grep '^Mode:' $$file | sed -e 's/ \[.*\]$$//'` ; \
+		found=`grep '^Mode:' $$file | $(SED) -e 's/\r$$//' -e 's/ \[.*\]$$//'` ; \
 		case $$file in \
 		    */work/*/othervm/* ) expect_compile=othervm ;; \
 		    mode.agentvm/* | mode.none/ts.agentvm/* ) expect_compile=agentvm ;; \

--- a/test/empty/EmptyTest.gmk
+++ b/test/empty/EmptyTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ $(BUILDTESTDIR)/EmptyTest_EmptyFile.ok: \
 		-dir:$(TESTDIR)/empty/ts1 \
 		empty/Empty.java ; \
 	rc=$$? ; if [ $$rc != 5 ]; then echo "unexpected exit code: $$rc"; exit 1; fi
-	$(GREP) -s 'Error: Not a test or directory containing tests: empty/Empty.java' $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s 'Error: Not a test or directory containing tests: empty[/\\]Empty\.java' $(@:%.ok=%/jt.log) > /dev/null
 	echo "test passed at `date`" > $@
 
 TESTS.jtreg += \

--- a/test/groups2/Group2Test.gmk
+++ b/test/groups2/Group2Test.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ $(Group2Test.GROUPS:%=$(BUILDTESTDIR)/Group2Test.%.ok): \
 		-jdk:$(JDKHOME) \
 		$(TESTDIR)/groups2:$(@:$(BUILDTESTDIR)/Group2Test.%.ok=%) \
 		1>$(@:%.ok=%)/jt.log 2>&1
-	$(GREP) '^Test results: passed: 3$$' $(@:%.ok=%)/jt.log
+	$(SED) -e 's/\r$$//' $(@:%.ok=%)/jt.log | $(GREP) '^Test results: passed: 3$$'
 	echo $@ passed at `date` > $@
 
 $(Group2Test.GROUPS:%=$(BUILDTESTDIR)/Group2Test.report-files.%.ok): \
@@ -54,7 +54,7 @@ $(Group2Test.GROUPS:%=$(BUILDTESTDIR)/Group2Test.report-files.%.ok): \
 		-report:files \
 		$(TESTDIR)/groups2:$(@:$(BUILDTESTDIR)/Group2Test.report-files.%.ok=%) \
 		1>$(@:%.ok=%)/jt.log 2>&1
-	$(GREP) '^Test results: passed: 3$$' $(@:%.ok=%)/jt.log
+	$(SED) -e 's/\r$$//' $(@:%.ok=%)/jt.log | $(GREP) '^Test results: passed: 3$$'
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/Group2Test.ok

--- a/test/junitQueryTest/JUnitQueryTest.gmk
+++ b/test/junitQueryTest/JUnitQueryTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,11 @@
 #
 # Execute all (6) test methods in the test suite
 
+JUNIT_QUERY_TEST_STDOUT = $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $$0; } { }' $(@:%.ok=%)/jt.log \
+		| $(GREP) -v STD \
+		| $(SED) -e 's/\r$$//' \
+		| xargs $(ECHO) )
+
 $(BUILDTESTDIR)/JUnitQueryTest.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(JTREG_IMAGEDIR)/lib/jtreg.jar \
 		$(JTREG_IMAGEDIR)/bin/jtreg
@@ -39,7 +44,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-va \
 		$(TESTDIR)/junitQueryTest/ \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.parameterized Test1.m11 Test1.m12 Test1.m13 Test1.nested Test2.m21 Test2.m22 Test2.m23" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -64,7 +69,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		-va \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.m12" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -92,7 +97,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.m12.Test2.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar 
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test2.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.m12 Test2.m21 Test2.m22 Test2.m23" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -119,7 +124,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.m13.m12.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.m12" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -146,7 +151,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.m12.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m12 \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.m13" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -173,7 +178,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.m13.all.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.parameterized Test1.m11 Test1.m12 Test1.m13 Test1.nested" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -200,7 +205,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.all.m13.ok: $(JTREG_IMAGEDIR)/lib/javatest.jar \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java \
 		$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?m13 \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.m13" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -225,7 +230,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.parameterized.ok: $(JTREG_IMAGEDIR)/lib/javatest.
 		-va \
 		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?junit-select:method:Test1#parameterized(java.lang.String,Test1\$$NestedClass,boolean,byte,char,short,int,long,float,double,[Ljava.lang.String;,[Z,[B,[C,[S,[I,[J,[F,[D)" \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.parameterized" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -250,7 +255,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.nested.class.ok: $(JTREG_IMAGEDIR)/lib/javatest.j
 		-va \
 		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?junit-select:class:Test1\$$NestedTests" \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.nested" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -275,7 +280,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.toplevel.class.ok: $(JTREG_IMAGEDIR)/lib/javatest
 		-va \
 		"$(TESTDIR)/junitQueryTest/a/b/c/Test1.java?junit-select:class:Test1" \
 		 > $(@:%.ok=%)/jt.log 2>&1
-	OUT=$$( $(ECHO) $$( $(AWK) '/STDOUT:/,/STDERR:/{ print $0; } { }' $(@:%.ok=%)/jt.log | $(GREP) -v STD ) ) ; \
+	OUT=$(JUNIT_QUERY_TEST_STDOUT) ; \
 	if [ "$$OUT" != "Test1.parameterized Test1.m11 Test1.m12 Test1.m13 Test1.nested" ]; then \
 	    echo "unexpected set of tests run: $$OUT"; exit 1 ; \
 	fi
@@ -301,7 +306,7 @@ $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok: $(JTREG_IMAGEDIR)/lib/javatest.j
 		$(TESTDIR)/junitQueryTest/a/b/c?m13 \
 			> $(@:%.ok=%)/jt.log 2>&1 || \
 		true "non-zero exit code from jtreg intentionally ignored"
-	$(GREP) -s "Error: Invalid use of query component: a/b/c?m13" $(@:%.ok=%)/jt.log
+	$(GREP) -s "Error: Invalid use of query component: .*a[/\\]b[/\\]c?m13" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/JUnitQueryTest.invalidQuery.ok

--- a/test/keywords/testKeywords.gmk
+++ b/test/keywords/testKeywords.gmk
@@ -50,7 +50,7 @@ $(BUILDTESTDIR)/TestKeywords.badProps.ok: \
 		$(TESTDIR)/keywords/badProps \
 		> $(@:%.ok=%/jt.log) 2>&1 || \
 	    true "non-zero exit code from JavaTest intentionally ignored"
-	$(GREP) -s "Error: .*/test/keywords/badProps/badProps/TEST.properties: bad keyword 'bad%word': invalid character: %" $(@:%.ok=%/jt.log)  > /dev/null
+	$(GREP) -s "Error: .*[/\\]test[/\\]keywords[/\\]badProps[/\\]badProps[/\\]TEST.properties: bad keyword 'bad%word': invalid character: %" $(@:%.ok=%/jt.log)  > /dev/null
 	echo $@ passed at `date` > $@
 
 $(BUILDTESTDIR)/TestKeywords.badTest.ok: \

--- a/test/testngQueryTest/TestNGQueryTest.gmk
+++ b/test/testngQueryTest/TestNGQueryTest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,7 @@ $(BUILDTESTDIR)/TestNGQueryTest.invalidQuery.ok: $(JTREG_IMAGEDIR)/lib/javatest.
 		$(TESTDIR)/testngQueryTest/a/b/c?m13 \
 			> $(@:%.ok=%)/jt.log 2>&1 || \
 		true "non-zero exit code from jtreg intentionally ignored"
-	$(GREP) -s "Error: Invalid use of query component: a/b/c?m13" $(@:%.ok=%)/jt.log
+	$(GREP) -s "Error: Invalid use of query component: .*a[/\\]b[/\\]c?m13" $(@:%.ok=%)/jt.log
 	echo $@ passed at `date` > $@
 
 TESTS.jtreg += $(BUILDTESTDIR)/TestNGQueryTest.invalidQuery.ok


### PR DESCRIPTION
This patch makes two changes.  First, it strips the carriage-return
character from line endings before running grep to check for matches and
second, it broadens the file path regexes to accept both forward and
backward slashes.  I validated this patch by running all tests
(`bash make/build.sh -- tests`) on both Windows and macOS.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904200](https://bugs.openjdk.org/browse/CODETOOLS-7904200): Several tests fail to run on Cygwin/Windows (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jtreg.git pull/327/head:pull/327` \
`$ git checkout pull/327`

Update a local copy of the PR: \
`$ git checkout pull/327` \
`$ git pull https://git.openjdk.org/jtreg.git pull/327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 327`

View PR using the GUI difftool: \
`$ git pr show -t 327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jtreg/pull/327.diff">https://git.openjdk.org/jtreg/pull/327.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jtreg/pull/327#issuecomment-5134182987)
</details>
